### PR TITLE
Clean ShortRead/fasta and remove wildcard import coupling

### DIFF
--- a/SpliceGrapher/formats/fasta.py
+++ b/SpliceGrapher/formats/fasta.py
@@ -160,9 +160,9 @@ class fasta_slice(object):
         self.__itr = _fasta_itr(src)
         self.__first = first
         self.__last = last
-        if type(first) == int:
+        if isinstance(first, int):
             self.__current = 0
-        elif type(first) == type(""):
+        elif isinstance(first, str):
             self.__current = None
         else:
             raise ValueError("bad first")
@@ -177,7 +177,7 @@ class fasta_slice(object):
     def __next__(self):
         if not self.__foundFirst:
             for rec in self.__itr:
-                if type(self.__first) == int:
+                if isinstance(self.__first, int):
                     if self.__first == self.__current:
                         self.__foundFirst = True
                         break
@@ -193,7 +193,7 @@ class fasta_slice(object):
         rec = next(self.__itr)
 
         if self.__last is not None:
-            if type(self.__first) == int:
+            if isinstance(self.__first, int):
                 self.__current += 1
                 if self.__current == self.__last:
                     raise StopIteration

--- a/SpliceGrapher/shared/ShortRead.py
+++ b/SpliceGrapher/shared/ShortRead.py
@@ -2,11 +2,11 @@
 Module containing classes and methods for handling short-read data.
 """
 
-import sys
+import os
 from sys import maxsize as MAXINT
 
-from SpliceGrapher.formats.fasta import *
-from SpliceGrapher.shared.utils import ProgressIndicator, commaFormat, getAttribute, idFactory
+from SpliceGrapher.shared.file_utils import ezopen
+from SpliceGrapher.shared.utils import ProgressIndicator, getAttribute, idFactory
 
 #################################################
 #  Constants
@@ -27,21 +27,21 @@ def depthsHeader(path):
     """Returns the header (chromosome) information from a
     SpliceGrapher depths file.  Note that the chromosome
     information must all come at the start of a file."""
-    inStream = ezopen(path)
     result = {}
     ctr = 0
-    for line in inStream:
-        ctr += 1
-        s = line.strip()
-        parts = s.split("\t")
-        if parts[0] == CHROM_CODE:
-            if len(parts) != 3:
-                raise ValueError(
-                    "** %s has invalid chromosome record at line %d:\n%s\n" % (path, ctr, s)
-                )
-            result[parts[1]] = int(parts[2])
-        else:
-            break
+    with ezopen(path) as inStream:
+        for line in inStream:
+            ctr += 1
+            s = line.strip()
+            parts = s.split("\t")
+            if parts[0] == CHROM_CODE:
+                if len(parts) != 3:
+                    raise ValueError(
+                        "** %s has invalid chromosome record at line %d:\n%s\n" % (path, ctr, s)
+                    )
+                result[parts[1]] = int(parts[2])
+            else:
+                break
     return result
 
 
@@ -58,8 +58,6 @@ def depthsToClusters(chromosome, depths, **args):
     maxpos = getAttribute("maxpos", MAXINT, **args)
     reference = getAttribute("reference", 0, **args)
     threshold = getAttribute("threshold", 1, **args)
-    verbose = getAttribute("verbose", False, **args)
-
     result = []
     current = None
     maxpos = min(len(depths), maxpos)
@@ -89,19 +87,21 @@ def depthsToClusters(chromosome, depths, **args):
 
 def isDepthsFile(f):
     """Returns True if a file is a SpliceGrapher depths file; False otherwise."""
-    if type(f) == str:
-        if not os.path.isfile(f):
+    if isinstance(f, (str, os.PathLike)):
+        path = os.fspath(f)
+        if not os.path.isfile(path):
             return False
-        inStream = ezopen(f)
-        firstLine = inStream.readline()
-        inStream.close()
-    elif type(f) == file:
-        inStream = f
-        firstLine = inStream.readline()
-        f.seek(0)
+        with ezopen(path) as inStream:
+            firstLine = inStream.readline()
+    elif hasattr(f, "read"):
+        firstLine = f.readline()
+        if hasattr(f, "seek"):
+            f.seek(0)
     else:
         return False
 
+    if isinstance(firstLine, bytes):
+        firstLine = firstLine.decode("utf-8")
     parts = firstLine.strip().split("\t")
     return parts and parts[0] in DEPTH_CODES
 
@@ -213,10 +213,12 @@ def writeDepths(ostr, depthDict, jctDict={}, verbose=False):
     must provide an output destination (file path or writeable stream),
     and read depths stored as a dictionary of chromosome ids mapped
     to lists of integer values."""
