### PR TITLE
Decompose shared/utils.py into focused modules with compatibility shim

### DIFF
--- a/SpliceGrapher/formats/fasta.py
+++ b/SpliceGrapher/formats/fasta.py
@@ -27,7 +27,7 @@ with changes by Asa Ben-Hur and Mark Rogers
 
 import os
 
-from SpliceGrapher.shared.utils import ezopen
+from SpliceGrapher.shared.file_utils import ezopen
 
 
 class MalformedInput:

--- a/SpliceGrapher/shared/collection_utils.py
+++ b/SpliceGrapher/shared/collection_utils.py
@@ -1,0 +1,55 @@
+"""Collection and searching helpers extracted from shared.utils."""
+
+from SpliceGrapher.shared.process_utils import getAttribute
+
+
+def asList(value, delim=","):
+    """Generic method for creating a list from a given value.
+    The value may be a string of delimiter-separated values,
+    a list or a set."""
+    if isinstance(value, str):
+        return value.split(delim)
+    elif isinstance(value, list):
+        return value
+    elif isinstance(value, set):
+        return list(value)
+    else:
+        raise ValueError("Expected a string, a list or a set; received %s" % type(value))
+
+
+def asSet(value, delim=","):
+    """Generic method for creating a set from a given value.
+    The value may be a string of delimiter-separated values,
+    a list or a set."""
+    if isinstance(value, str):
+        return set(value.split(delim))
+    elif isinstance(value, list):
+        return set(value)
+    elif isinstance(value, set):
+        return value
+    else:
+        raise ValueError("Expected a string, a list or a set; received %s" % type(value))
+
+
+def bsearch(X, target, getValue=lambda a: a, **args):
+    """
+    Generic binary search returns the index of the value in X that
+    is closest to the target.  'getValue' provides access to the correct
+    attribute of each element in X.  Assumes X is sorted such that
+    getValue(a) < getValue(b) iff a < b.
+    """
+    if not X:
+        raise ValueError("Cannot perform binary search on an empty list")
+    lo = getAttribute("low", 0, **args)
+    hi = getAttribute("high", len(X) - 1, **args)
+    mid = lo
+    while lo < hi:
+        mid = (lo + hi) // 2
+        midval = getValue(X[mid])
+        if midval < target:
+            lo = mid + 1
+        elif midval > target:
+            hi = mid - 1
+        else:
+            return mid
+    return lo

--- a/SpliceGrapher/shared/config_utils.py
+++ b/SpliceGrapher/shared/config_utils.py
@@ -1,0 +1,36 @@
+"""Configuration and environment helpers extracted from shared.utils."""
+
+import configparser as ConfigParser
+import os
+
+
+def configMap(cfgFile):
+    """Reads a configuration file and returns a dictionary of all sections, options and values."""
+    result = {}
+    config = ConfigParser.ConfigParser()
+    # Activates case-sensitivity:
+    config.optionxform = str
+
+    try:
+        config.read(cfgFile)
+    except ConfigParser.ParsingError:
+        raise ValueError("Invalid configuration file %s" % cfgFile)
+
+    for sect in config.sections():
+        result[sect] = {}
+        options = config.options(sect)
+        for opt in options:
+            try:
+                result[sect][opt] = config.get(sect, opt)
+            except Exception:
+                result[sect][opt] = None
+    return result
+
+
+def getEnvironmentValue(name, default=None):
+    """Returns the value for the given environment variable name, if found;
+    otherwise returns default value."""
+    try:
+        return os.environ[name]
+    except KeyError:
+        return default

