### PR TITLE
docs: curate canonical plant and human tutorial datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ python -m pip install . &&
 python -c "import importlib.metadata as md; print(md.version(\"splicegrapher-next\"))"'
 ```
 
+## Tutorial Dataset Curation
+
+Canonical modern tutorial/e2e dataset selections (plant + human) are tracked
+in:
+
+- `docs/tutorials/dataset_manifest.toml`
+- `docs/tutorials/datasets.md`
+
 ## Migration Status
 
 This project is in active extraction and stabilization.

--- a/docs/tutorials/dataset_manifest.toml
+++ b/docs/tutorials/dataset_manifest.toml
@@ -1,0 +1,64 @@
+[manifest]
+schema_version = 1
+last_reviewed = "2026-02-25"
+tracking_issue = 29
+primary_acquisition = "python-httpx"
+supported_acquisition = ["python-httpx", "sra-toolkit"]
+selection_policy = "biologically-contrasted-pair"
+tier_policy = "canonical-study-fetch-for-notebooks plus tiny-derived-fixtures-for-ci"
+
+[species.ath]
+key = "ath"
+name = "Arabidopsis thaliana"
+taxon_id = 3702
+study_accession = "PRJNA755474"
+study_source = "INSDC BioProject"
+focus = "Alternative splicing and transcript reference updates (AtRTD3)"
+reference_genome = "TAIR10"
+reference_annotation = "AtRTD3 + Araport11 context"
+run_accessions = ["SRR17001820", "SRR17001821"]
+
+[species.ath.run_metadata.SRR17001820]
+label = "WT_BA1"
+platform = "ILLUMINA"
+library_layout = "PAIRED"
+group = "control_like"
+
+[species.ath.run_metadata.SRR17001821]
+label = "lrp2_BA1"
+platform = "ILLUMINA"
+library_layout = "PAIRED"
+group = "perturbed_like"
+
+[species.hsa]
+key = "hsa"
+name = "Homo sapiens"
+taxon_id = 9606
+study_accession = "GSE172421"
+study_source = "GEO Series (short/long-read DTU benchmark context)"
+focus = "Differential transcript usage benchmark with short-read support"
+reference_genome = "GRCh38"
+reference_annotation = "GENCODE/Ensembl-compatible transcript annotation"
+run_accessions = ["SRR14684074", "SRR14684079"]
+
+[species.hsa.run_metadata.SRR14684074]
+label = "human_pair_A"
+platform = "ILLUMINA"
+library_layout = "PAIRED"
+group = "control_like"
+
+[species.hsa.run_metadata.SRR14684079]
+label = "human_pair_B"
+platform = "ILLUMINA"
+library_layout = "PAIRED"
+group = "perturbed_like"
+
+[checksums]
+# Filled after fixture construction in follow-up notebook/e2e implementation.
+canonical_metadata_lock_sha256 = "TBD"
+fixture_bundle_sha256 = "TBD"
+
+[citations]
+plant_primary = "Zhang R, Calixto CPG, Marquez Y, et al. A high quality Arabidopsis transcriptome for accurate transcript-level analysis of alternative splicing. Genome Biol. 2022;23(1):211. doi:10.1186/s13059-022-02711-0"
+human_primary = "Glinos DA, Garborcauskas G, Hoffman P, et al. Transcriptome variation in human tissues revealed by long-read sequencing. Nature. 2022;608(7922):353-359. doi:10.1038/s41586-022-05035-y"
+human_benchmark = "Sahlin K, Limasset A, Lu S, et al. Benchmarking differential transcript usage and differential expression analysis tools for short- and long-read RNA-seq data. Nat Methods. 2023;20:1206-1216. doi:10.1038/s41592-023-02026-3"

--- a/docs/tutorials/datasets.md
+++ b/docs/tutorials/datasets.md
@@ -1,0 +1,98 @@
+# Tutorial Dataset Curation (Plant + Human)
+
+This document defines the canonical modern datasets used by
+`splicegrapher-next` tutorial notebooks and e2e/integration tracks.
+
+Canonical selection is pinned in `docs/tutorials/dataset_manifest.toml`.
+Species entries use short stable keys (`ath`, `hsa`) and store scientific names
+and taxonomy IDs in explicit fields.
+
+## Why These Datasets
+
+Goals for canonical tutorial/e2e data:
+
+- modern, publication-backed provenance
+- clear relevance to transcript and alternative splicing analysis
+- tractable subset size for local and CI execution
+- stable accession metadata for reproducible acquisition
+
+Selected canonical studies:
+
+- Plant: Arabidopsis AtRTD3 study (`PRJNA755474`)
+- Human: DTU benchmark context (`GSE172421`, short-read subset)
+
+## Tiering Model
+
+Two-tier model:
+
+- Notebook tier:
+  - source data fetched from canonical public studies
+  - suitable for local hands-on tutorials
+- CI/e2e tier:
+  - tiny derived fixtures generated from canonical studies
+  - tracked under `tests/fixtures/` with checksums
+
+CI should not depend on full public data downloads.
+
+## Acquisition Methods
+
+Both methods are supported by policy:
+
+- Primary: Python/HTTP metadata and file acquisition (implemented with `httpx`)
+- Alternative: SRA Toolkit (`prefetch`, `fasterq-dump`) for users who prefer it
+
+### Python/HTTP Method (Default)
+
+Planned script contract:
+
+```bash
+uv run python scripts/data/fetch_tutorial_data.py \
+  --manifest docs/tutorials/dataset_manifest.toml \
+  --species plant \
+  --method python-httpx
+```
+
+### SRA Toolkit Method (Alternative)
+
+Example command shape:
+
+```bash
+prefetch SRR17001820 SRR17001821
+fasterq-dump SRR17001820 SRR17001821 --threads 8 --outdir data/raw/plant
+```
+
+Human example:
+
+```bash
+prefetch SRR14684074 SRR14684079
+fasterq-dump SRR14684074 SRR14684079 --threads 8 --outdir data/raw/human
+```
+
+## Reproducibility Requirements
+
+- Keep accession IDs pinned in `dataset_manifest.toml`.
+- Keep study references and citation metadata updated when dataset choices
+  change.
+- Add and verify checksums for derived fixture bundles.
+- If acquisition logic changes, document it in the related issue/PR.
+- Any use of sync HTTP or `requests` requires explicit issue/PR justification
+  under repository HTTP policy.
+
+## Curation Update Rules
+
+When rotating canonical runs:
+
+1. Open/update a scoped issue.
+2. Update `dataset_manifest.toml` with explicit accession changes.
+3. Rebuild fixture tier and refresh checksums.
+4. Verify notebook smoke execution still passes.
+5. Call out migration/compatibility impact in PR notes.
+
+## References
+
+- AtRTD3 (Arabidopsis) data availability and publication:
+  - <https://doi.org/10.1186/s13059-022-02711-0>
+- DTU benchmark publication:
+  - <https://doi.org/10.1038/s41592-023-02026-3>
+- GEO study context for human benchmark:
+  - <https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE172421>


### PR DESCRIPTION
## Summary
- add canonical modern tutorial/e2e dataset manifest for plant + human tracks
- add tutorial dataset curation/provenance guidance with dual acquisition paths (python-httpx and SRA Toolkit)
- add README pointer to tutorial dataset contract

## Details
- Added `docs/tutorials/dataset_manifest.toml`
  - pinned canonical studies and run accessions
  - concise species keys (`ath`, `hsa`) with explicit scientific names + taxonomy IDs
  - two-tier policy encoded (canonical notebook data + tiny derived CI fixtures)
- Added `docs/tutorials/datasets.md`
  - dataset selection rationale and reproducibility policy
  - primary Python/HTTP acquisition path and documented SRA Toolkit alternative
  - curation update workflow and references
- Updated `README.md` with tutorial dataset curation section

## Validation
- `uv run ruff check . --fix`
- `uv run ruff format .`
- `uv run pytest`
- `uv build`

Closes #29
