### PR TITLE
#84 Harden process_utils command execution

### DIFF
--- a/SpliceGrapher/shared/process_utils.py
+++ b/SpliceGrapher/shared/process_utils.py
@@ -1,8 +1,11 @@
 """Process and command execution helpers extracted from shared.utils."""
 
 import os
+import shlex
 import subprocess
 import sys
+from collections.abc import Sequence
+from typing import Any
 
 from SpliceGrapher.shared.format_utils import time_string
 from SpliceGrapher.shared.logging_utils import get_logger
@@ -21,7 +24,7 @@ def idFactory(pfx="", initial=1):
     idFactory('ev_') will generate 'ev_1', 'ev_2', ..."""
     prefix = pfx if pfx else ""
     counter = initial
-    while 1:
+    while True:
         yield "%s%d" % (prefix, counter)
         counter += 1
 
@@ -32,6 +35,32 @@ def logMessage(s, logstream=None):
     sys.stderr.write(s)
     if logstream:
         logstream.write(s)
+
+
+def run_command(
+    command: str | Sequence[str],
+    *,
+    shell: bool = False,
+    check: bool = False,
+    stdout: Any = None,
+    stderr: Any = None,
+    text: bool = False,
+) -> subprocess.CompletedProcess[Any]:
+    """Run a command with explicit shell behavior."""
+    command_args: str | list[str]
+    if isinstance(command, str):
+        command_args = command if shell else shlex.split(command)
+    else:
+        command_args = list(command)
+
+    return subprocess.run(
+        command_args,
+        shell=shell,
+        check=check,
+        stdout=stdout,
+        stderr=stderr,
+        text=text,
+    )
 
 
 def runCommand(s, **args):
@@ -51,16 +80,19 @@ def runCommand(s, **args):
     if not debug:
         stderr_stream = stderr if stderr is not None else subprocess.DEVNULL
         stdout_stream = stdout if stdout is not None else subprocess.DEVNULL
-        retcode = subprocess.call(
+        completed = run_command(
             s,
             shell=True,
+            check=False,
             stderr=stderr_stream,
             stdout=stdout_stream,
         )
+        retcode = completed.returncode
 
-    if exitOnError and retcode < 0:
+    if exitOnError and retcode != 0:
         LOGGER.error("command_failed", command=s, return_code=retcode)
-        raise Exception("Error running command: returned %d signal\n%s" % (retcode, s))
+        code_type = "signal" if retcode < 0 else "code"
+        raise Exception("Error running command: returned %d %s\n%s" % (retcode, code_type, s))
 
 
 def writeStartupMessage():

--- a/tests/test_process_utils.py
+++ b/tests/test_process_utils.py
@@ -6,19 +6,21 @@ import io
 import subprocess
 from typing import Any
 
+import pytest
+
 from SpliceGrapher.shared import process_utils
 
 
 def test_run_command_redirects_to_devnull_by_default(monkeypatch) -> None:
     captured: dict[str, Any] = {}
 
-    def fake_call(command: str, **kwargs: Any) -> int:
+    def fake_run(command: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
         captured["command"] = command
         captured["stdout"] = kwargs.get("stdout")
         captured["stderr"] = kwargs.get("stderr")
-        return 0
+        return subprocess.CompletedProcess(args=command, returncode=0)
 
-    monkeypatch.setattr(subprocess, "call", fake_call)
+    monkeypatch.setattr(subprocess, "run", fake_run)
     process_utils.runCommand("echo hello", exitOnError=False)
 
     assert captured["command"] == "echo hello"
@@ -29,13 +31,13 @@ def test_run_command_redirects_to_devnull_by_default(monkeypatch) -> None:
 def test_run_command_preserves_explicit_stream_overrides(monkeypatch) -> None:
     captured: dict[str, Any] = {}
 
-    def fake_call(command: str, **kwargs: Any) -> int:
+    def fake_run(command: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
         captured["command"] = command
         captured["stdout"] = kwargs.get("stdout")
         captured["stderr"] = kwargs.get("stderr")
-        return 0
+        return subprocess.CompletedProcess(args=command, returncode=0)
 
-    monkeypatch.setattr(subprocess, "call", fake_call)
+    monkeypatch.setattr(subprocess, "run", fake_run)
 
     process_utils.runCommand(
         "echo hello",
@@ -80,3 +82,63 @@ def test_write_startup_message_emits_structured_event(monkeypatch) -> None:
     event, payload = captured[0]
     assert event == "startup"
     assert payload["script"] == "example_script.py"
+
+
+def test_run_command_defaults_to_shell_false_and_passes_args(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_run(command: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
+        captured["command"] = command
+        captured["shell"] = kwargs.get("shell")
+        captured["check"] = kwargs.get("check")
+        return subprocess.CompletedProcess(args=command, returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    process_utils.run_command(["echo", "hello"])
+
+    assert captured["command"] == ["echo", "hello"]
+    assert captured["shell"] is False
+    assert captured["check"] is False
+
+
+def test_run_command_splits_string_when_shell_false(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_run(command: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
+        captured["command"] = command
+        captured["shell"] = kwargs.get("shell")
+        return subprocess.CompletedProcess(args=command, returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    process_utils.run_command("echo hello")
+
+    assert captured["command"] == ["echo", "hello"]
+    assert captured["shell"] is False
+
+
+def test_run_command_preserves_string_when_shell_true(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_run(command: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
+        captured["command"] = command
+        captured["shell"] = kwargs.get("shell")
+        return subprocess.CompletedProcess(args=command, returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    process_utils.run_command("echo hello", shell=True)
+
+    assert captured["command"] == "echo hello"
+    assert captured["shell"] is True
+
+
+def test_run_command_raises_on_nonzero_return_with_exit_on_error(monkeypatch) -> None:
+    def fake_run(command: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
+        return subprocess.CompletedProcess(args=command, returncode=1)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(Exception, match=r"returned 1"):
+        process_utils.runCommand("false", exitOnError=True)


### PR DESCRIPTION
Closes #84

## Summary
- add new run_command API backed by subprocess.run with explicit shell behavior
- fix runCommand to treat any non-zero return code as failure when exitOnError is true
- keep compatibility entrypoints while modernizing internals and tests
- add coverage for safe run_command behavior and non-zero error handling

## Verification
- uv run ruff check .
- uv run pytest -q