--- a/SpliceGrapher/shared/file_utils.py
+++ b/SpliceGrapher/shared/file_utils.py
@@ -1,0 +1,80 @@
+"""Filesystem and file-format helpers extracted from shared.utils."""
+
+import gzip
+import os
+from glob import glob
+
+
+def ezopen(fileName):
+    """Allows clients to open files without regard for whether they're gzipped."""
+    if not (os.path.exists(fileName) and os.path.isfile(fileName)):
+        raise ValueError("file does not exist at %s" % fileName)
+
+    fileHandle = gzip.GzipFile(fileName)
+    try:
+        fileHandle.readline()
+        return gzip.GzipFile(fileName)
+    except Exception:
+        return open(fileName)
+    finally:
+        fileHandle.close()
+
+
+def fileLen(path):
+    """Simple function to get an exact file length."""
+    line_count = 0
+    with open(path) as instream:
+        for line_count, _line in enumerate(instream, start=1):
+            pass
+    return line_count
+
+
+def filePrefix(f):
+    """Returns the filename prefix for a file.  For example:
+    /my/dir/myfile.ext --> myfile"""
+    _head, tail = os.path.split(f)
+    prefix, _suffix = os.path.splitext(tail)
+    return prefix
+
+
+def findFile(name, path, delim=":"):
+    """Finds the first instance of a file name in the given path string."""
+    paths = path.split(delim)
+    for p in paths:
+        filePath = os.path.join(p, name)
+        if os.path.exists(filePath) and os.path.isfile(filePath):
+            return filePath
+
+
+def makeGraphListFile(spliceGraphDir):
+    """Given a path to a top-level directory of splice graphs, returns
+    a file that contains the paths to all graphs under that directory.
+    Follows the standard SpliceGrapher directory structure:
+        top-level-dir/chromosome-dir/splice-graph-file"""
+    subdirs = os.path.join(spliceGraphDir, "*")
+    target = os.path.join(subdirs, "*.gff")
+    graphList = glob(target)
+    if not graphList:
+        raise ValueError("No splice graphs found in %s\n" % spliceGraphDir)
+
+    graphList.sort()
+    result = "%s.lis" % spliceGraphDir
+    with open(result, "w") as graphStream:
+        graphStream.write("\n".join(graphList))
+    return result
+
+
+def validateDir(path):
+    """Standard method for validating directory paths."""
+    validateFile(path)
+    if not os.path.isdir(path):
+        raise Exception("'%s' is not a directory; exiting." % path)
+
+
+def validateFile(path):
+    """Standard method for validating file paths."""
+    if not path:
+        raise Exception("'%s' is not a valid file path; exiting." % path)
+
+    if not os.path.exists(path):
+        raise Exception("File '%s' not found; exiting." % path)

--- a/SpliceGrapher/shared/format_utils.py
+++ b/SpliceGrapher/shared/format_utils.py
@@ -1,0 +1,73 @@
+"""Formatting and parsing helpers extracted from shared.utils."""
+
+import time
+
+
+def commaFormat(d):
+    """Formats integer values using commas.  For example, 123456789 becomes '123,456,789'"""
+    return f"{int(d):,}"
+
+
+def dictString(valDict, delim=","):
+    """Returns a simple string representation of a list of values."""
+    return delim.join(["%s -> %s" % (x, valDict[x]) for x in valDict])
+
+
+def listString(vals, delim=","):
+    """Returns a simple string representation of a list of values."""
+    return delim.join([str(x) for x in vals])
+
+
+def substringAfter(s, tag):
+    """Returns the substring after the given tag, if found; None otherwise."""
+    pos = s.find(tag)
+    if pos >= 0:
+        return s[pos + len(tag) :]
+
+
+def substringBefore(s, tag):
+    """Returns the substring before the given tag, if found; None otherwise."""
+    pos = s.find(tag)
+    if pos >= 0:
+        return s[:pos]
+
+
+def substringBetween(s, tag1, tag2):
+    """Returns the substring between the two tags, if found; None otherwise."""
+    p1 = s.find(tag1)
+    if p1 < 0:
+        return None
+    p1 += len(tag1)
+    p2 = s.find(tag2, p1)
+    if p2 > 0:
+        return s[p1:p2]
+
+
+def timestamp(format_string="%Y%m%d%H%M%S"):
+    """Returns a timestamp unique to the current second."""
+    return time.strftime(format_string, time.localtime())
+
+
+def timeString(s, format_string="%X", LF=False):
+    """Returns the input string with user-readable a timestamp prefix."""
+    timestamp = time.strftime(format_string, time.localtime())
+    result = "%s %s" % (timestamp, s)
+    if LF:
+        result += "\n"
+    return result
+
+
+def to_numeric(s):
+    """Attempts to return the given value as a float or an int, else returns the original string."""
+    try:
+        return int(s)
+    except ValueError:
+        # (fails on numbers with decimals like '12.34')
+        pass
+
+    try:
+        return float(s)
+    except ValueError:
+        pass
+
+    return s

