### PR TITLE
#10 Standardize tqdm progress policy and conda guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,27 @@ export SGN_SPLICEGRAPHER__GENE_MODEL=/mnt/data/genes.gtf
 
 Detailed loader behavior and API examples are in `docs/configuration.md`.
 
+## Progress Reporting Policy (tqdm)
+
+User-visible long-running loops should use `SpliceGrapher.shared.progress.ProgressIndicator`.
+This compatibility class now routes through `tqdm` and applies TTY-aware defaults:
+
+- interactive terminal + `verbose=True`: tqdm progress is enabled
+- non-interactive stderr or `verbose=False`: progress output is suppressed
+
+Example:
+
+```python
+from SpliceGrapher.shared.progress import ProgressIndicator
+
+indicator = ProgressIndicator(1000000, description="loading", verbose=True)
+for _ in range(5000):
+    indicator.update()
+indicator.finish()
+```
+
+Logging policy remains tracked separately in issue `#9` (structlog adoption).
+
 ## Conda / Mamba / Miniconda / Bioconda-Friendly Guidance
 
 Use conda-based environments when needed for scientific stacks:
@@ -111,6 +132,12 @@ mamba create -n splicegrapher-next python=3.12 -y
 mamba activate splicegrapher-next
 mamba install -c conda-forge -c bioconda numpy scipy matplotlib pysam gffutils networkx -y
 python -m pip install -e .
+```
+
+Quick compatibility smoke check in that environment:
+
+```bash
+python -c "import tqdm; import SpliceGrapher; print(SpliceGrapher.__name__)"
 ```
 
 `uv` remains the preferred local development workflow in this repository.

--- a/SpliceGrapher/shared/progress.py
+++ b/SpliceGrapher/shared/progress.py
@@ -1,51 +1,70 @@
 """Progress and random-iterator helpers extracted from shared.utils."""
 
+from __future__ import annotations
+
 import random
 import sys
 
-from SpliceGrapher.shared.format_utils import comma_format
+from tqdm.auto import tqdm
+
+
+def _is_tty(stream) -> bool:
+    """Return True when a stream is interactive."""
+    try:
+        return bool(stream.isatty())
+    except Exception:
+        return False
 
 
 class ProgressIndicator:
-    """A simple progress indicator."""
+    """Compatibility wrapper around a tqdm progress bar."""
 
     def __init__(self, increment, description="", verbose=True):
-        self.limit = increment
-        self.barlim = int(self.limit / 10)
-        self.dotlim = int(self.barlim / 5)
+        self.limit = max(1, int(increment))
         self.descr = description
-        self.started = False
         self.verbose = verbose
         self.ctr = 0
+        self._enabled = self.verbose and _is_tty(sys.stderr)
+        self._bar = tqdm(
+            total=None,
+            desc=self.descr or None,
+            disable=not self._enabled,
+            leave=False,
+            unit="records",
+            miniters=self.limit,
+            dynamic_ncols=True,
+            file=sys.stderr,
+        )
 
     def count(self):
         """Returns the current count."""
         return self.ctr
 
     def finish(self):
-        """Finishes the progress output by appending a newline,
-        if anything has been written."""
-        if self.started:
-            sys.stderr.write("\n")
-        self.started = False
+        """Finishes progress output."""
+        self._bar.close()
 
     def reset(self):
         """Resets the indicator to be used again."""
-        self.ctr = 0
         self.finish()
+        self.ctr = 0
+        self._bar = tqdm(
+            total=None,
+            desc=self.descr or None,
+            disable=not self._enabled,
+            leave=False,
+            unit="records",
+            miniters=self.limit,
+            dynamic_ncols=True,
+            file=sys.stderr,
+        )
 
     def update(self):
         """Updates the indicator."""
         self.ctr += 1
         if not self.verbose:
             return
-        if self.ctr % self.limit == 0:
-            sys.stderr.write(f"{comma_format(self.ctr)} {self.descr}\n")
-        elif self.ctr % self.barlim == 0:
-            sys.stderr.write("|")
-        elif self.ctr % self.dotlim == 0:
-            self.started = True
-            sys.stderr.write(".")
+        self._bar.update(1)
 
 
 class RandomListIterator:
@@ -60,7 +79,7 @@ class RandomListIterator:
         self.rand = random.Random()
         self.limit = len(self.values) - 1
         if "seed" in args:
-            self.rand.seed = args["seed"]
+            self.rand.seed(args["seed"])
 
     def __iter__(self):
         return self

--- a/docs/workflow-integrations.md
+++ b/docs/workflow-integrations.md
@@ -76,7 +76,8 @@ Current smoke command target:
 ## Relationship to Other Standards
 
 - Logging standardization is tracked separately in issue `#9`.
-- Progress bar/conda standardization is tracked separately in issue `#10`.
+- Progress/conda standardization is implemented in issue `#10`; runtime policy is
+  documented in `README.md` under "Progress Reporting Policy (tqdm)".
 
 This document only covers Docker/Nextflow/BioContainers friendliness for issue
 `#11`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
   "pydantic>=2.10",
   "pydantic-settings>=2.6",
   "structlog>=24.4",
