### PR TITLE
Modernize GitHub Pages tutorial site with dark mode

### DIFF
--- a/.github/workflows/docs-notebooks-pages.yml
+++ b/.github/workflows/docs-notebooks-pages.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - ".github/workflows/docs-notebooks-pages.yml"
       - "docs/notebooks/**"
+      - "docs/site/**"
       - "docs/tutorials/**"
       - "pyproject.toml"
       - "uv.lock"
@@ -42,31 +43,8 @@ jobs:
       - name: Register python kernel
         run: uv run python -m ipykernel install --user --name python3 --display-name "Python 3"
 
-      - name: Render notebooks
-        run: |
-          mkdir -p site/notebooks
-          uv run jupyter nbconvert --to html --execute docs/notebooks/01_legacy_tutorial_foundation.ipynb --output 01_legacy_tutorial_foundation.html --output-dir site/notebooks
-          uv run jupyter nbconvert --to html --execute docs/notebooks/02_modern_dataset_track.ipynb --output 02_modern_dataset_track.html --output-dir site/notebooks
-
-      - name: Build docs index
-        run: |
-          cat > site/index.html <<'EOF'
-          <!doctype html>
-          <html lang="en">
-          <head>
-            <meta charset="utf-8">
-            <meta name="viewport" content="width=device-width, initial-scale=1">
-            <title>splicegrapher-next Tutorials</title>
-          </head>
-          <body>
-            <h1>splicegrapher-next Tutorial Notebooks</h1>
-            <ul>
-              <li><a href="notebooks/01_legacy_tutorial_foundation.html">Legacy Tutorial Foundation</a></li>
-              <li><a href="notebooks/02_modern_dataset_track.html">Modern Dataset Track</a></li>
-            </ul>
-          </body>
-          </html>
-          EOF
+      - name: Build themed docs site
+        run: uv run python docs/site/build_pages_site.py
 
       - name: Upload pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/docs/notebooks/README.md
+++ b/docs/notebooks/README.md
@@ -28,3 +28,12 @@ uv run jupyter lab
 - PR smoke execution is handled by `.github/workflows/notebook-smoke.yml`.
 - GitHub Pages rendering/deploy is handled by
   `.github/workflows/docs-notebooks-pages.yml`.
+- The Pages visual shell (landing page + notebook dark mode toggle/theme) is
+  built by `docs/site/build_pages_site.py`.
+
+Local Pages preview:
+
+```bash
+uv run python docs/site/build_pages_site.py
+python -m http.server --directory site 8000
+```