--- a/SpliceGrapher/shared/header_utils.py
+++ b/SpliceGrapher/shared/header_utils.py
@@ -1,0 +1,21 @@
+"""Header parsing helpers extracted from shared.utils."""
+
+
+def process_fastq_header(header):
+    """Find the chromosome identifier within a FASTQ header."""
+    return header.split()[0]
+
+
+def process_fasta_header(header):
+    """Find the chromosome identifier within a FASTA header."""
+    return header.split()[0]
+
+
+def process_labeled_fasta_header(header):
+    """
+    Extract a sequence ID and its label from a fasta file.
+    Used with training data FASTA files, so it assumes
+    headers have the form "ID label=#".
+    """
+    id, labelToken = header.split()
+    return id.strip(), labelToken.split("=")[1]

--- a/SpliceGrapher/shared/process_utils.py
+++ b/SpliceGrapher/shared/process_utils.py
@@ -1,0 +1,65 @@
+"""Process and command execution helpers extracted from shared.utils."""
+
+import os
+import subprocess
+import sys
+
+from SpliceGrapher.shared import streams
+from SpliceGrapher.shared.format_utils import timeString
+
+
+def getAttribute(key, default, **args):
+    """Returns the value for the given key in the arguments dict, if found;
+    otherwise returns default value."""
+    return default if key not in args else args[key]
+
+
+def idFactory(pfx="", initial=1):
+    """Generates unique ids using the given prefix.  For example,
+    idFactory('ev_') will generate 'ev_1', 'ev_2', ..."""
+    prefix = pfx if pfx else ""
+    counter = initial
+    while 1:
+        yield "%s%d" % (prefix, counter)
+        counter += 1
+
+
+def logMessage(s, logstream=None):
+    """Allows log messages to be output both to stderr and a log file."""
+    sys.stderr.write(s)
+    if logstream:
+        logstream.write(s)
+
+
+def runCommand(s, **args):
+    """Announces a command runs it.."""
+    logstream = getAttribute("logstream", None, **args)
+    debug = getAttribute("debug", False, **args)
+    exitOnError = getAttribute("exitOnError", True, **args)
+    stderr = getAttribute("stderr", None, **args)
+    stdout = getAttribute("stdout", None, **args)
+    message = "    " + timeString("%s\n" % s)
+    sys.stderr.write(message)
+    if logstream:
+        logstream.write(message)
+
+    retcode = 0
+    if not debug:
+        if not stderr:
+            streams.hideStderr()
+        if not stdout:
+            streams.hideStdout()
+        retcode = subprocess.call(s, shell=True, stderr=stderr, stdout=stdout)
+        if not stderr:
+            streams.showStderr()
+        if not stdout:
+            streams.showStdout()
+
+    if exitOnError and retcode < 0:
+        raise Exception("Error running command: returned %d signal\n%s" % (retcode, s))
+
+
+def writeStartupMessage():
+    """Standardized startup message for all scripts."""
+    base = os.path.basename(sys.argv[0])
+    sys.stderr.write(timeString("%s Started\n" % base))