+  "tqdm>=4.66",
 ]
 
 [project.urls]

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,103 @@
+"""Tests for progress reporting helpers."""
+
+from __future__ import annotations
+
+from SpliceGrapher.shared import progress as progress_module
+
+
+class _FakeStream:
+    def __init__(self, tty: bool) -> None:
+        self._tty = tty
+        self.writes: list[str] = []
+
+    def isatty(self) -> bool:
+        return self._tty
+
+    def write(self, text: str) -> int:
+        self.writes.append(text)
+        return len(text)
+
+    def flush(self) -> None:
+        return None
+
+
+class _FakeTqdm:
+    def __init__(self, **kwargs) -> None:
+        self.kwargs = kwargs
+        self.total_updates = 0
+        self.closed = False
+
+    def update(self, amount: int = 1) -> None:
+        self.total_updates += amount
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_progress_indicator_uses_tqdm_when_interactive(monkeypatch) -> None:
+    fake_stream = _FakeStream(tty=True)
+    created: list[_FakeTqdm] = []
+
+    def make_bar(**kwargs) -> _FakeTqdm:
+        bar = _FakeTqdm(**kwargs)
+        created.append(bar)
+        return bar
+
+    monkeypatch.setattr(progress_module, "tqdm", make_bar)
+    monkeypatch.setattr(progress_module.sys, "stderr", fake_stream)
+
+    indicator = progress_module.ProgressIndicator(10, description="load", verbose=True)
+    indicator.update()
+    indicator.update()
+    indicator.finish()
+
+    assert len(created) == 1
+    assert created[0].kwargs["disable"] is False
+    assert created[0].kwargs["desc"] == "load"
+    assert created[0].total_updates == 2
+    assert created[0].closed is True
+
+
+def test_progress_indicator_suppresses_output_when_not_interactive(monkeypatch) -> None:
+    fake_stream = _FakeStream(tty=False)
+    created: list[_FakeTqdm] = []
+
+    def make_bar(**kwargs) -> _FakeTqdm:
+        bar = _FakeTqdm(**kwargs)
+        created.append(bar)
+        return bar
+
+    monkeypatch.setattr(progress_module, "tqdm", make_bar)
+    monkeypatch.setattr(progress_module.sys, "stderr", fake_stream)
+
+    indicator = progress_module.ProgressIndicator(10, description="load", verbose=True)
+    indicator.update()
+    indicator.update()
+    indicator.finish()
+
+    assert len(created) == 1
+    assert created[0].kwargs["disable"] is True
+    assert created[0].total_updates == 2
+    assert fake_stream.writes == []
+
+
+def test_progress_indicator_suppresses_output_when_verbose_is_false(monkeypatch) -> None:
+    fake_stream = _FakeStream(tty=True)
+    created: list[_FakeTqdm] = []
+
+    def make_bar(**kwargs) -> _FakeTqdm:
+        bar = _FakeTqdm(**kwargs)
+        created.append(bar)
+        return bar
+
+    monkeypatch.setattr(progress_module, "tqdm", make_bar)
+    monkeypatch.setattr(progress_module.sys, "stderr", fake_stream)
+
+    indicator = progress_module.ProgressIndicator(10, description="load", verbose=False)
+    indicator.update()
+    indicator.finish()
+
+    assert len(created) == 1
+    assert created[0].kwargs["disable"] is True
+    assert created[0].total_updates == 0
+    assert fake_stream.writes == []

--- a/uv.lock
+++ b/uv.lock
@@ -2755,6 +2755,7 @@ dependencies = [
     { name = "pysam" },
     { name = "scipy" },
     { name = "structlog" },
+    { name = "tqdm" },
 ]
 
 [package.dev-dependencies]
@@ -2784,6 +2785,7 @@ requires-dist = [
     { name = "pysam" },
     { name = "scipy" },
     { name = "structlog", specifier = ">=24.4" },
+    { name = "tqdm", specifier = ">=4.66" },
 ]
 
 [package.metadata.requires-dev]
@@ -2969,6 +2971,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/1a/d7592328d037d36f2d2462f4bc1fbb383eec9278bc786c1b111cbbd44cfa/tornado-6.5.4-cp39-abi3-win32.whl", hash = "sha256:1768110f2411d5cd281bac0a090f707223ce77fd110424361092859e089b38d1", size = 446481, upload-time = "2025-12-15T19:21:00.008Z" },
     { url = "https://files.pythonhosted.org/packages/d6/6d/c69be695a0a64fd37a97db12355a035a6d90f79067a3cf936ec2b1dc38cd/tornado-6.5.4-cp39-abi3-win_amd64.whl", hash = "sha256:fa07d31e0cd85c60713f2b995da613588aa03e1303d75705dca6af8babc18ddc", size = 446886, upload-time = "2025-12-15T19:21:01.287Z" },
     { url = "https://files.pythonhosted.org/packages/50/49/8dc3fd90902f70084bd2cd059d576ddb4f8bb44c2c7c0e33a11422acb17e/tornado-6.5.4-cp39-abi3-win_arm64.whl", hash = "sha256:053e6e16701eb6cbe641f308f4c1a9541f91b6261991160391bfc342e8a551a1", size = 445910, upload-time = "2025-12-15T19:21:02.571Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #10

## Summary
- replace legacy stderr dot/bar output in `SpliceGrapher/shared/progress.py` with a `tqdm`-backed `ProgressIndicator` while keeping compatibility methods (`update`, `finish`, `reset`, `count`)
- apply TTY-aware defaults: progress is enabled only for interactive stderr with `verbose=True`; non-interactive and `verbose=False` paths are silent
- add focused progress policy tests in `tests/test_progress.py`
- add runtime dependency baseline for `tqdm` in `pyproject.toml` (lockfile refreshed)
- document progress policy and conda smoke guidance in `README.md` and align `docs/workflow-integrations.md` references

## Verification
- `uv run pytest -q tests/test_progress.py tests/test_shared_utils_shim.py tests/test_core_shared_import_smoke.py`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest -q`
- `uv run python scripts/ci/check_clean_invariant.py`
- `uv run python -c "import tqdm; import SpliceGrapher; print(SpliceGrapher.__name__)"`
- `uv build`
