### PR TITLE
#23 Testing tranche T1: parity harness expansion

### DIFF
--- a/docs/testing/parity-harness.md
+++ b/docs/testing/parity-harness.md
@@ -1,0 +1,38 @@
+# Parity Harness (T1)
+
+Issue: `#23` Testing tranche T1 parity harness expansion.
+
+## Purpose
+
+Keep cleanup and extraction slices gated by explicit parity coverage for core/formats behavior.
+
+## Required Targeted Test Matrix
+
+The canonical matrix is tracked in `tests/fixtures/parity_harness.toml`.
+
+Required areas:
+
+- `core_shared_import_smoke` -> `tests/test_core_shared_import_smoke.py`
+- `annotation_io` -> `tests/test_annotation_io.py`
+- `alignment_io_parity` -> `tests/test_alignment_io_parity.py`
+- `splicegrapher_alignment_io` -> `tests/test_splicegrapher_alignment_io.py`
+
+## Fixture Conventions
+
+Fixture conventions and builder pointers are documented in:
+
+- `tests/fixtures/README.md`
+
+## PR Expectations
+
+For cleanup/extraction PRs that touch core or formats paths:
+
+1. Run full gates:
+   - `uv run ruff check .`
+   - `uv run ruff format --check .`
+   - `uv run pytest -q`
+2. Ensure any changed parity area still maps in `tests/fixtures/parity_harness.toml`.
+3. If new parity areas are added, update:
+   - `tests/fixtures/parity_harness.toml`
+   - `tests/test_parity_harness_matrix.py`
+   - this document.

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,0 +1,22 @@
+# Test Fixture Conventions
+
+This directory contains fixture metadata and tiny deterministic test assets used by parity-focused test modules.
+
+## Rules
+
+- Keep fixture files small and deterministic.
+- Prefer synthetic or reduced fixture inputs over large upstream datasets.
+- Track parity matrix requirements in `tests/fixtures/parity_harness.toml`.
+- Keep all paths in the manifest repository-relative.
+
+## Required Parity Areas
+
+- `core_shared_import_smoke`
+- `annotation_io`
+- `alignment_io_parity`
+- `splicegrapher_alignment_io`
+
+## Fixture Builders
+
+- `tests/helpers/alignment_fixture_builder.py`
+- `tests/helpers/idiffir_fixture_builder.py`

--- a/tests/fixtures/parity_harness.toml
+++ b/tests/fixtures/parity_harness.toml
@@ -1,0 +1,9 @@
+[required_tests]
+core_shared_import_smoke = "tests/test_core_shared_import_smoke.py"
+annotation_io = "tests/test_annotation_io.py"
+alignment_io_parity = "tests/test_alignment_io_parity.py"
+splicegrapher_alignment_io = "tests/test_splicegrapher_alignment_io.py"
+
+[fixture_builders]
+alignment = "tests/helpers/alignment_fixture_builder.py"
+idiffir = "tests/helpers/idiffir_fixture_builder.py"

--- a/tests/test_parity_harness_matrix.py
+++ b/tests/test_parity_harness_matrix.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = REPO_ROOT / "tests" / "fixtures" / "parity_harness.toml"
+FIXTURE_README_PATH = REPO_ROOT / "tests" / "fixtures" / "README.md"
+
+REQUIRED_TEST_AREAS = {
+    "core_shared_import_smoke",
+    "annotation_io",
+    "alignment_io_parity",
+    "splicegrapher_alignment_io",
+}
+
+
+def test_parity_harness_manifest_declares_required_test_areas() -> None:
+    manifest = tomllib.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    declared_areas = set(manifest["required_tests"].keys())
+    missing = REQUIRED_TEST_AREAS - declared_areas
+    assert not missing, f"Missing required parity test areas: {sorted(missing)}"
+
+
+def test_parity_harness_manifest_points_to_existing_test_files() -> None:
+    manifest = tomllib.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    for area, relative_path in manifest["required_tests"].items():
+        test_path = REPO_ROOT / relative_path
+        assert test_path.exists(), f"{area} references missing file: {relative_path}"
+
+
+def test_fixture_conventions_documentation_exists() -> None:
+    assert FIXTURE_README_PATH.exists(), "Missing tests/fixtures/README.md conventions doc"


### PR DESCRIPTION
Closes #23

Refs #63

Summary:
- add a parity harness policy doc at docs/testing/parity-harness.md
- add fixture conventions doc and canonical parity matrix manifest under tests/fixtures
- add enforcement test tests/test_parity_harness_matrix.py to keep required parity areas declared and file-backed

Verification:
- uv run ruff check .
- uv run ruff format --check .
- uv run pytest -q
- uv run python scripts/ci/check_clean_invariant.py