--- a/SpliceGrapher/shared/progress.py
+++ b/SpliceGrapher/shared/progress.py
@@ -1,0 +1,75 @@
+"""Progress and random-iterator helpers extracted from shared.utils."""
+
+import random
+import sys
+
+from SpliceGrapher.shared.format_utils import commaFormat
+
+
+class ProgressIndicator:
+    """A simple progress indicator."""
+
+    def __init__(self, increment, description="", verbose=True):
+        self.limit = increment
+        self.barlim = int(self.limit / 10)
+        self.dotlim = int(self.barlim / 5)
+        self.descr = description
+        self.started = False
+        self.verbose = verbose
+        self.ctr = 0
+
+    def count(self):
+        """Returns the current count."""
+        return self.ctr
+
+    def finish(self):
+        """Finishes the progress output by appending a newline,
+        if anything has been written."""
+        if self.started:
+            sys.stderr.write("\n")
+        self.started = False
+
+    def reset(self):
+        """Resets the indicator to be used again."""
+        self.ctr = 0
+        self.finish()
+
+    def update(self):
+        """Updates the indicator."""
+        self.ctr += 1
+        if not self.verbose:
+            return
+        if self.ctr % self.limit == 0:
+            sys.stderr.write("%s %s\n" % (commaFormat(self.ctr), self.descr))
+        elif self.ctr % self.barlim == 0:
+            sys.stderr.write("|")
+        elif self.ctr % self.dotlim == 0:
+            self.started = True
+            sys.stderr.write(".")
+
+
+class RandomListIterator:
+    """
+    Returns items at random, with replacement, from a list of values.
+    For lists with more than ~1000 elements, this is about 30% more
+    efficient than using random.sample() repeatedly.
+    """
+
+    def __init__(self, values, **args):
+        self.values = values
+        self.rand = random.Random()
+        self.limit = len(self.values) - 1
+        if "seed" in args:
+            self.rand.seed = args["seed"]
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        """Iterator implementation that returns a random value, with
+        replacement, from a list."""
+        i = self.rand.randint(0, self.limit)
+        return self.values[i]
+
+    # Python 2 compatibility alias
+    next = __next__

