### PR TITLE
Bootstrap README and pyproject packaging metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,9 +182,9 @@ cython_debug/
 .abstra/
 
 # Visual Studio Code
-#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#  and can be added to the global gitignore or merged into this file. However, if you prefer,
 #  you could uncomment the following to ignore the entire vscode folder
 # .vscode/
 
@@ -205,3 +205,7 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Local planning/context files (keep untracked)
+AGENTS.md
+LOCAL_TODO.md

--- a/README.md
+++ b/README.md
@@ -1,2 +1,91 @@
 # splicegrapher-next
-A revisioning of SpliceGrapher with modern dependencies
+
+`splicegrapher-next` is an unofficial Python 3 modernization/continuation of
+SpliceGrapher for shared use by iDiffIR and TAPIS during active migration.
+
+- Repository/distribution name: `splicegrapher-next`
+- Python import namespace (compatibility): `SpliceGrapher`
+
+## Why This Repo Exists
+
+Historically, iDiffIR and TAPIS relied on divergent SpliceGrapher copies.
+This repository is the compatibility bridge that reduces duplication and
+centralizes migration work while preserving behavior and imports.
+
+## Phase 1 Scope
+
+Goals:
+
+- Extract and stabilize modernized SpliceGrapher components from iDiffIR.
+- Preserve `SpliceGrapher` import compatibility where practical.
+- Keep visualization (`view/`, `plot/`) as first-class functionality.
+- Enable incremental external adoption by iDiffIR and TAPIS.
+
+Non-goals:
+
+- Full graph-engine rewrite.
+- Big-bang API redesign.
+- Immediate unification of iDiffIR/TAPIS project-specific logic.
+
+## Quick Start
+
+```bash
+git clone git@github.com:bio-comp/splicegrapher-next.git
+cd splicegrapher-next
+```
+
+### Development Install (uv-first)
+
+```bash
+uv sync --group dev
+```
+
+### Editable pip Fallback
+
+```bash
+python -m pip install -e .
+```
+
+### Import Compatibility Check
+
+```bash
+uv run python -c "import SpliceGrapher; print(SpliceGrapher.__name__)"
+```
+
+## Conda / Mamba / Miniconda / Bioconda-Friendly Guidance
+
+Use conda-based environments when needed for scientific stacks:
+
+```bash
+mamba create -n splicegrapher-next python=3.12 -y
+mamba activate splicegrapher-next
+mamba install -c conda-forge -c bioconda numpy scipy matplotlib pysam gffutils networkx -y
+python -m pip install -e .
+```
+
+`uv` remains the preferred local development workflow in this repository.
+
+## Migration Status
+
+This project is in active extraction and stabilization.
+Current priority is compatibility, correctness, and tests before deeper
+cleanup or re-architecture.
+
+## License and Provenance
+
+This repository is a continuation/derivative effort and may contain mixed
+provenance over time. Preserve original notices and license headers in copied
+files. See `LICENSE` and any future provenance/license inventory docs.
+
+## Original SpliceGrapher References
+
+Rogers MF, Thomas J, Reddy AS, Ben-Hur A. SpliceGrapher: detecting patterns of
+alternative splicing from RNA-Seq data in the context of gene models and EST
+data. *Genome Biology*. 2012 Jan 31;13(1):R4. doi:10.1186/gb-2012-13-1-r4.
+PMID: 22293517; PMCID: PMC3334585.
+
+Rogers MF, Boucher C, Ben-Hur A. SpliceGrapherXT: From Splice Graphs to
+Transcripts Using RNA-Seq. In: *Proceedings of the International Conference on
+Bioinformatics, Computational Biology and Biomedical Informatics (BCB 2013)*.
+Association for Computing Machinery; 2013:247-255.
+doi:10.1145/2506583.2506625. <https://doi.org/10.1145/2506583.2506625>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,86 @@
+[build-system]
+requires = ["hatchling>=1.26.0"]
+build-backend = "hatchling.build"
+
+[project]
+name = "splicegrapher-next"
+version = "0.1.0a1"
+description = "Python 3 modernization / continuation of SpliceGrapher for shared iDiffIR and TAPIS use"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "Mixed licensing; see LICENSE and provenance notices." }
+authors = [
+  { name = "Mike Hamilton", email = "mike.hamilton7@gmail.com" },
+]
+maintainers = [
+  { name = "Mike Hamilton", email = "mike.hamilton7@gmail.com" },
+]
+keywords = [
+  "bioinformatics",
+  "rna-seq",
+  "splicing",
+  "splice-graph",
+  "genomics",
+  "visualization",
+]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Science/Research",
+  "Topic :: Scientific/Engineering :: Bio-Informatics",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Operating System :: OS Independent",
+]
+dependencies = [
+  "numpy",
+  "scipy",
+  "matplotlib",
+  "pysam",
+  "gffutils>=0.13",
+  "networkx>=3.4",
+]
+
+[project.urls]
+Homepage = "https://github.com/bio-comp/splicegrapher-next"
+Repository = "https://github.com/bio-comp/splicegrapher-next"
+Issues = "https://github.com/bio-comp/splicegrapher-next/issues"
+
+[dependency-groups]
+dev = [
+  "pytest>=8.0",
+  "pytest-cov>=5.0",
+  "ruff>=0.6.0",
+  "mypy>=1.10",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["SpliceGrapher"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"
+markers = [
+  "slow: slow-running tests",
+  "integration: integration tests using external-style fixtures",
+]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W"]
+ignore = [
+  # Legacy cleanup is incremental during migration.
+  "E402",
+]
+
+[tool.mypy]
+python_version = "3.10"
+ignore_missing_imports = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+check_untyped_defs = false
+show_error_codes = true


### PR DESCRIPTION
Closes #1

## Summary
- rewrite `README.md` into concise onboarding docs
- add bootstrap `pyproject.toml` (PEP 621 + Hatchling + tool config)
- keep local-only agent context files ignored via `.gitignore`
- add original SpliceGrapher literature references

## Validation
- `uv build`
- `git check-ignore -v AGENTS.md LOCAL_TODO.md`
