### PR TITLE
#75 Dedupe and harden shared header_utils helpers

### DIFF
--- a/SpliceGrapher/shared/header_utils.py
+++ b/SpliceGrapher/shared/header_utils.py
@@ -1,21 +1,36 @@
 """Header parsing helpers extracted from shared.utils."""
 
 
-def process_fastq_header(header):
+def _first_header_token(header: str) -> str:
+    """Return the first token in a header string."""
+    tokens = header.split()
+    if not tokens:
+        raise ValueError("Header is empty")
+    return tokens[0]
+
+
+def process_fastq_header(header: str) -> str:
     """Find the chromosome identifier within a FASTQ header."""
-    return header.split()[0]
+    return _first_header_token(header)
 
 
-def process_fasta_header(header):
+def process_fasta_header(header: str) -> str:
     """Find the chromosome identifier within a FASTA header."""
-    return header.split()[0]
+    return _first_header_token(header)
 
 
-def process_labeled_fasta_header(header):
+def process_labeled_fasta_header(header: str) -> tuple[str, str]:
     """
     Extract a sequence ID and its label from a fasta file.
     Used with training data FASTA files, so it assumes
     headers have the form "ID label=#".
     """
-    id, labelToken = header.split()
-    return id.strip(), labelToken.split("=")[1]
+    sequence_id = _first_header_token(header).strip()
+    label_token = next((token for token in header.split()[1:] if token.startswith("label=")), None)
+    if label_token is None:
+        raise ValueError("Header missing label= token")
+
+    _, label = label_token.split("=", 1)
+    if not label:
+        raise ValueError("Header has empty label value")
+    return sequence_id, label

--- a/tests/test_header_utils.py
+++ b/tests/test_header_utils.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import pytest
+
+from SpliceGrapher.shared.header_utils import (
+    process_fasta_header,
+    process_fastq_header,
+    process_labeled_fasta_header,
+)
+
+
+def test_process_fastq_header_returns_first_token() -> None:
+    assert process_fastq_header("chr1 read=abc") == "chr1"
+
+
+def test_process_fasta_header_returns_first_token() -> None:
+    assert process_fasta_header("chr2 transcript=xyz") == "chr2"
+
+
+def test_process_fasta_like_header_rejects_empty_values() -> None:
+    with pytest.raises(ValueError, match="Header is empty"):
+        process_fastq_header("   ")
+
+    with pytest.raises(ValueError, match="Header is empty"):
+        process_fasta_header("")
+
+
+def test_process_labeled_fasta_header_parses_label_with_extra_tokens() -> None:
+    seq_id, label = process_labeled_fasta_header("seqA label=retained source=training")
+    assert seq_id == "seqA"
+    assert label == "retained"
+
+
+def test_process_labeled_fasta_header_requires_label_token() -> None:
+    with pytest.raises(ValueError, match="label="):
+        process_labeled_fasta_header("seqA source=training")


### PR DESCRIPTION
Closes #75

## Summary
- remove duplicated FASTA/FASTQ header-token logic by introducing a shared `_first_header_token` helper in `SpliceGrapher/shared/header_utils.py`
- harden header helpers with explicit validation errors for empty headers and missing/empty label tokens
- support labeled FASTA headers that include extra metadata tokens after `label=`
- add focused tests in `tests/test_header_utils.py`

## Verification
- uv run pytest -q tests/test_header_utils.py
- uv run ruff check .
- uv run ruff format --check .
- uv run pytest -q
- uv run python scripts/ci/check_clean_invariant.py
- uv build
