### PR TITLE
Normalize SGN license header policy to project-level docs

### DIFF
--- a/LICENSES/README.md
+++ b/LICENSES/README.md
@@ -27,3 +27,10 @@ sources, add:
 - Top-level repository license: `LICENSE`
 - Provenance ledger: `PROVENANCE.md`
 - Project notice: `NOTICE`
+
+## Policy Note
+
+`splicegrapher-next` treats project-level licensing/provenance inventory files
+as the canonical attribution surface. Redundant legacy file-header comment
+blocks may be removed during tracked cleanup, while any legally required
+file-level notices must be retained and documented in `PROVENANCE.md`.

--- a/NOTICE
+++ b/NOTICE
@@ -13,8 +13,12 @@ Attribution and provenance details are tracked in:
 - LICENSES/README.md
 
 Important:
-- Preserve existing copyright headers.
-- Preserve file-level notices from upstream/derived sources.
+- Licensing and attribution are managed at the project level via `LICENSE`,
+  `NOTICE`, `PROVENANCE.md`, and `LICENSES/`.
+- Redundant per-file legacy license header comment blocks may be removed as
+  part of tracked cleanup issues.
+- If a source requires file-level notices, retain them and document the
+  exception in `PROVENANCE.md`.
 - Do not assume a single license governs all future extracted files.
 
 This NOTICE is an engineering notice scaffold and should be updated as source

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -39,17 +39,22 @@ Planned/known source relationships:
 ## Licensing Notes (Non-Legal Summary)
 
 - Top-level license currently present in this repository: `LICENSE`.
-- Vendored iDiffIR SpliceGrapher tree includes additional file-level licensing
-  context that must be preserved during extraction.
+- Licensing/provenance source of truth is centralized in project-level docs:
+  `LICENSE`, `NOTICE`, `PROVENANCE.md`, and `LICENSES/`.
+- Vendored iDiffIR SpliceGrapher tree includes mixed licensing provenance;
+  required notices must remain discoverable through project inventory docs.
 - Do not treat this file as legal advice; it is an engineering traceability
   record.
 
-## Attribution and Header Preservation Rules
+## Attribution and Notice Handling Rules
 
-When copying files into this repository:
+When copying or normalizing files in this repository:
 
-- Preserve original copyright headers.
-- Preserve file-level notices and author attributions.
+- Preserve attribution and provenance through project-level inventories.
+- Remove redundant per-file legacy license header blocks in tracked cleanup
+  issues when legally safe.
+- Preserve file-level notices when explicitly required by source licensing
+  terms, and document those exceptions here.
 - Record source path, commit/ref, and destination path in this file.
 - Document any intentional modifications from the copied baseline.
 
@@ -155,4 +160,53 @@ Behavioral modifications from source baseline:
 Validation run:
 
 - `uv run python -c "import SpliceGrapher"`
+- `uv build`
+
+### 2026-02-27 - License-header normalization tranche A (issue #34)
+
+Date:
+
+- 2026-02-27
+
+Issue/PR:
+
+- Issue: #34
+- PR: (to be filled when opened)
+
+Source repository/path:
+
+- Repository: `bio-comp/splicegrapher-next`
+- Paths:
+  - `SpliceGrapher/SpliceGraph.py`
+  - `SpliceGrapher/shared/streams.py`
+  - `SpliceGrapher/shared/ShortRead.py`
+  - `SpliceGrapher/formats/fasta.py`
+  - `SpliceGrapher/formats/GeneModel.py`
+  - `SpliceGrapher/formats/loader.py`
+  - `SpliceGrapher/formats/alignment_io.py`
+
+Source commit/ref:
+
+- `c1ea06b1a8f7fdb5f0bff8984180ef6672a8ea30`
+
+Destination paths:
+
+- same as source paths above (in-place normalization)
+
+License/notice files added or updated:
+
+- `NOTICE`
+- `PROVENANCE.md`
+
+Behavioral modifications from source baseline:
+
+- None. Removed redundant top-of-file legacy license header comment blocks.
+- Standardized repository policy to project-level licensing/provenance
+  inventory docs with exception handling for required file-level notices.
+
+Validation run:
+
+- `uv run ruff check . --fix`
+- `uv run ruff format .`
+- `uv run pytest`
 - `uv build`

