### PR TITLE
#79 Refine logging_utils processors and get_logger first-call level

### DIFF
--- a/SpliceGrapher/shared/logging_utils.py
+++ b/SpliceGrapher/shared/logging_utils.py
@@ -20,7 +20,8 @@ def configure_logging(*, level: int = 20) -> None:
     timestamper = structlog.processors.TimeStamper(fmt="iso", utc=True)
     structlog.configure(
         processors=[
-            structlog.stdlib.add_log_level,
+            structlog.contextvars.merge_contextvars,
+            structlog.processors.add_log_level,
             timestamper,
             structlog.processors.StackInfoRenderer(),
             structlog.dev.set_exc_info,
@@ -33,7 +34,12 @@ def configure_logging(*, level: int = 20) -> None:
     _CONFIGURED = True
 
 
-def get_logger(name: str | None = None) -> FilteringBoundLogger:
+def get_logger(
+    name: str | None = None,
+    *,
+    level: int | None = None,
+) -> FilteringBoundLogger:
     """Return a configured structlog logger."""
-    configure_logging()
+    if not _CONFIGURED:
+        configure_logging(level=20 if level is None else level)
     return cast(FilteringBoundLogger, structlog.get_logger(name))

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from typing import Any
+
+import structlog
+
 from SpliceGrapher.shared import logging_utils
 
 
@@ -16,3 +20,37 @@ def test_configure_logging_is_idempotent() -> None:
 def test_get_logger_returns_logger_with_info_method() -> None:
     logger = logging_utils.get_logger(__name__)
     assert hasattr(logger, "info")
+
+
+def test_configure_logging_uses_nonstdlib_processors(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_configure(**kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    logging_utils._CONFIGURED = False
+    monkeypatch.setattr(structlog, "configure", fake_configure)
+
+    logging_utils.configure_logging(level=10)
+
+    processors = captured["processors"]
+    assert processors[0] is structlog.contextvars.merge_contextvars
+    assert processors[1] is structlog.processors.add_log_level
+
+
+def test_get_logger_passes_level_to_first_configure_call(monkeypatch) -> None:
+    seen: dict[str, Any] = {}
+    sentinel_logger = structlog.get_logger("sentinel")
+
+    def fake_configure_logging(*, level: int = 20) -> None:
+        seen["level"] = level
+        logging_utils._CONFIGURED = True
+
+    logging_utils._CONFIGURED = False
+    monkeypatch.setattr(logging_utils, "configure_logging", fake_configure_logging)
+    monkeypatch.setattr(structlog, "get_logger", lambda name=None: sentinel_logger)
+
+    logger = logging_utils.get_logger("sample", level=10)
+
+    assert seen["level"] == 10
+    assert logger is sentinel_logger


### PR DESCRIPTION
Closes #79

## Summary
- switch logging bootstrap processor stack to non-stdlib path for PrintLogger usage
  - add `structlog.contextvars.merge_contextvars`
  - use `structlog.processors.add_log_level`
- make first-call logger level behavior explicit by adding optional `level` to `get_logger()` and applying it on first configure
- add focused tests for processor selection/order and first-call level passthrough

## Verification
- uv run pytest -q tests/test_logging_utils.py
- uv run ruff check SpliceGrapher/shared/logging_utils.py tests/test_logging_utils.py
- uv run mypy SpliceGrapher/shared/logging_utils.py
