### PR TITLE
Reposition SGN docs and metadata as general-use tool (#15)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -4,8 +4,9 @@ NOTICE
 Project: splicegrapher-next
 Repository: https://github.com/bio-comp/splicegrapher-next
 
-This project is an unofficial continuation/modernization bridge for
-SpliceGrapher, intended to support iDiffIR and TAPIS migration workflows.
+This project is an unofficial continuation/modernization of SpliceGrapher for
+general use, with compatibility priorities for iDiffIR and TAPIS migration
+workflows.
 
 Attribution and provenance details are tracked in:
 - PROVENANCE.md

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -7,8 +7,8 @@ upstream/downstream integration work.
 ## Repository Identity
 
 - Repository: `bio-comp/splicegrapher-next`
-- Purpose: shared Python 3 modernization/continuation bridge for SpliceGrapher
-  used by iDiffIR and TAPIS
+- Purpose: generally usable Python 3 modernization/continuation of
+  SpliceGrapher, with compatibility priorities for iDiffIR and TAPIS
 - Import namespace compatibility target: `SpliceGrapher`
 
 ## Current Source Inventory (Phase: Scaffold)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # splicegrapher-next
 
 `splicegrapher-next` is an unofficial Python 3 modernization/continuation of
-SpliceGrapher for shared use by iDiffIR and TAPIS during active migration.
+SpliceGrapher for general splice-graph and RNA-seq analysis workflows, with
+compatibility priorities for iDiffIR and TAPIS during active migration.
 
 - Repository/distribution name: `splicegrapher-next`
 - Python import namespace (compatibility): `SpliceGrapher`
@@ -9,8 +10,8 @@ SpliceGrapher for shared use by iDiffIR and TAPIS during active migration.
 ## Why This Repo Exists
 
 Historically, iDiffIR and TAPIS relied on divergent SpliceGrapher copies.
-This repository is the compatibility bridge that reduces duplication and
-centralizes migration work while preserving behavior and imports.
+This repository reduces duplication, centralizes migration work, and provides
+a generally usable Python 3 continuation while preserving behavior and imports.
 
 ## Phase 1 Scope
 
@@ -19,7 +20,7 @@ Goals:
 - Extract and stabilize modernized SpliceGrapher components from iDiffIR.
 - Preserve `SpliceGrapher` import compatibility where practical.
 - Keep visualization (`view/`, `plot/`) as first-class functionality.
-- Enable incremental external adoption by iDiffIR and TAPIS.
+- Enable incremental external adoption by iDiffIR, TAPIS, and other users.
 
 Non-goals:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "splicegrapher-next"
 version = "0.1.0a1"
-description = "Python 3 modernization / continuation of SpliceGrapher for shared iDiffIR and TAPIS use"
+description = "Python 3 modernization / continuation of SpliceGrapher for general use, with iDiffIR and TAPIS compatibility priorities"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "Mixed licensing; see LICENSE and provenance notices." }


### PR DESCRIPTION
## Summary
- reposition README lead/purpose language to present splicegrapher-next as generally usable, with iDiffIR/TAPIS as compatibility priorities
- update project metadata summary in pyproject.toml to match the public identity framing
- align NOTICE and PROVENANCE repository-purpose phrasing without altering provenance/licensing facts

## Validation
- uv run ruff check . --fix
- uv run ruff format .
- uv run pytest
- uv build
- uv run python -c "import importlib.metadata as md; print(md.metadata('splicegrapher-next')['Summary'])"

## Issue
Closes #15
