### PR TITLE
Add provenance and license scaffolding for extraction phase

### DIFF
--- a/LICENSES/README.md
+++ b/LICENSES/README.md
@@ -1,0 +1,29 @@
+# LICENSES Inventory (Scaffold)
+
+This directory is reserved for license texts, notices, and per-source
+attribution artifacts as extraction progresses.
+
+## Current Contents
+
+- `LICENSES/README.md` (this inventory scaffold)
+
+## Expected Additions
+
+As files are extracted from iDiffIR's vendored SpliceGrapher tree and related
+sources, add:
+
+- Upstream or source-specific license texts
+- Source-specific notice files
+- Any required attribution files
+
+## Inventory Table Template
+
+| Source | Source Path/URL | Destination Scope | License Artifact | Notes |
+| --- | --- | --- | --- | --- |
+| _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ |
+
+## References
+
+- Top-level repository license: `LICENSE`
+- Provenance ledger: `PROVENANCE.md`
+- Project notice: `NOTICE`

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,20 @@
+NOTICE
+======
+
+Project: splicegrapher-next
+Repository: https://github.com/bio-comp/splicegrapher-next
+
+This project is an unofficial continuation/modernization bridge for
+SpliceGrapher, intended to support iDiffIR and TAPIS migration workflows.
+
+Attribution and provenance details are tracked in:
+- PROVENANCE.md
+- LICENSES/README.md
+
+Important:
+- Preserve existing copyright headers.
+- Preserve file-level notices from upstream/derived sources.
+- Do not assume a single license governs all future extracted files.
+
+This NOTICE is an engineering notice scaffold and should be updated as source
+files are extracted.

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -1,0 +1,70 @@
+# PROVENANCE.md
+
+This document tracks code/data/document provenance for `splicegrapher-next`
+during extraction from iDiffIR's vendored `SpliceGrapher` tree and any future
+upstream/downstream integration work.
+
+## Repository Identity
+
+- Repository: `bio-comp/splicegrapher-next`
+- Purpose: shared Python 3 modernization/continuation bridge for SpliceGrapher
+  used by iDiffIR and TAPIS
+- Import namespace compatibility target: `SpliceGrapher`
+
+## Current Source Inventory (Phase: Scaffold)
+
+This repository currently contains bootstrap packaging and documentation assets.
+No large SpliceGrapher source-module extraction is recorded yet in this file.
+
+## Upstream and Derived Sources
+
+Planned/known source relationships:
+
+1. Historical upstream SpliceGrapher project
+   - URL: <https://splicegrapher.sourceforge.net/>
+   - Publication reference:
+     Rogers MF, Thomas J, Reddy AS, Ben-Hur A. Genome Biol. 2012;13(1):R4.
+2. iDiffIR vendored/refactored SpliceGrapher tree (primary extraction source)
+   - Local source path used for extraction work:
+     `iDiffIR/iDiffIR/SpliceGrapher`
+   - Repository context: <https://github.com/bio-comp/iDiffIR>
+3. TAPIS compatibility consumer context
+   - Repository context: <https://github.com/bio-comp/tapis>
+
+## Licensing Notes (Non-Legal Summary)
+
+- Top-level license currently present in this repository: `LICENSE`.
+- Vendored iDiffIR SpliceGrapher tree includes additional file-level licensing
+  context that must be preserved during extraction.
+- Do not treat this file as legal advice; it is an engineering traceability
+  record.
+
+## Attribution and Header Preservation Rules
+
+When copying files into this repository:
+
+- Preserve original copyright headers.
+- Preserve file-level notices and author attributions.
+- Record source path, commit/ref, and destination path in this file.
+- Document any intentional modifications from the copied baseline.
+
+## Extraction Ledger Template
+
+Use one entry per extraction change-set:
+
+```text
+Date:
+Issue/PR:
+Source repository/path:
+Source commit/ref:
+Destination paths:
+License/notice files added or updated:
+Behavioral modifications from source baseline:
+Validation run:
+```
+
+## Initial Follow-Up Items
+
+- Populate this ledger when issue #6 extraction begins.
+- Add explicit source commit hashes for each copied batch.
+- Add file-level license inventory rows in `LICENSES/README.md`.

--- a/README.md
+++ b/README.md
@@ -75,14 +75,14 @@ cleanup or re-architecture.
 
 This repository is a continuation/derivative effort and may contain mixed
 provenance over time. Preserve original notices and license headers in copied
-files. See `LICENSE` and any future provenance/license inventory docs.
+files. See `LICENSE`, `NOTICE`, `PROVENANCE.md`, and `LICENSES/README.md`.
 
 ## Original SpliceGrapher References
 
 Rogers MF, Thomas J, Reddy AS, Ben-Hur A. SpliceGrapher: detecting patterns of
 alternative splicing from RNA-Seq data in the context of gene models and EST
 data. *Genome Biology*. 2012 Jan 31;13(1):R4. doi:10.1186/gb-2012-13-1-r4.
-PMID: 22293517; PMCID: PMC3334585.
+PMID: 22293517; PMCID: PMC3334585. <https://doi.org/10.1186/gb-2012-13-1-r4>
 
 Rogers MF, Boucher C, Ben-Hur A. SpliceGrapherXT: From Splice Graphs to
 Transcripts Using RNA-Seq. In: *Proceedings of the International Conference on


### PR DESCRIPTION
Closes #3

## Summary
- add tracked provenance scaffold: `PROVENANCE.md`
- add tracked notice scaffold: `NOTICE`
- add tracked license inventory scaffold: `LICENSES/README.md`
- update `README.md` license/provenance section to link new scaffolding files

## Validation
- `uv build`

## Notes
- Keeps scope documentation-focused for SGN-M1.
- No runtime behavior or import path changes in this PR.