-    if type(ostr) == file:
+    if isinstance(ostr, (str, os.PathLike)):
+        outStream = open(os.fspath(ostr), "w", encoding="utf-8")
+        closeStream = True
+    elif hasattr(ostr, "write"):
         outStream = ostr
-    elif type(ostr) == str:
-        outStream = open(ostr, "w")
+        closeStream = False
     else:
         raise ValueError("Unrecognized file type: %s" % type(ostr))
 
@@ -254,6 +256,8 @@ def writeDepths(ostr, depthDict, jctDict={}, verbose=False):
             indicator.update()
             outStream.write("%s\n" % j.toString())
     indicator.finish()
+    if closeStream:
+        outStream.close()
 
 
 #################################################
@@ -499,7 +503,7 @@ class SpliceJunction(Read):
         )
 
     def update(self, o):
-        """Updates read count and anchor information using the given SplicedRead or SpliceJunction record."""
+        """Update read count and anchors using a SplicedRead or SpliceJunction."""
         if (
             o.chromosome != self.chromosome
             or o.strand != self.strand
@@ -518,7 +522,8 @@ class SpliceJunction(Read):
             self.anchors[1] = max(self.anchors[1], o.anchors[1])
         else:
             raise ValueError(
-                "Attempted to update junction with object that was not a SplicedRead or SpliceJunction"
+                "Attempted to update junction with object that was not a "
+                "SplicedRead or SpliceJunction"
             )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,8 +93,6 @@ ignore = [
 "SpliceGrapher/SpliceGraph.py" = ["E", "F"]
 "SpliceGrapher/formats/GeneModel.py" = ["E", "F", "W"]
 "SpliceGrapher/formats/alignment_io.py" = ["E", "F", "W"]
-"SpliceGrapher/formats/fasta.py" = ["E", "F", "W"]
-"SpliceGrapher/shared/ShortRead.py" = ["E", "F", "W"]
 
 [tool.mypy]
 python_version = "3.10"

--- a/tests/test_shortread_io.py
+++ b/tests/test_shortread_io.py
@@ -1,0 +1,34 @@
+"""Parity-focused tests for shared.ShortRead modernization."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+from SpliceGrapher.shared.ShortRead import isDepthsFile, writeDepths
+
+
+def test_shortread_source_does_not_use_fasta_star_import() -> None:
+    shortread_path = (
+        Path(__file__).resolve().parents[1] / "SpliceGrapher" / "shared" / "ShortRead.py"
+    )
+    source = shortread_path.read_text(encoding="utf-8")
+
+    assert "from SpliceGrapher.formats.fasta import *" not in source
+
+
+def test_is_depths_file_accepts_file_like_stream() -> None:
+    stream = io.StringIO("C\tchr1\t3\nD\tchr1\t1:0,2:2\n")
+
+    assert isDepthsFile(stream) is True
+    assert stream.tell() == 0
+
+
+def test_write_depths_accepts_text_io_stream() -> None:
+    out_stream = io.StringIO()
+
+    writeDepths(out_stream, {"chr1": [0, 2, 2]}, verbose=False)
+    payload = out_stream.getvalue()
+
+    assert payload.startswith("C\tchr1\t3\n")
+    assert "D\tchr1\t" in payload


### PR DESCRIPTION
## Summary
- remove wildcard coupling from `SpliceGrapher/shared/ShortRead.py` (`from ...fasta import *`)
- modernize `ShortRead` file/stream handling for Python 3 file-like objects
- clean remaining `fasta.py` type-comparison lint debt in `fasta_slice`
- remove per-file Ruff ignores for `SpliceGrapher/shared/ShortRead.py` and `SpliceGrapher/formats/fasta.py`
- add focused parity tests for `ShortRead` source coupling and stream I/O behavior

## Validation
- `uv run pytest tests/test_shortread_io.py tests/test_fasta_io.py -q`
- `uv run ruff check SpliceGrapher/shared/ShortRead.py SpliceGrapher/formats/fasta.py --isolated --line-length 100 --target-version py310 --select E,F,W,I`
- `uv run python scripts/ci/check_clean_invariant.py`
- `uv run ruff check . --fix`
- `uv run ruff format .`
- `uv run pytest`
- `uv build`
- `uv run mypy SpliceGrapher/shared/ShortRead.py SpliceGrapher/formats/fasta.py tests/test_shortread_io.py`

Tracking note:
- Long-term replacement/deprecation planning for `ShortRead.py` is tracked in #45.

Closes #19
