### PR TITLE
#56 Retire file_utils legacy wrappers and enforce snake_case API

### DIFF
--- a/SpliceGrapher/shared/file_utils.py
+++ b/SpliceGrapher/shared/file_utils.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import gzip
-import warnings
 from pathlib import Path
 from typing import TextIO
 
@@ -82,51 +81,6 @@ def validate_file(path: str | Path) -> None:
         raise FileNotFoundError(f"File '{path}' not found; exiting.")
 
 
-def _warn_deprecated(old_name: str, new_name: str) -> None:
-    warnings.warn(
-        f"'{old_name}' is deprecated and will be removed in a future release. "
-        f"Use '{new_name}' instead.",
-        DeprecationWarning,
-        stacklevel=3,
-    )
-
-
-# Compatibility wrappers retained while older modules migrate to snake_case names.
-def ezopen(file_name: str | Path) -> TextIO:
-    _warn_deprecated("ezopen", "ez_open")
-    return ez_open(file_name)
-
-
-def fileLen(path: str | Path) -> int:
-    _warn_deprecated("fileLen", "file_len")
-    return file_len(path)
-
-
-def filePrefix(path: str | Path) -> str:
-    _warn_deprecated("filePrefix", "file_prefix")
-    return file_prefix(path)
-
-
-def findFile(name: str, search_path: str, delim: str = ":") -> str | None:
-    _warn_deprecated("findFile", "find_file")
-    return find_file(name, search_path, delim)
-
-
-def makeGraphListFile(splice_graph_dir: str | Path) -> str:
-    _warn_deprecated("makeGraphListFile", "make_graph_list_file")
-    return make_graph_list_file(splice_graph_dir)
-
-
-def validateDir(path: str | Path) -> None:
-    _warn_deprecated("validateDir", "validate_dir")
-    validate_dir(path)
-
-
-def validateFile(path: str | Path) -> None:
-    _warn_deprecated("validateFile", "validate_file")
-    validate_file(path)
-
-
 __all__ = [
     "ez_open",
     "file_len",
@@ -135,11 +89,4 @@ __all__ = [
     "make_graph_list_file",
     "validate_dir",
     "validate_file",
-    "ezopen",
-    "fileLen",
-    "filePrefix",
-    "findFile",
-    "makeGraphListFile",
-    "validateDir",
-    "validateFile",
 ]

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -1,25 +1,19 @@
 from __future__ import annotations
 
 import gzip
+import importlib
 from pathlib import Path
 
 import pytest
 
 from SpliceGrapher.shared.file_utils import (
     ez_open,
-    ezopen,
     file_len,
     file_prefix,
-    fileLen,
-    filePrefix,
     find_file,
-    findFile,
     make_graph_list_file,
-    makeGraphListFile,
     validate_dir,
     validate_file,
-    validateDir,
-    validateFile,
 )
 
 
@@ -103,38 +97,16 @@ def test_validate_file_and_dir(tmp_path: Path) -> None:
         validate_dir(data_file)
 
 
-@pytest.mark.parametrize(
-    ("legacy_call", "warning_text"),
-    [
-        (lambda path: ezopen(path), "ezopen"),
-        (lambda path: fileLen(path), "fileLen"),
-        (lambda path: filePrefix(path), "filePrefix"),
-        (lambda path: findFile(path.name, str(path.parent)), "findFile"),
-        (lambda path: validateDir(path.parent), "validateDir"),
-        (lambda path: validateFile(path), "validateFile"),
-    ],
-)
-def test_legacy_wrappers_emit_deprecation_warning(
-    tmp_path: Path, legacy_call, warning_text: str
-) -> None:
-    target = tmp_path / "target.txt"
-    target.write_text("ok\n")
-
-    with pytest.warns(DeprecationWarning, match=warning_text):
-        result = legacy_call(target)
-
-    # Avoid leaving file handles open for the ezopen case.
-    if hasattr(result, "close"):
-        result.close()
-
-
-def test_make_graph_list_legacy_wrapper_emits_deprecation_warning(tmp_path: Path) -> None:
-    root = tmp_path / "graphs"
-    (root / "chr1").mkdir(parents=True)
-    gff = root / "chr1" / "a.gff"
-    gff.write_text("node\n")
-
-    with pytest.warns(DeprecationWarning, match="makeGraphListFile"):
-        list_path = makeGraphListFile(root)
-
-    assert Path(list_path).exists()
+def test_legacy_wrappers_are_not_exposed() -> None:
+    module = importlib.import_module("SpliceGrapher.shared.file_utils")
+    legacy_names = [
+        "ezopen",
+        "fileLen",
+        "filePrefix",
+        "findFile",
+        "makeGraphListFile",
+        "validateDir",
+        "validateFile",
+    ]
+    for name in legacy_names:
+        assert not hasattr(module, name)


### PR DESCRIPTION
Closes #56

## Summary
- remove deprecated camelCase compatibility wrappers from SpliceGrapher/shared/file_utils.py
- narrow __all__ to snake_case APIs only
- update tests/test_file_utils.py to enforce wrapper removal contract

## Verification
- uv run pytest -q tests/test_file_utils.py
- uv run ruff check .
- uv run ruff format --check .
- uv run pytest -q
- uv run python scripts/ci/check_clean_invariant.py