--- a/SpliceGrapher/SpliceGraph.py
+++ b/SpliceGrapher/SpliceGraph.py
@@ -1,20 +1,3 @@
-# Copyright (C) 2010 by Colorado State University
-# Contact: Mark Rogers <rogersma@cs.colostate.edu>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or (at
-# your option) any later version.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307,
-# USA.
 """
 Module that encapsulates a splice graph.
 """

--- a/SpliceGrapher/formats/GeneModel.py
+++ b/SpliceGrapher/formats/GeneModel.py
@@ -1,20 +1,3 @@
-# Copyright (C) 2010 by Colorado State University
-# Contact: Mark Rogers <rogersma@cs.colostate.edu>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or (at
-# your option) any later version.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307,
-# USA.
 """
 Stores gene annotation information from a GFF3 annotation
 file and provides methods for searching on the data.

--- a/SpliceGrapher/formats/alignment_io.py
+++ b/SpliceGrapher/formats/alignment_io.py
@@ -1,20 +1,3 @@
-# Copyright (C) 2010 by Colorado State University
-# Contact: Mark Rogers <rogersma@cs.colostate.edu>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or (at
-# your option) any later version.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307,
-# USA.
 """Alignment I/O helpers for SAM/BAM/CRAM inputs."""
 
 import io

--- a/SpliceGrapher/formats/fasta.py
+++ b/SpliceGrapher/formats/fasta.py
@@ -1,28 +1,5 @@
-# Copyright (C) 2003, 2004 by BiRC -- Bioinformatics Research Center
-#                                     University of Aarhus, Denmark
-#                                     Contact: Thomas Mailund <mailund@birc.dk>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or (at
-# your option) any later version.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307,
-# USA.
 """
 A parser for FASTA files.
-
-Copyright (C) 2003, 2004 by BiRC -- Bioinformatics Research Center
-                                    University of Aarhus, Denmark
-                                    Contact: Thomas Mailund <mailund@birc.dk>
-with changes by Asa Ben-Hur and Mark Rogers
 """
 
 import os

--- a/SpliceGrapher/formats/loader.py
+++ b/SpliceGrapher/formats/loader.py
@@ -1,20 +1,3 @@
-# Copyright (C) 2010 by Colorado State University
-# Contact: Mark Rogers <rogersma@cs.colostate.edu>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or (at
-# your option) any later version.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307,
-# USA.
 from SpliceGrapher.formats.annotation_io import load_gene_models
 
 

--- a/SpliceGrapher/shared/ShortRead.py
+++ b/SpliceGrapher/shared/ShortRead.py
@@ -1,20 +1,3 @@
-# Copyright (C) 2010 by Colorado State University
-# Contact: Mark Rogers <rogersma@cs.colostate.edu>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or (at
-# your option) any later version.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307,
-# USA.
 """
 Module containing classes and methods for handling short-read data.
 """

--- a/SpliceGrapher/shared/streams.py
+++ b/SpliceGrapher/shared/streams.py
@@ -1,20 +1,3 @@
-# Copyright (C) 2010 by Colorado State University
-# Contact: Mark Rogers <rogersma@cs.colostate.edu>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or (at
-# your option) any later version.
-#
-# This program is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307,
-# USA.
 """
 Module that provides control over the sys.stderr and sys.out streams.
 This is particularly useful for Python-wrapped C code that may not


### PR DESCRIPTION
## Summary
- normalize SGN licensing policy to project-level inventory docs (`LICENSE`, `NOTICE`, `PROVENANCE.md`, `LICENSES/`)
- remove redundant legacy file-level license header comment blocks from a first tranche of extracted modules
- document exception policy: retain file-level notices only where legally required and record exceptions in provenance

## Files Updated
Policy docs:
- `NOTICE`
- `PROVENANCE.md`
- `LICENSES/README.md`

Header normalization tranche A:
- `SpliceGrapher/SpliceGraph.py`
- `SpliceGrapher/shared/streams.py`
- `SpliceGrapher/shared/ShortRead.py`
- `SpliceGrapher/formats/fasta.py`
- `SpliceGrapher/formats/GeneModel.py`
- `SpliceGrapher/formats/loader.py`
- `SpliceGrapher/formats/alignment_io.py`

## Validation
- `uv run ruff check . --fix`
- `uv run ruff format .`
- `uv run pytest`
- `uv build`

Closes #34
