### PR TITLE
#88 Clean shared/collection_utils wrappers and search behavior

### DIFF
--- a/SpliceGrapher/shared/collection_utils.py
+++ b/SpliceGrapher/shared/collection_utils.py
@@ -3,11 +3,8 @@
 from __future__ import annotations
 
 import bisect
-import warnings
 from collections.abc import Callable
 from typing import Any, TypeVar
-
-from SpliceGrapher.shared.process_utils import getAttribute
 
 T = TypeVar("T")
 CollectionValue = str | list[object] | set[object] | tuple[object, ...]
@@ -42,54 +39,18 @@ def binary_search(
     lo: int = 0,
     hi: int | None = None,
 ) -> int:
-    """Return the index in ``sequence`` whose key is closest to ``target``."""
+    """Return the bisect insertion index for ``target`` in ``sequence``."""
     if not sequence:
         raise ValueError("Cannot perform binary search on an empty sequence")
 
     if hi is None:
         hi = len(sequence)
 
-    idx = bisect.bisect_left(sequence, target, lo=lo, hi=hi, key=key)
-    return min(idx, len(sequence) - 1)
-
-
-def _warn_deprecated(old_name: str, new_name: str) -> None:
-    warnings.warn(
-        f"'{old_name}' is deprecated and will be removed in a future release. "
-        f"Use '{new_name}' instead.",
-        DeprecationWarning,
-        stacklevel=3,
-    )
-
-
-# Compatibility wrappers retained while older modules migrate to snake_case names.
-def asList(value: CollectionValue, delim: str = ",") -> list[object]:
-    _warn_deprecated("asList", "as_list")
-    return as_list(value, delim)
-
-
-def asSet(value: CollectionValue, delim: str = ",") -> set[object]:
-    _warn_deprecated("asSet", "as_set")
-    return as_set(value, delim)
-
-
-def bsearch(
-    sequence: list[T],
-    target: Any,
-    getValue: Callable[[T], Any] = lambda item: item,
-    **args: Any,
-) -> int:
-    _warn_deprecated("bsearch", "binary_search")
-    lo = getAttribute("low", 0, **args)
-    high = getAttribute("high", len(sequence) - 1, **args)
-    return binary_search(sequence, target, key=getValue, lo=lo, hi=high + 1)
+    return bisect.bisect_left(sequence, target, lo=lo, hi=hi, key=key)
 
 
 __all__ = [
     "as_list",
     "as_set",
     "binary_search",
-    "asList",
-    "asSet",
-    "bsearch",
 ]

--- a/tests/test_collection_utils.py
+++ b/tests/test_collection_utils.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import pytest
+
+from SpliceGrapher.shared import collection_utils
+from SpliceGrapher.shared.collection_utils import as_list, as_set, binary_search
+
+
+def test_as_list_handles_supported_inputs() -> None:
+    assert as_list("a,b,c") == ["a", "b", "c"]
+    assert as_list(["a", "b"]) == ["a", "b"]
+    assert as_list(("a", "b")) == ["a", "b"]
+    assert sorted(as_list({"a", "b"})) == ["a", "b"]
+
+
+def test_as_set_handles_supported_inputs() -> None:
+    assert as_set("a,b,a") == {"a", "b"}
+    assert as_set(["a", "b", "a"]) == {"a", "b"}
+    assert as_set(("a", "b", "a")) == {"a", "b"}
+    assert as_set({"a", "b"}) == {"a", "b"}
+
+
+def test_as_list_and_as_set_reject_invalid_inputs() -> None:
+    with pytest.raises(TypeError):
+        as_list(123)  # type: ignore[arg-type]
+    with pytest.raises(TypeError):
+        as_set(123)  # type: ignore[arg-type]
+
+
+def test_binary_search_returns_raw_insertion_index() -> None:
+    sequence = [10, 20, 30]
+    assert binary_search(sequence, 5) == 0
+    assert binary_search(sequence, 20) == 1
+    assert binary_search(sequence, 25) == 2
+    assert binary_search(sequence, 40) == 3
+
+
+def test_binary_search_supports_key() -> None:
+    sequence = [("a", 10), ("b", 20), ("c", 30)]
+    assert binary_search(sequence, 25, key=lambda item: item[1]) == 2
+
+
+def test_binary_search_rejects_empty_sequence() -> None:
+    with pytest.raises(ValueError, match="empty"):
+        binary_search([], 1)
+
+
+def test_legacy_wrapper_names_removed() -> None:
+    assert not hasattr(collection_utils, "asList")
+    assert not hasattr(collection_utils, "asSet")
+    assert not hasattr(collection_utils, "bsearch")


### PR DESCRIPTION
Closes #88

## Summary
- remove legacy compatibility wrappers asList, asSet, and bsearch
- remove getAttribute dependency from shared/collection_utils.py
- change binary_search to return raw bisect_left insertion index
- add focused tests in tests/test_collection_utils.py

## Verification
- uv run ruff check .
- uv run pytest -q