### PR TITLE
#82 Harden shared file_utils behavior and fast paths

### DIFF
--- a/SpliceGrapher/shared/file_utils.py
+++ b/SpliceGrapher/shared/file_utils.py
@@ -24,6 +24,9 @@ def ez_open(file_name: str | Path) -> TextIO:
     if not path.is_file():
         raise FileNotFoundError(f"File does not exist at {path}")
 
+    if path.suffix.lower() == ".gz":
+        return gzip.open(path, mode="rt")
+
     if _is_gzip_file(path):
         return gzip.open(path, mode="rt")
 
@@ -31,10 +34,21 @@ def ez_open(file_name: str | Path) -> TextIO:
 
 
 def file_len(path: str | Path) -> int:
-    """Return an exact line count for a text file."""
+    """Return an exact line count for a text file using buffered byte reads."""
     file_path = _as_path(path)
-    with file_path.open("r") as instream:
-        return sum(1 for _ in instream)
+    line_count = 0
+    saw_bytes = False
+    last_chunk_ended_with_newline = True
+
+    with file_path.open("rb") as instream:
+        while chunk := instream.read(1024 * 1024):
+            saw_bytes = True
+            line_count += chunk.count(b"\n")
+            last_chunk_ended_with_newline = chunk.endswith(b"\n")
+
+    if saw_bytes and not last_chunk_ended_with_newline:
+        line_count += 1
+    return line_count
 
 
 def file_prefix(path: str | Path) -> str:
@@ -45,7 +59,9 @@ def file_prefix(path: str | Path) -> str:
 def find_file(name: str, search_path: str, delim: str = ":") -> str | None:
     """Find the first matching file in a delimiter-separated path string."""
     for raw_path in search_path.split(delim):
-        base = Path(raw_path) if raw_path else Path(".")
+        if not raw_path:
+            continue
+        base = Path(raw_path)
         file_path = base / name
         if file_path.is_file():
             return str(file_path)
@@ -69,16 +85,16 @@ def validate_dir(path: str | Path) -> None:
     """Validate a directory path."""
     validate_file(path)
     if not _as_path(path).is_dir():
-        raise NotADirectoryError(f"'{path}' is not a directory; exiting.")
+        raise NotADirectoryError(f"'{path}' is not a directory.")
 
 
 def validate_file(path: str | Path) -> None:
     """Validate a non-empty existing path."""
     if not path:
-        raise ValueError("Provided path is empty; exiting.")
+        raise ValueError("Provided path is empty.")
 
     if not _as_path(path).exists():
-        raise FileNotFoundError(f"File '{path}' not found; exiting.")
+        raise FileNotFoundError(f"File '{path}' not found.")
 
 
 __all__ = [

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -47,6 +47,12 @@ def test_file_len_and_prefix(tmp_path: Path) -> None:
     assert file_prefix(file_path) == "sample.data"
 
 
+def test_file_len_counts_last_line_without_trailing_newline(tmp_path: Path) -> None:
+    file_path = tmp_path / "no_trailing_newline.txt"
+    file_path.write_text("1\n2\n3")
+    assert file_len(file_path) == 3
+
+
 def test_find_file(tmp_path: Path) -> None:
     one = tmp_path / "one"
     two = tmp_path / "two"
@@ -60,6 +66,17 @@ def test_find_file(tmp_path: Path) -> None:
     assert found == str(target)
 
     assert find_file("missing.txt", f"{one}:{two}") is None
+
+
+def test_find_file_skips_empty_search_segments(tmp_path: Path, monkeypatch) -> None:
+    cwd_target = tmp_path / "cwd_target.txt"
+    cwd_target.write_text("ok")
+    monkeypatch.chdir(tmp_path)
+
+    missing_a = tmp_path / "missing_a"
+    missing_b = tmp_path / "missing_b"
+
+    assert find_file("cwd_target.txt", f"{missing_a}::{missing_b}") is None
 
 
 def test_make_graph_list_file(tmp_path: Path) -> None:
@@ -95,6 +112,22 @@ def test_validate_file_and_dir(tmp_path: Path) -> None:
 
     with pytest.raises(NotADirectoryError):
         validate_dir(data_file)
+
+
+def test_validate_messages_do_not_include_exiting(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="Provided path is empty") as value_error:
+        validate_file("")
+    assert "exiting" not in str(value_error.value).lower()
+
+    with pytest.raises(FileNotFoundError, match="not found") as file_error:
+        validate_file(tmp_path / "missing")
+    assert "exiting" not in str(file_error.value).lower()
+
+    file_path = tmp_path / "not_a_dir.txt"
+    file_path.write_text("x")
+    with pytest.raises(NotADirectoryError, match="is not a directory") as dir_error:
+        validate_dir(file_path)
+    assert "exiting" not in str(dir_error.value).lower()
 
 
 def test_legacy_wrappers_are_not_exposed() -> None:


### PR DESCRIPTION
Closes #82

## Summary
- harden `find_file()` to skip empty search-path segments instead of implicitly searching cwd
- improve `file_len()` with buffered byte reads while preserving exact line counts (including no trailing newline case)
- clean validation exception text by removing `"; exiting."` suffixes from library helper errors
- add gzip extension fast-path in `ez_open()` while preserving magic-byte fallback for non-`.gz` gzip files
- expand focused tests in `tests/test_file_utils.py`

## Verification
- uv run pytest -q tests/test_file_utils.py
- uv run ruff check .
- uv run ruff format --check .
- uv run pytest -q
- uv run python scripts/ci/check_clean_invariant.py
- uv build