--- a/SpliceGrapher/shared/utils.py
+++ b/SpliceGrapher/shared/utils.py
@@ -1,406 +1,74 @@
-# Copyright (C) 2010 by Colorado State University
-# Contact: Mark Rogers <rogersma@cs.colostate.edu>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or (at
-# your option) any later version.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307,
-# USA.
-"""
-Module containing general utility methods.
+"""Compatibility shim for legacy imports from :mod:`SpliceGrapher.shared.utils`.
+
+Use focused modules under ``SpliceGrapher.shared`` for new code.
 """
 
-import configparser as ConfigParser
-import gzip
-import os
-import random
-import subprocess
-import sys
-import time
-from glob import glob
-
-from SpliceGrapher.shared import streams
-
-
-def asList(value, delim=","):
-    """Generic method for creating a list from a given value.
-    The value may be a string of delimiter-separated values,
-    a list or a set."""
-    if type(value) == str:
-        return value.split(delim)
-    elif type(value) == list:
-        return value
-    elif type(value) == set:
-        return list(value)
-    else:
-        raise ValueError("Expected a string, a list or a set; received %s" % type(value))
-
-
-def asSet(value, delim=","):
-    """Generic method for creating a set from a given value.
-    The value may be a string of delimiter-separated values,
-    a list or a set."""
-    if type(value) == str:
-        return set(value.split(delim))
-    elif type(value) == list:
-        return set(value)
-    elif type(value) == set:
-        return value
-    else:
-        raise ValueError("Expected a string, a list or a set; received %s" % type(value))
-
-
-def bsearch(X, target, getValue=lambda a: a, **args):
-    """
-    Generic binary search returns the index of the value in X that
-    is closest to the target.  'getValue' provides access to the correct
-    attribute of each element in X.  Assumes X is sorted such that
-    getValue(a) < getValue(b) iff a < b.
-    """
-    if not X:
-        raise ValueError("Cannot perform binary search on an empty list")
-    lo = getAttribute("low", 0, **args)
-    hi = getAttribute("high", len(X) - 1, **args)
-    mid = lo
-    while lo < hi:
-        mid = (lo + hi) // 2
-        midval = getValue(X[mid])
-        if midval < target:
-            lo = mid + 1
-        elif midval > target:
-            hi = mid - 1
-        else:
-            return mid
-    return lo
-
-
-def commaFormat(d):
-    """Formats integer values using commas.  For example, 123456789 becomes '123,456,789'"""
-    return f"{int(d):,}"
-
-
-def configMap(cfgFile):
-    """Reads a configuration file and returns a dictionary of all sections, options and values."""
-    result = {}
-    config = ConfigParser.ConfigParser()
-    # Activates case-sensitivity:
-    config.optionxform = str
-
-    try:
-        config.read(cfgFile)
-    except ConfigParser.ParsingError:
-        raise ValueError("Invalid configuration file %s" % cfgFile)
-
-    for sect in config.sections():
-        result[sect] = {}
-        options = config.options(sect)
-        for opt in options:
-            try:
-                result[sect][opt] = config.get(sect, opt)
-            except:
-                result[option] = None
-    return result
-
-
-def dictString(valDict, delim=","):
-    """Returns a simple string representation of a list of values."""
-    return delim.join(["%s -> %s" % (x, valDict[x]) for x in valDict])
-
-
-def ezopen(fileName):
-    """Allows clients to open files without regard for whether they're gzipped."""
-    if not (os.path.exists(fileName) and os.path.isfile(fileName)):
-        raise ValueError("file does not exist at %s" % fileName)
-
-    fileHandle = gzip.GzipFile(fileName)
-    gzippedFile = True
-    try:
-        line = fileHandle.readline()
-        fileHandle.close()
-        return gzip.GzipFile(fileName)
-    except:
-        return open(fileName)
-
-
-def fileLen(path):
-    """Simple function to get an exact file length."""
-    with open(path) as f:
-        for i, l in enumerate(f):
-            pass
-    return i + 1
-
-
-def filePrefix(f):
-    """Returns the filename prefix for a file.  For example:
-    /my/dir/myfile.ext --> myfile"""
-    head, tail = os.path.split(f)
-    prefix, suffix = os.path.splitext(tail)
-    return prefix
-
-
-def findFile(name, path, delim=":"):
-    """Finds the first instance of a file name in the given path string."""
-    paths = path.split(delim)
-    for p in paths:
-        filePath = os.path.join(p, name)
-        if os.path.exists(filePath) and os.path.isfile(filePath):
-            return filePath
-
-
-def getAttribute(key, default, **args):
-    """Returns the value for the given key in the arguments dict, if found;
-    otherwise returns default value."""
-    return default if key not in args else args[key]
-
-
-def getEnvironmentValue(name, default=None):
-    """Returns the value for the given environment variable name, if found;
-    otherwise returns default value."""
-    try:
-        return os.environ[name]
-    except KeyError:
-        return default
-
-
-def idFactory(pfx="", initial=1):
-    """Generates unique ids using the given prefix.  For example,
-    idFactory('ev_') will generate 'ev_1', 'ev_2', ..."""
-    prefix = pfx if pfx else ""
-    counter = initial
-    while 1:
-        yield "%s%d" % (prefix, counter)
-        counter += 1
-
-
-def listString(vals, delim=","):
-    """Returns a simple string representation of a list of values."""
-    return delim.join([str(x) for x in vals])
-
-
-def logMessage(s, logstream=None):
-    """Allows log messages to be output both to stderr and a log file."""
-    sys.stderr.write(s)
-    if logstream:
-        logstream.write(s)
-
-
-def makeGraphListFile(spliceGraphDir):
-    """Given a path to a top-level directory of splice graphs, returns
-    a file that contains the paths to all graphs under that directory.
-    Follows the standard SpliceGrapher directory structure:
-        top-level-dir/chromosome-dir/splice-graph-file"""
-    subdirs = os.path.join(spliceGraphDir, "*")
-    target = os.path.join(subdirs, "*.gff")
-    graphList = glob(target)
-    if not graphList:
-        raise ValueError("No splice graphs found in %s\n" % spliceGraphDir)
-
-    graphList.sort()
-    result = "%s.lis" % spliceGraphDir
-    graphStream = open(result, "w")
-    graphStream.write("\n".join(graphList))
-    graphStream.close()
-    return result
-
-
-def process_fastq_header(header):
-    """Find the chromosome identifier within a FASTQ header."""
-    return header.split()[0]
-
-
-def process_fasta_header(header):
-    """Find the chromosome identifier within a FASTA header."""
-    return header.split()[0]
-
-
-def process_labeled_fasta_header(header):
-    """
-    Extract a sequence ID and its label from a fasta file.
-    Used with training data FASTA files, so it assumes
-    headers have the form "ID label=#".
-    """
-    id, labelToken = header.split()
-    return id.strip(), labelToken.split("=")[1]
-
-
-def runCommand(s, **args):
-    """Announces a command runs it.."""
-    logstream = getAttribute("logstream", None, **args)
-    debug = getAttribute("debug", False, **args)
-    exitOnError = getAttribute("exitOnError", True, **args)
-    stderr = getAttribute("stderr", None, **args)
-    stdout = getAttribute("stdout", None, **args)
-    message = "    " + timeString("%s\n" % s)
-    sys.stderr.write(message)
-    if logstream:
-        logstream.write(message)
-
-    retcode = 0
-    if not debug:
-        if not stderr:
-            streams.hideStderr()
-        if not stdout:
-            streams.hideStdout()
-        retcode = subprocess.call(s, shell=True, stderr=stderr, stdout=stdout)
-        if not stderr:
-            streams.showStderr()
-        if not stdout:
-            streams.showStdout()
-
-    if exitOnError and retcode < 0:
-        raise Exception("Error running command: returned %d signal\n%s" % (retcode, s))
-
-
-def substringAfter(s, tag):
-    """Returns the substring after the given tag, if found; None otherwise."""
-    pos = s.find(tag)
-    if pos >= 0:
-        return s[pos + len(tag) :]
-
-
-def substringBefore(s, tag):
-    """Returns the substring before the given tag, if found; None otherwise."""
-    pos = s.find(tag)
-    if pos >= 0:
-        return s[:pos]
-
-
-def substringBetween(s, tag1, tag2):
-    """Returns the substring between the two tags, if found; None otherwise."""
-    p1 = s.find(tag1)
-    if p1 < 0:
-        return None
-    p1 += len(tag1)
-    p2 = s.find(tag2, p1)
-    if p2 > 0:
-        return s[p1:p2]
-
-
-def timestamp(format_string="%Y%m%d%H%M%S"):
-    """Returns a timestamp unique to the current second."""
-    return time.strftime(format_string, time.localtime())
-
-
-def timeString(s, format_string="%X", LF=False):
-    """Returns the input string with user-readable a timestamp prefix."""
-    timestamp = time.strftime(format_string, time.localtime())
-    result = "%s %s" % (timestamp, s)
-    if LF:
-        result += "\n"
-    return result
-
-
-def to_numeric(s):
-    """Attempts to return the given value as a float or an int, else returns the original string."""
-    try:
-        return int(s)
-    except ValueError:
-        # (fails on numbers with decimals like '12.34')
-        pass
-
-    try:
-        return float(s)
-    except ValueError:
-        pass
-
-    return s
-
-
-def validateDir(path):
-    """Standard method for validating directory paths."""
-    validateFile(path)
-    if not os.path.isdir(path):
-        raise Exception("'%s' is not a directory; exiting." % path)
-
-
-def validateFile(path):
-    """Standard method for validating file paths."""
-    if not path:
-        raise Exception("'%s' is not a valid file path; exiting." % path)
-
-    if not os.path.exists(path):
-        raise Exception("File '%s' not found; exiting." % path)
-
-
-def writeStartupMessage():
-    """Standardized startup message for all scripts."""
-    base = os.path.basename(sys.argv[0])
-    sys.stderr.write(timeString("%s Started\n" % base))
-
-
-class ProgressIndicator(object):
-    """A simple progress indicator."""
-
-    def __init__(self, increment, description="", verbose=True):
-        self.limit = increment
-        self.barlim = int(self.limit / 10)
-        self.dotlim = int(self.barlim / 5)
-        self.descr = description
-        self.started = False
-        self.verbose = verbose
-        self.ctr = 0
-
-    def count(self):
-        """Returns the current count."""
-        return self.ctr
-
-    def finish(self):
-        """Finishes the progress output by appending a newline,
-        if anything has been written."""
-        if self.started:
-            sys.stderr.write("\n")
-        self.started = False
-
-    def reset(self):
-        """Resets the indicator to be used again."""
-        self.ctr = 0
-        self.finish()
-
-    def update(self):
-        """Updates the indicator."""
-        self.ctr += 1
-        if not self.verbose:
-            return
-        if self.ctr % self.limit == 0:
-            sys.stderr.write("%s %s\n" % (commaFormat(self.ctr), self.descr))
-        elif self.ctr % self.barlim == 0:
-            sys.stderr.write("|")
-        elif self.ctr % self.dotlim == 0:
-            self.started = True
-            sys.stderr.write(".")
-
-
-class RandomListIterator(object):
-    """
-    Returns items at random, with replacement, from a list of values.
-    For lists with more than ~1000 elements, this is about 30% more
-    efficient than using random.sample() repeatedly.
-    """
-
-    def __init__(self, values, **args):
-        self.values = values
-        self.rand = random.Random()
-        self.limit = len(self.values) - 1
-        if "seed" in args:
-            self.rand.seed = args["seed"]
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        """Iterator implementation that returns a random value, with
-        replacement, from a list."""
-        i = self.rand.randint(0, self.limit)
-        return self.values[i]
-
-    # Python 2 compatibility alias
-    next = __next__
+from SpliceGrapher.shared.collection_utils import asList, asSet, bsearch
+from SpliceGrapher.shared.config_utils import configMap, getEnvironmentValue
+from SpliceGrapher.shared.file_utils import (
+    ezopen,
+    fileLen,
+    filePrefix,
+    findFile,
+    makeGraphListFile,
+    validateDir,
+    validateFile,
+)
+from SpliceGrapher.shared.format_utils import (
+    commaFormat,
+    dictString,
+    listString,
+    substringAfter,
+    substringBefore,
+    substringBetween,
+    timestamp,
+    timeString,
+    to_numeric,
+)
+from SpliceGrapher.shared.header_utils import (
+    process_fasta_header,
+    process_fastq_header,
+    process_labeled_fasta_header,
+)
+from SpliceGrapher.shared.process_utils import (
+    getAttribute,
+    idFactory,
+    logMessage,
+    runCommand,
+    writeStartupMessage,
+)
+from SpliceGrapher.shared.progress import ProgressIndicator, RandomListIterator
+
+__all__ = [
+    "asList",
+    "asSet",
+    "bsearch",
+    "commaFormat",
+    "configMap",
+    "dictString",
+    "ezopen",
+    "fileLen",
+    "filePrefix",
+    "findFile",
+    "getAttribute",
+    "getEnvironmentValue",
+    "idFactory",
+    "listString",
+    "logMessage",
+    "makeGraphListFile",
+    "process_fastq_header",
+    "process_fasta_header",
+    "process_labeled_fasta_header",
+    "runCommand",
+    "substringAfter",
+    "substringBefore",
+    "substringBetween",
+    "timestamp",
+    "timeString",
+    "to_numeric",
+    "validateDir",
+    "validateFile",
+    "writeStartupMessage",
+    "ProgressIndicator",
+    "RandomListIterator",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,6 @@ ignore = [
 "SpliceGrapher/formats/fasta.py" = ["E", "F", "W"]
 "SpliceGrapher/shared/streams.py" = ["E", "F"]
 "SpliceGrapher/shared/ShortRead.py" = ["E", "F", "W"]
-"SpliceGrapher/shared/utils.py" = ["E", "F"]
 
 [tool.mypy]
 python_version = "3.10"

--- a/tests/test_shared_utils_shim.py
+++ b/tests/test_shared_utils_shim.py
@@ -1,0 +1,34 @@
+"""Compatibility checks for the shared.utils decomposition shim."""
+
+from __future__ import annotations
+
+import importlib
+
+
+def test_shim_reexports_match_focused_modules() -> None:
+    utils_module = importlib.import_module("SpliceGrapher.shared.utils")
+    file_utils_module = importlib.import_module("SpliceGrapher.shared.file_utils")
+    format_utils_module = importlib.import_module("SpliceGrapher.shared.format_utils")
+    process_utils_module = importlib.import_module("SpliceGrapher.shared.process_utils")
+    progress_module = importlib.import_module("SpliceGrapher.shared.progress")
+
+    assert utils_module.ezopen is file_utils_module.ezopen
+    assert utils_module.commaFormat is format_utils_module.commaFormat
+    assert utils_module.getAttribute is process_utils_module.getAttribute
+    assert utils_module.ProgressIndicator is progress_module.ProgressIndicator
+
+
+def test_fasta_import_uses_focused_file_utils_module() -> None:
+    fasta_module = importlib.import_module("SpliceGrapher.formats.fasta")
+    file_utils_module = importlib.import_module("SpliceGrapher.shared.file_utils")
+
+    assert fasta_module.ezopen is file_utils_module.ezopen
+
+
+def test_shim_retains_representative_utility_behavior() -> None:
+    utils_module = importlib.import_module("SpliceGrapher.shared.utils")
+
+    assert utils_module.asList("a,b,c") == ["a", "b", "c"]
+    assert utils_module.asSet("a,b,a") == {"a", "b"}
+    assert utils_module.to_numeric("12") == 12
+    assert utils_module.to_numeric("12.5") == 12.5


### PR DESCRIPTION
## Summary
- decompose `SpliceGrapher/shared/utils.py` into focused utility modules
- keep `SpliceGrapher/shared/utils.py` as a compatibility shim that re-exports existing names
- update one extracted consumer (`SpliceGrapher/formats/fasta.py`) to use focused imports
- add shim regression coverage and remove the Ruff per-file ignore for `SpliceGrapher/shared/utils.py`

## Changes
- added:
  - `SpliceGrapher/shared/collection_utils.py`
  - `SpliceGrapher/shared/config_utils.py`
  - `SpliceGrapher/shared/file_utils.py`
  - `SpliceGrapher/shared/format_utils.py`
  - `SpliceGrapher/shared/header_utils.py`
  - `SpliceGrapher/shared/process_utils.py`
  - `SpliceGrapher/shared/progress.py`
  - `tests/test_shared_utils_shim.py`
- replaced implementation of:
  - `SpliceGrapher/shared/utils.py` (compatibility shim only)
- updated:
  - `SpliceGrapher/formats/fasta.py` (`ezopen` import moved to `shared.file_utils`)
  - `pyproject.toml` (removed per-file Ruff ignore for `SpliceGrapher/shared/utils.py`)

## Validation
- `uv run ruff check . --fix`
- `uv run ruff format .`
- `uv run pytest`
- `uv build`

Closes #8
