### PR TITLE
#63 Harmonize ShortRead and alignment header enums

### DIFF
--- a/SpliceGrapher/core/enums.py
+++ b/SpliceGrapher/core/enums.py
@@ -2,16 +2,16 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from enum import StrEnum
 
 
-class Strand(str, Enum):
+class Strand(StrEnum):
     PLUS = "+"
     MINUS = "-"
     UNKNOWN = "."
 
 
-class RecordType(str, Enum):
+class RecordType(StrEnum):
     GENE = "gene"
     PSEUDOGENE = "pseudogene"
     PREDICTED_GENE = "predicted_gene"
@@ -35,18 +35,18 @@ class RecordType(str, Enum):
     CHILD = "child"
 
 
-class NodeDisposition(str, Enum):
+class NodeDisposition(StrEnum):
     KNOWN = "known"
     PREDICTED = "predicted"
     UNRESOLVED = "unresolved"
 
 
-class EdgeType(str, Enum):
+class EdgeType(StrEnum):
     PARENT = "parent"
     CHILD = "child"
 
 
-class AttrKey(str, Enum):
+class AttrKey(StrEnum):
     ID = "ID"
     NAME = "Name"
     PARENT = "Parent"
@@ -57,3 +57,31 @@ class AttrKey(str, Enum):
     ISOFORMS = "Isoforms"
     DISPOSITION = "disposition"
     EXPANDED = "Expanded"
+
+
+class ShortReadCode(StrEnum):
+    CHROM = "C"
+    DEPTH = "D"
+    READ = "R"
+    JUNCTION = "J"
+    SPLICE = "S"
+
+
+class JunctionCode(StrEnum):
+    KNOWN = "K"
+    UNKNOWN = "U"
+    PREDICTED = "P"
+    UNLABELED = ""
+
+
+class SamHeaderTag(StrEnum):
+    HD = "HD"
+    LN = "LN"
+    SN = "SN"
+    SO = "SO"
+    SQ = "SQ"
+    VN = "VN"
+
+
+class SamHeaderLine(StrEnum):
+    SQ = "@SQ"

--- a/SpliceGrapher/formats/alignment_io.py
+++ b/SpliceGrapher/formats/alignment_io.py
@@ -8,6 +8,7 @@ from sys import maxsize as MAXINT
 import pysam
 import structlog
 
+from SpliceGrapher.core.enums import SamHeaderLine, SamHeaderTag
 from SpliceGrapher.shared.file_utils import ez_open
 from SpliceGrapher.shared.process_utils import getAttribute
 from SpliceGrapher.shared.progress import ProgressIndicator
