### PR TITLE
#63 GeneModel enum harmonization tranche: enum-backed record types

### DIFF
--- a/SpliceGrapher/formats/GeneModel.py
+++ b/SpliceGrapher/formats/GeneModel.py
@@ -12,25 +12,25 @@ from SpliceGrapher.core.enum_coercion import coerce_record_type, coerce_strand
 from SpliceGrapher.core.enums import AttrKey, RecordType, Strand
 from SpliceGrapher.shared.utils import ProgressIndicator, comma_format, ez_open, getAttribute
 
-# GFF record types
-CDS_TYPE = RecordType.CDS.value
-CHR_TYPE = RecordType.CHROMOSOME.value
-EXON_TYPE = RecordType.EXON.value
-FP_UTR_TYPE = RecordType.FIVE_PRIME_UTR.value
-GENE_TYPE = RecordType.GENE.value
-INTRON_TYPE = RecordType.INTRON.value
-MRNA_TYPE = RecordType.MRNA.value
-MRNA_TE_TYPE = RecordType.MRNA_TE_GENE.value
-NONUNIQUE_TYPE = RecordType.NONUNIQUE.value
-PROTEIN_RECORD = RecordType.PROTEIN.value
-PREDCDS_TYPE = RecordType.CDS_PREDICTED.value
-PREDGENE_TYPE = RecordType.PREDICTED_GENE.value
-TP_UTR_TYPE = RecordType.THREE_PRIME_UTR.value
-TRANS_ELE_TYPE = RecordType.TRANS_ELE_GENE.value
+# GFF record types (enum-backed, str-compatible)
+CDS_TYPE = RecordType.CDS
+CHR_TYPE = RecordType.CHROMOSOME
+EXON_TYPE = RecordType.EXON
+FP_UTR_TYPE = RecordType.FIVE_PRIME_UTR
+GENE_TYPE = RecordType.GENE
+INTRON_TYPE = RecordType.INTRON
+MRNA_TYPE = RecordType.MRNA
+MRNA_TE_TYPE = RecordType.MRNA_TE_GENE
+NONUNIQUE_TYPE = RecordType.NONUNIQUE
+PROTEIN_RECORD = RecordType.PROTEIN
+PREDCDS_TYPE = RecordType.CDS_PREDICTED
+PREDGENE_TYPE = RecordType.PREDICTED_GENE
+TP_UTR_TYPE = RecordType.THREE_PRIME_UTR
+TRANS_ELE_TYPE = RecordType.TRANS_ELE_GENE
 
-PSEUDOGENE_TYPE = RecordType.PSEUDOGENE.value
-PSEUDOTRANS_TYPE = RecordType.PSEUDOGENIC_TRANSCRIPT.value
-PSEUDOEXON_TYPE = RecordType.PSEUDOGENIC_EXON.value
+PSEUDOGENE_TYPE = RecordType.PSEUDOGENE
+PSEUDOTRANS_TYPE = RecordType.PSEUDOGENIC_TRANSCRIPT
+PSEUDOEXON_TYPE = RecordType.PSEUDOGENIC_EXON
 
 KNOWN_RECTYPES = [
     CDS_TYPE,

--- a/tests/test_gene_model.py
+++ b/tests/test_gene_model.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import pytest
 
+from SpliceGrapher.core.enums import RecordType
+from SpliceGrapher.formats import GeneModel as gm
 from SpliceGrapher.formats.GeneModel import Exon, Gene, GeneModel, featureSearch
 
 
@@ -69,3 +71,19 @@ def test_load_gene_model_rejects_unknown_record_type() -> None:
 
     with pytest.raises(ValueError):
         model.loadGeneModel(records)
+
+
+def test_gene_model_record_type_constants_use_enum_members() -> None:
+    assert gm.CDS_TYPE is RecordType.CDS
+    assert gm.CHR_TYPE is RecordType.CHROMOSOME
+    assert gm.EXON_TYPE is RecordType.EXON
+    assert gm.GENE_TYPE is RecordType.GENE
+    assert gm.MRNA_TYPE is RecordType.MRNA
+    assert gm.PSEUDOGENE_TYPE is RecordType.PSEUDOGENE
+    assert gm.PSEUDOEXON_TYPE is RecordType.PSEUDOGENIC_EXON
+
+
+def test_gene_model_record_type_collections_are_enum_backed() -> None:
+    assert all(isinstance(item, RecordType) for item in gm.KNOWN_RECTYPES)
+    assert all(isinstance(item, RecordType) for item in gm.IGNORE_RECTYPES)
+    assert all(isinstance(item, RecordType) for item in gm.CDS_TYPES)


### PR DESCRIPTION
Part of #63

## Summary
- replace `GeneModel` GFF record-type constant aliases from `RecordType.<X>.value` to canonical enum members (`RecordType.<X>`)
- keep behavior compatible by relying on `RecordType(str, Enum)` string-compat semantics in existing comparisons/maps
- add regression tests asserting enum-backed constants and enum-backed record-type collections in `tests/test_gene_model.py`

## Verification
- `uv run pytest -q tests/test_gene_model.py`
- `uv run pytest -q`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python scripts/ci/check_clean_invariant.py`
- `uv build`