--- a/docs/site/assets/pages.css
+++ b/docs/site/assets/pages.css
@@ -1,0 +1,260 @@
+@import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&family=Space+Grotesk:wght@400;500;700&family=Source+Serif+4:wght@400;600&display=swap");
+
+:root {
+  color-scheme: light dark;
+  --bg: #f6f7fb;
+  --bg-accent: #e8eef9;
+  --surface: #ffffff;
+  --surface-raised: #f3f6ff;
+  --fg: #11213a;
+  --muted: #4d5f7a;
+  --border: #ced8ea;
+  --link: #085db7;
+  --link-hover: #063f7e;
+  --hero-gradient: radial-gradient(circle at 20% -20%, #b8d8ff 0%, transparent 45%),
+    radial-gradient(circle at 90% 20%, #d8ffe6 0%, transparent 40%);
+  --card-gradient: linear-gradient(160deg, #ffffff 0%, #f3f6ff 100%);
+  --shadow-soft: 0 20px 45px rgba(16, 45, 86, 0.08);
+  --code-bg: #eaf1ff;
+  --code-fg: #0f2140;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg: #0d121c;
+    --bg-accent: #141f31;
+    --surface: #172336;
+    --surface-raised: #1b2a41;
+    --fg: #ebf3ff;
+    --muted: #a8bbd8;
+    --border: #2b3e5e;
+    --link: #89c4ff;
+    --link-hover: #b0daff;
+    --hero-gradient: radial-gradient(circle at 15% -25%, #24466f 0%, transparent 45%),
+      radial-gradient(circle at 90% 15%, #1f4f3f 0%, transparent 35%);
+    --card-gradient: linear-gradient(160deg, #172336 0%, #1c2e48 100%);
+    --shadow-soft: 0 25px 45px rgba(0, 0, 0, 0.38);
+    --code-bg: #0f1828;
+    --code-fg: #e8f2ff;
+  }
+}
+
+:root[data-theme="dark"] {
+  --bg: #0d121c;
+  --bg-accent: #141f31;
+  --surface: #172336;
+  --surface-raised: #1b2a41;
+  --fg: #ebf3ff;
+  --muted: #a8bbd8;
+  --border: #2b3e5e;
+  --link: #89c4ff;
+  --link-hover: #b0daff;
+  --hero-gradient: radial-gradient(circle at 15% -25%, #24466f 0%, transparent 45%),
+    radial-gradient(circle at 90% 15%, #1f4f3f 0%, transparent 35%);
+  --card-gradient: linear-gradient(160deg, #172336 0%, #1c2e48 100%);
+  --shadow-soft: 0 25px 45px rgba(0, 0, 0, 0.38);
+  --code-bg: #0f1828;
+  --code-fg: #e8f2ff;
+}
+
+:root[data-theme="light"] {
+  --bg: #f6f7fb;
+  --bg-accent: #e8eef9;
+  --surface: #ffffff;
+  --surface-raised: #f3f6ff;
+  --fg: #11213a;
+  --muted: #4d5f7a;
+  --border: #ced8ea;
+  --link: #085db7;
+  --link-hover: #063f7e;
+  --hero-gradient: radial-gradient(circle at 20% -20%, #b8d8ff 0%, transparent 45%),
+    radial-gradient(circle at 90% 20%, #d8ffe6 0%, transparent 40%);
+  --card-gradient: linear-gradient(160deg, #ffffff 0%, #f3f6ff 100%);
+  --shadow-soft: 0 20px 45px rgba(16, 45, 86, 0.08);
+  --code-bg: #eaf1ff;
+  --code-fg: #0f2140;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: linear-gradient(180deg, var(--bg-accent) 0%, var(--bg) 260px);
+  color: var(--fg);
+  font-family: "Space Grotesk", "Avenir Next", "Segoe UI", sans-serif;
+  line-height: 1.6;
+}
+
+a {
+  color: var(--link);
+}
+
+a:hover,
+a:focus-visible {
+  color: var(--link-hover);
+}
+
+.sgn-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  backdrop-filter: blur(10px);
+  background: color-mix(in srgb, var(--surface) 90%, transparent);
+  border-bottom: 1px solid var(--border);
+}
+
+.sgn-topbar-inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0.8rem 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.sgn-home-link {
+  text-decoration: none;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.sgn-theme-toggle {
+  border: 1px solid var(--border);
+  background: var(--surface-raised);
+  color: var(--fg);
+  font-family: inherit;
+  font-size: 0.92rem;
+  font-weight: 600;
+  padding: 0.45rem 0.8rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: transform 120ms ease, border-color 120ms ease;
+}
+
+.sgn-theme-toggle:hover {
+  transform: translateY(-1px);
+  border-color: var(--link);
+}
+
+.sgn-shell {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 2.2rem 1.25rem 3.2rem;
+}
+
+.sgn-hero {
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  padding: 2rem 2rem 1.6rem;
+  background: var(--hero-gradient), var(--card-gradient);
+  box-shadow: var(--shadow-soft);
+}
+
+.sgn-eyebrow {
+  margin: 0;
+  font-size: 0.8rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.sgn-hero h1 {
+  margin: 0.6rem 0 0.8rem;
+  line-height: 1.1;
+  font-size: clamp(1.9rem, 3vw, 2.8rem);
+}
+
+.sgn-hero p {
+  margin: 0;
+  max-width: 70ch;
+  color: var(--muted);
+}
+
+.sgn-grid {
+  margin-top: 1.35rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+}
+
+.sgn-card {
+  background: var(--card-gradient);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  box-shadow: var(--shadow-soft);
+  padding: 1rem 1rem 1.1rem;
+}
+
+.sgn-card h2 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.sgn-card p {
+  margin: 0.65rem 0 0.85rem;
+  color: var(--muted);
+  min-height: 3.2rem;
+}
+
+.sgn-card-link {
+  text-decoration: none;
+  font-weight: 700;
+}
+
+/* Notebook rendering normalization */
+main,
+.jp-Notebook,
+.jp-RenderedHTMLCommon,
+.jp-Cell,
+.jp-InputArea,
+.jp-OutputArea,
+.cell,
+#notebook-container {
+  color: var(--fg);
+}
+
+.jp-Cell,
+.cell {
+  border-color: var(--border) !important;
+}
+
+.jp-InputArea-editor,
+.jp-OutputArea-output pre,
+pre,
+code {
+  font-family: "JetBrains Mono", "SFMono-Regular", ui-monospace, monospace !important;
+}
+
+.jp-RenderedHTMLCommon pre,
+div.highlight pre,
+pre {
+  background: var(--code-bg) !important;
+  color: var(--code-fg) !important;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  padding: 0.7rem 0.85rem;
+}
+
+.jp-RenderedHTMLCommon p,
+.jp-RenderedHTMLCommon li,
+p,
+li {
+  font-family: "Source Serif 4", "Iowan Old Style", serif;
+}
+
+@media (max-width: 700px) {
+  .sgn-topbar-inner {
+    padding-left: 0.8rem;
+    padding-right: 0.8rem;
+  }
+
+  .sgn-shell {
+    padding-left: 0.8rem;
+    padding-right: 0.8rem;
+  }
+
+  .sgn-hero {
+    padding: 1.4rem;
+  }
+}

--- a/docs/site/assets/theme.js
+++ b/docs/site/assets/theme.js
@@ -1,0 +1,44 @@
+(() => {
+  const STORAGE_KEY = "sgn-theme";
+
+  function systemTheme() {
+    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  }
+
+  function getInitialTheme() {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored === "light" || stored === "dark") {
+      return stored;
+    }
+    return systemTheme();
+  }
+
+  function updateToggleLabels(theme) {
+    const nextTheme = theme === "dark" ? "light" : "dark";
+    const buttonText = nextTheme === "dark" ? "Dark mode" : "Light mode";
+    document.querySelectorAll(".sgn-theme-toggle").forEach((button) => {
+      button.setAttribute("aria-pressed", String(theme === "dark"));
+      button.textContent = buttonText;
+      button.setAttribute("title", `Switch to ${nextTheme} theme`);
+    });
+  }
+
+  function applyTheme(theme) {
+    document.documentElement.setAttribute("data-theme", theme);
+    updateToggleLabels(theme);
+  }
+
+  function toggleTheme() {
+    const current = document.documentElement.getAttribute("data-theme") || getInitialTheme();
+    const next = current === "dark" ? "light" : "dark";
+    window.localStorage.setItem(STORAGE_KEY, next);
+    applyTheme(next);
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    applyTheme(getInitialTheme());
+    document.querySelectorAll(".sgn-theme-toggle").forEach((button) => {
+      button.addEventListener("click", toggleTheme);
+    });
+  });
+})();

--- a/docs/site/build_pages_site.py
+++ b/docs/site/build_pages_site.py
@@ -1,0 +1,201 @@
+"""Build the GitHub Pages site for SGN tutorial notebooks."""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import sys
+import textwrap
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class NotebookTarget:
+    """Notebook rendering contract for the Pages site."""
+
+    notebook_path: str
+    output_html: str
+    title: str
+    summary: str
+
+
+NOTEBOOK_TARGETS: tuple[NotebookTarget, ...] = (
+    NotebookTarget(
+        notebook_path="docs/notebooks/01_legacy_tutorial_foundation.ipynb",
+        output_html="01_legacy_tutorial_foundation.html",
+        title="Legacy Tutorial Foundation",
+        summary=(
+            "Core SGN tutorial flow grounded in the original SpliceGrapher "
+            "workflow, updated for Python 3 execution."
+        ),
+    ),
+    NotebookTarget(
+        notebook_path="docs/notebooks/02_modern_dataset_track.ipynb",
+        output_html="02_modern_dataset_track.html",
+        title="Modern Dataset Track",
+        summary=("Plant and human dataset curation checks using the modern SGN manifest contract."),
+    ),
+)
+
+HEAD_CLOSE_RE = re.compile(r"</head>", flags=re.IGNORECASE)
+BODY_TAG_RE = re.compile(r"<body[^>]*>", flags=re.IGNORECASE)
+
+
+def inject_theme_shell(raw_html: str, css_href: str, script_href: str, home_href: str) -> str:
+    """Inject shared theme assets and top-bar controls into a rendered page."""
+    head_match = HEAD_CLOSE_RE.search(raw_html)
+    if head_match is None:
+        raise ValueError("Rendered page missing </head> tag")
+
+    head_snippet = textwrap.dedent(
+        f"""
+        <meta name="color-scheme" content="light dark">
+        <link rel="stylesheet" href="{css_href}">
+        <script defer src="{script_href}"></script>
+        """
+    ).strip()
+
+    themed_html = (
+        raw_html[: head_match.start()] + head_snippet + "\n" + raw_html[head_match.start() :]
+    )
+
+    body_match = BODY_TAG_RE.search(themed_html)
+    if body_match is None:
+        raise ValueError("Rendered page missing <body> tag")
+
+    top_bar = textwrap.dedent(
+        f"""
+        <header class="sgn-topbar">
+          <div class="sgn-topbar-inner">
+            <a class="sgn-home-link" href="{home_href}">splicegrapher-next tutorials</a>
+            <button class="sgn-theme-toggle" type="button" aria-label="Toggle theme"></button>
+          </div>
+        </header>
+        """
+    ).strip()
+
+    return themed_html[: body_match.end()] + "\n" + top_bar + themed_html[body_match.end() :]
+
+
+def render_index_html(targets: tuple[NotebookTarget, ...]) -> str:
+    """Render the landing page with links to themed notebook pages."""
+    cards = []
+    for target in targets:
+        cards.append(
+            textwrap.dedent(
+                f"""
+                <article class="sgn-card">
+                  <h2>{target.title}</h2>
+                  <p>{target.summary}</p>
+                  <a class="sgn-card-link" href="notebooks/{target.output_html}">Open notebook</a>
+                </article>
+                """
+            ).strip()
+        )
+
+    cards_html = "\n".join(cards)
+    return textwrap.dedent(
+        f"""\
+        <!doctype html>
+        <html lang="en">
+        <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+          <meta name="color-scheme" content="light dark">
+          <title>splicegrapher-next Tutorials</title>
+          <link rel="stylesheet" href="assets/pages.css">
+          <script defer src="assets/theme.js"></script>
+        </head>
+        <body>
+          <header class="sgn-topbar">
+            <div class="sgn-topbar-inner">
+              <a class="sgn-home-link" href="https://github.com/bio-comp/splicegrapher-next">
+                splicegrapher-next
+              </a>
+              <button class="sgn-theme-toggle" type="button" aria-label="Toggle theme"></button>
+            </div>
+          </header>
+          <main class="sgn-shell">
+            <section class="sgn-hero">
+              <p class="sgn-eyebrow">Hands-on docs + executable notebooks</p>
+              <h1>SpliceGrapher-Next Tutorial Hub</h1>
+              <p>
+                Modernized tutorials for splice-graph workflows, designed as
+                user-facing documentation and integration smoke validation.
+              </p>
+            </section>
+            <section class="sgn-grid">
+              {cards_html}
+            </section>
+          </main>
+        </body>
+        </html>
+        """
+    )
+
+
+def _run_nbconvert(repo_root: Path, notebook_rel_path: str, output_html_name: str) -> None:
+    notebook_path = repo_root / notebook_rel_path
+    output_dir = repo_root / "site" / "notebooks"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    command = [
+        sys.executable,
+        "-m",
+        "jupyter",
+        "nbconvert",
+        "--to",
+        "html",
+        "--template",
+        "lab",
+        "--execute",
+        notebook_rel_path,
+        "--output",
+        output_html_name,
+        "--output-dir",
+        "site/notebooks",
+    ]
+    subprocess.run(command, check=True, cwd=repo_root)
+
+    if not notebook_path.exists():
+        raise FileNotFoundError(f"Notebook not found: {notebook_path}")
+
+
+def build_pages_site(repo_root: Path) -> None:
+    """Build themed index + themed notebook pages under site/."""
+    site_dir = repo_root / "site"
+    site_dir.mkdir(parents=True, exist_ok=True)
+    notebooks_dir = site_dir / "notebooks"
+    notebooks_dir.mkdir(parents=True, exist_ok=True)
+
+    assets_src = repo_root / "docs" / "site" / "assets"
+    assets_dst = site_dir / "assets"
+    assets_dst.mkdir(parents=True, exist_ok=True)
+
+    for asset_name in ("pages.css", "theme.js"):
+        shutil.copy2(assets_src / asset_name, assets_dst / asset_name)
+
+    for target in NOTEBOOK_TARGETS:
+        _run_nbconvert(repo_root, target.notebook_path, target.output_html)
+        html_path = notebooks_dir / target.output_html
+        themed_html = inject_theme_shell(
+            raw_html=html_path.read_text(encoding="utf-8"),
+            css_href="../assets/pages.css",
+            script_href="../assets/theme.js",
+            home_href="../index.html",
+        )
+        html_path.write_text(themed_html, encoding="utf-8")
+
+    index_html = render_index_html(NOTEBOOK_TARGETS)
+    (site_dir / "index.html").write_text(index_html, encoding="utf-8")
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    build_pages_site(repo_root=repo_root)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_pages_site_builder.py
+++ b/tests/test_pages_site_builder.py
@@ -1,0 +1,50 @@
+"""Unit tests for Pages site builder helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "docs" / "site" / "build_pages_site.py"
+
+
+def _load_builder_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("build_pages_site", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Unable to load docs/site/build_pages_site.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_inject_theme_shell_adds_assets_and_navigation() -> None:
+    module = _load_builder_module()
+    raw_html = "<html><head><title>Notebook</title></head><body><main>Body</main></body></html>"
+
+    themed = module.inject_theme_shell(
+        raw_html=raw_html,
+        css_href="../assets/pages.css",
+        script_href="../assets/theme.js",
+        home_href="../index.html",
+    )
+
+    assert 'href="../assets/pages.css"' in themed
+    assert 'src="../assets/theme.js"' in themed
+    assert 'class="sgn-topbar"' in themed
+    assert 'href="../index.html"' in themed
+
+
+def test_render_index_html_contains_notebook_links() -> None:
+    module = _load_builder_module()
+
+    page_html = module.render_index_html(module.NOTEBOOK_TARGETS)
+
+    assert "<title>splicegrapher-next Tutorials</title>" in page_html
+    assert "assets/pages.css" in page_html
+    assert "assets/theme.js" in page_html
+    assert "notebooks/01_legacy_tutorial_foundation.html" in page_html
+    assert "notebooks/02_modern_dataset_track.html" in page_html


### PR DESCRIPTION
## Summary
- replace the minimal Pages index generation with a dedicated themed site builder
- add shared Pages assets (modern layout + dark-mode toggle) and apply them to landing and notebook HTML pages
- keep notebook execution in the workflow but route rendering through `docs/site/build_pages_site.py`

## Changes
- updated workflow:
  - `.github/workflows/docs-notebooks-pages.yml`
- added themed Pages builder + assets:
  - `docs/site/build_pages_site.py`
  - `docs/site/assets/pages.css`
  - `docs/site/assets/theme.js`
- added tests:
  - `tests/test_pages_site_builder.py`
- docs update:
  - `docs/notebooks/README.md`

## Validation
- `uv run ruff check . --fix`
- `uv run ruff format .`
- `uv run pytest`
- `uv build`
- `uv run python docs/site/build_pages_site.py`

Closes #36
