### PR TITLE
#55 Modernize shared/config_utils env and INI parsing

### DIFF
--- a/SpliceGrapher/shared/config_utils.py
+++ b/SpliceGrapher/shared/config_utils.py
@@ -1,36 +1,45 @@
 """Configuration and environment helpers extracted from shared.utils."""
 
-import configparser as ConfigParser
+from __future__ import annotations
+
+import configparser
 import os
+from pathlib import Path
 
 
-def configMap(cfgFile):
-    """Reads a configuration file and returns a dictionary of all sections, options and values."""
-    result = {}
-    config = ConfigParser.ConfigParser()
-    # Activates case-sensitivity:
+def configMap(cfgFile: str | Path) -> dict[str, dict[str, str]]:
+    """Read an INI configuration file into a nested mapping.
+
+    Keeps section and option names case-sensitive for compatibility with
+    existing SGN config conventions.
+    """
+    cfg_path = cfgFile if isinstance(cfgFile, Path) else Path(cfgFile)
+    if not cfg_path.is_file():
+        raise FileNotFoundError(f"Configuration file not found: {cfg_path}")
+
+    config = configparser.ConfigParser()
     config.optionxform = str
-
     try:
-        config.read(cfgFile)
-    except ConfigParser.ParsingError:
-        raise ValueError("Invalid configuration file %s" % cfgFile)
+        with cfg_path.open("r", encoding="utf-8") as config_stream:
+            config.read_file(config_stream)
+    except (configparser.ParsingError, configparser.MissingSectionHeaderError) as exc:
+        raise ValueError(f"Invalid configuration file {cfg_path}") from exc
 
+    result: dict[str, dict[str, str]] = {}
     for sect in config.sections():
-        result[sect] = {}
-        options = config.options(sect)
-        for opt in options:
+        values: dict[str, str] = {}
+        for opt in config.options(sect):
             try:
-                result[sect][opt] = config.get(sect, opt)
-            except Exception:
-                result[sect][opt] = None
+                values[opt] = config.get(sect, opt)
+            except configparser.Error as exc:
+                raise ValueError(
+                    f"Invalid configuration value for option '{opt}' in section '{sect}'"
+                ) from exc
+        result[sect] = values
     return result
 
 
-def getEnvironmentValue(name, default=None):
+def getEnvironmentValue(name: str, default: str | None = None) -> str | None:
     """Returns the value for the given environment variable name, if found;
     otherwise returns default value."""
-    try:
-        return os.environ[name]
-    except KeyError:
-        return default
+    return os.getenv(name, default)

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -1,0 +1,49 @@
+"""Focused tests for shared config/environment helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from SpliceGrapher.shared.config_utils import configMap, getEnvironmentValue
+
+
+def test_config_map_reads_valid_ini_with_case_sensitive_keys(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "sample.ini"
+    cfg_path.write_text("[SectionA]\nMixedCase = Value\nplain = x\n")
+
+    parsed = configMap(cfg_path)
+
+    assert parsed == {"SectionA": {"MixedCase": "Value", "plain": "x"}}
+
+
+def test_config_map_raises_on_invalid_ini(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "broken.ini"
+    cfg_path.write_text("[Broken\nmissing_close = 1\n")
+
+    with pytest.raises(ValueError, match="Invalid configuration file"):
+        configMap(cfg_path)
+
+
+def test_config_map_raises_on_missing_file(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.ini"
+    with pytest.raises(FileNotFoundError):
+        configMap(missing)
+
+
+def test_config_map_raises_on_invalid_option_value(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "invalid_value.ini"
+    cfg_path.write_text("[SectionA]\nkey = %(missing)s\n")
+
+    with pytest.raises(ValueError, match="Invalid configuration value"):
+        configMap(cfg_path)
+
+
+def test_get_environment_value_prefers_env_and_falls_back_to_default(monkeypatch) -> None:
+    key = "SGN_CONFIG_UTILS_TEST"
+    monkeypatch.delenv(key, raising=False)
+    assert getEnvironmentValue(key, "fallback") == "fallback"
+
+    monkeypatch.setenv(key, "present")
+    assert getEnvironmentValue(key, "fallback") == "present"


### PR DESCRIPTION
Closes #55

## Summary
- refactor `SpliceGrapher/shared/config_utils.py` with typed, pathlib-friendly INI parsing while preserving compatibility function names (`configMap`, `getEnvironmentValue`)
- replace broad exception handling with explicit parser error handling and fail-fast validation for missing files and invalid option values
- migrate environment lookup to direct `os.getenv` semantics
- add focused tests in `tests/test_config_utils.py` for valid parse, invalid INI, missing file, invalid value, and env fallback behavior

## Verification
- `uv run pytest -q tests/test_config_utils.py`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest -q`
- `uv run python scripts/ci/check_clean_invariant.py`
- `uv build`