@@ -20,13 +21,13 @@ from SpliceGrapher.shared.ShortRead import (
 LOGGER = structlog.get_logger(__name__)
 
 # Header tags
-HEADER_HD_TAG = "HD"
-HEADER_LN_TAG = "LN"
-HEADER_SN_TAG = "SN"
-HEADER_SO_TAG = "SO"
-HEADER_SQ_TAG = "SQ"
-HEADER_VN_TAG = "VN"
-HEADER_SQ_LINE = "@SQ"
+HEADER_HD_TAG = SamHeaderTag.HD
+HEADER_LN_TAG = SamHeaderTag.LN
+HEADER_SN_TAG = SamHeaderTag.SN
+HEADER_SO_TAG = SamHeaderTag.SO
+HEADER_SQ_TAG = SamHeaderTag.SQ
+HEADER_VN_TAG = SamHeaderTag.VN
+HEADER_SQ_LINE = SamHeaderLine.SQ
 
 # SAM files have the following tab-delimited columns:
 # Column  Value

--- a/SpliceGrapher/shared/ShortRead.py
+++ b/SpliceGrapher/shared/ShortRead.py
@@ -5,6 +5,7 @@ Module containing classes and methods for handling short-read data.
 import os
 from sys import maxsize as MAXINT
 
+from SpliceGrapher.core.enums import JunctionCode, ShortReadCode
 from SpliceGrapher.shared.file_utils import ez_open
 from SpliceGrapher.shared.process_utils import getAttribute, idFactory
 from SpliceGrapher.shared.progress import ProgressIndicator
@@ -12,13 +13,22 @@ from SpliceGrapher.shared.progress import ProgressIndicator
 #################################################
 #  Constants
 #################################################
-CHROM_CODE = "C"
-DEPTH_CODE = "D"
-KNOWN_CODES = [READ_CODE, JCT_CODE, SPLICE_CODE] = ["R", "J", "S"]
+CHROM_CODE = ShortReadCode.CHROM
+DEPTH_CODE = ShortReadCode.DEPTH
+KNOWN_CODES = [READ_CODE, JCT_CODE, SPLICE_CODE] = [
+    ShortReadCode.READ,
+    ShortReadCode.JUNCTION,
+    ShortReadCode.SPLICE,
+]
 DEPTH_CODES = [CHROM_CODE, DEPTH_CODE, JCT_CODE]
 
 # Splice junction codes:
-SJ_CODES = [KNOWN_JCT, UNKNOWN_JCT, PREDICTED_JCT, UNLABELED_JCT] = ["K", "U", "P", ""]
+SJ_CODES = [KNOWN_JCT, UNKNOWN_JCT, PREDICTED_JCT, UNLABELED_JCT] = [
+    JunctionCode.KNOWN,
+    JunctionCode.UNKNOWN,
+    JunctionCode.PREDICTED,
+    JunctionCode.UNLABELED,
+]
 
 
 #################################################

--- a/tests/test_alignment_io_constants.py
+++ b/tests/test_alignment_io_constants.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from SpliceGrapher.core.enums import SamHeaderLine, SamHeaderTag
+from SpliceGrapher.formats import alignment_io
+
+
+def test_alignment_io_header_tags_are_enum_backed() -> None:
+    assert alignment_io.HEADER_HD_TAG is SamHeaderTag.HD
+    assert alignment_io.HEADER_LN_TAG is SamHeaderTag.LN
+    assert alignment_io.HEADER_SN_TAG is SamHeaderTag.SN
+    assert alignment_io.HEADER_SO_TAG is SamHeaderTag.SO
+    assert alignment_io.HEADER_SQ_TAG is SamHeaderTag.SQ
+    assert alignment_io.HEADER_VN_TAG is SamHeaderTag.VN
+    assert alignment_io.HEADER_SQ_LINE is SamHeaderLine.SQ

--- a/tests/test_shortread_constants.py
+++ b/tests/test_shortread_constants.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from SpliceGrapher.core.enums import JunctionCode, ShortReadCode
+from SpliceGrapher.shared import ShortRead as shortread
+
+
+def test_shortread_codes_are_enum_backed() -> None:
+    assert shortread.CHROM_CODE is ShortReadCode.CHROM
+    assert shortread.DEPTH_CODE is ShortReadCode.DEPTH
+    assert shortread.READ_CODE is ShortReadCode.READ
+    assert shortread.JCT_CODE is ShortReadCode.JUNCTION
+    assert shortread.SPLICE_CODE is ShortReadCode.SPLICE
+
+    assert shortread.KNOWN_JCT is JunctionCode.KNOWN
+    assert shortread.UNKNOWN_JCT is JunctionCode.UNKNOWN
+    assert shortread.PREDICTED_JCT is JunctionCode.PREDICTED
+    assert shortread.UNLABELED_JCT is JunctionCode.UNLABELED
+
+
+def test_shortread_code_collections_are_enum_backed() -> None:
+    assert all(isinstance(code, ShortReadCode) for code in shortread.KNOWN_CODES)
+    assert all(isinstance(code, ShortReadCode) for code in shortread.DEPTH_CODES)
+    assert all(isinstance(code, JunctionCode) for code in shortread.SJ_CODES)


### PR DESCRIPTION
Closes #63

## Summary
- add canonical enum domains in SpliceGrapher/core/enums.py for short read record codes, splice junction codes, and SAM header tags/line prefixes
- migrate SpliceGrapher/shared/ShortRead.py constants to enum-backed values while preserving existing string behavior
- migrate SpliceGrapher/formats/alignment_io.py SAM header constants to enum-backed values
- add focused parity tests for enum-backed constants in both modules

## Verification
- uv run ruff check . --fix
- uv run ruff check .
- uv run ruff format --check .
- uv run pytest -q
- uv run python scripts/ci/check_clean_invariant.py
- uv build
