### PR TITLE
#85 Simplify enum coercion to generic API

### DIFF
--- a/SpliceGrapher/SpliceGraph.py
+++ b/SpliceGrapher/SpliceGraph.py
@@ -4,7 +4,7 @@ Module that encapsulates a splice graph.
 
 import sys
 
-from SpliceGrapher.core.enum_coercion import coerce_record_type, coerce_strand
+from SpliceGrapher.core.enum_coercion import coerce_enum
 from SpliceGrapher.core.enums import AttrKey, EdgeType, NodeDisposition, RecordType, Strand
 from SpliceGrapher.shared.collection_utils import as_list
 from SpliceGrapher.shared.file_utils import ez_open
@@ -692,7 +692,7 @@ class SpliceGraphNode(object):
 
     def __init__(self, id, start, end, strand, chrom, parents=[], children=[]):
         self.id = id
-        self.strand = coerce_strand(strand).value
+        self.strand = coerce_enum(strand, Strand, field="strand").value
         self.chromosome = chrom
         self.minpos = min(start, end)
         self.maxpos = max(start, end)
@@ -1094,7 +1094,7 @@ class SpliceGraph(object):
            'strand'     - strand associated with the graph
         """
         self.chromosome = chromosome
-        self.strand = coerce_strand(strand).value
+        self.strand = coerce_enum(strand, Strand, field="strand").value
         self.nodeDict = {}
         self.attrs = {}
         self.minpos = sys.maxsize
@@ -1519,8 +1519,8 @@ class SpliceGraph(object):
         idgen = getAttribute("idGenerator", idFactory("%s_U" % self.getName()), **args)
 
         # establish correct strand
-        self_strand = coerce_strand(self.strand)
-        other_strand = coerce_strand(other.strand)
+        self_strand = coerce_enum(self.strand, Strand, field="strand")
+        other_strand = coerce_enum(other.strand, Strand, field="strand")
         strand = self_strand
         if self_strand.value in VALID_STRANDS:
             if other_strand.value in VALID_STRANDS and self_strand != other_strand:
@@ -1730,7 +1730,7 @@ class SpliceGraphParser(object):
             parts = s.split("\t")
 
             try:
-                recType = coerce_record_type(parts[2].lower()).value
+                recType = coerce_enum(parts[2].lower(), RecordType, field="record_type").value
                 start = int(parts[3])
                 end = int(parts[4])
             except IndexError:

--- a/SpliceGrapher/core/__init__.py
+++ b/SpliceGrapher/core/__init__.py
@@ -1,12 +1,6 @@
 """Core shared types for SpliceGrapher."""
 
-from SpliceGrapher.core.enum_coercion import (
-    coerce_attr_key,
-    coerce_edge_type,
-    coerce_node_disposition,
-    coerce_record_type,
-    coerce_strand,
-)
+from SpliceGrapher.core.enum_coercion import coerce_enum
 from SpliceGrapher.core.enums import AttrKey, EdgeType, NodeDisposition, RecordType, Strand
 
 __all__ = [
@@ -15,9 +9,5 @@ __all__ = [
     "NodeDisposition",
     "RecordType",
     "Strand",
-    "coerce_attr_key",
-    "coerce_edge_type",
-    "coerce_node_disposition",
-    "coerce_record_type",
-    "coerce_strand",
+    "coerce_enum",
 ]

--- a/SpliceGrapher/core/enum_coercion.py
+++ b/SpliceGrapher/core/enum_coercion.py
@@ -5,12 +5,11 @@ from __future__ import annotations
 from enum import Enum
 from typing import TypeVar
 
-from SpliceGrapher.core.enums import AttrKey, EdgeType, NodeDisposition, RecordType, Strand
-
 _EnumT = TypeVar("_EnumT", bound=Enum)
 
 
-def _coerce_enum(value: str | _EnumT, enum_type: type[_EnumT], *, field: str) -> _EnumT:
+def coerce_enum(value: str | _EnumT, enum_type: type[_EnumT], *, field: str) -> _EnumT:
+    """Coerce an external value into a canonical enum domain."""
     if isinstance(value, enum_type):
         return value
     try:
@@ -20,23 +19,3 @@ def _coerce_enum(value: str | _EnumT, enum_type: type[_EnumT], *, field: str) ->
         raise ValueError(
             f"Invalid {field} value {value!r}. Expected one of: {valid_values}"
         ) from exc
-
-
-def coerce_strand(value: str | Strand) -> Strand:
-    return _coerce_enum(value, Strand, field="strand")
-
-
-def coerce_record_type(value: str | RecordType) -> RecordType:
-    return _coerce_enum(value, RecordType, field="record_type")
-
-
-def coerce_node_disposition(value: str | NodeDisposition) -> NodeDisposition:
-    return _coerce_enum(value, NodeDisposition, field="node_disposition")
-
-
-def coerce_edge_type(value: str | EdgeType) -> EdgeType:
-    return _coerce_enum(value, EdgeType, field="edge_type")
-
-
-def coerce_attr_key(value: str | AttrKey) -> AttrKey:
-    return _coerce_enum(value, AttrKey, field="attribute_key")

--- a/SpliceGrapher/formats/GeneModel.py
+++ b/SpliceGrapher/formats/GeneModel.py
@@ -8,7 +8,7 @@ import os
 import sys
 from urllib.parse import unquote
 
-from SpliceGrapher.core.enum_coercion import coerce_record_type, coerce_strand
+from SpliceGrapher.core.enum_coercion import coerce_enum
 from SpliceGrapher.core.enums import AttrKey, RecordType, Strand
 from SpliceGrapher.shared.file_utils import ez_open
 from SpliceGrapher.shared.format_utils import comma_format
@@ -1562,7 +1562,7 @@ class GeneModel(object):
             # Convert input record type into a known enum-backed domain and map
             # aliases (e.g. predicted_gene -> gene) before processing.
             try:
-                recType = coerce_record_type(parts[2].lower()).value
+                recType = coerce_enum(parts[2].lower(), RecordType, field="record_type").value
             except ValueError as exc:
                 raise ValueError("line %d: unknown record type '%s'" % (lineCtr, parts[2])) from exc
             recType = RECTYPE_MAP.get(recType, recType)
@@ -1570,7 +1570,7 @@ class GeneModel(object):
             startPos = int(parts[3])
             endPos = int(parts[4])
             try:
-                strand = coerce_strand(parts[6]).value
+                strand = coerce_enum(parts[6], Strand, field="strand").value
             except ValueError as exc:
                 raise ValueError("line %d: unknown strand '%s'" % (lineCtr, parts[6])) from exc
 

--- a/tests/test_core_enums.py
+++ b/tests/test_core_enums.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import pytest
 
-from SpliceGrapher.core.enum_coercion import coerce_record_type, coerce_strand
-from SpliceGrapher.core.enums import Strand
+from SpliceGrapher.core import enum_coercion
+from SpliceGrapher.core.enum_coercion import coerce_enum
+from SpliceGrapher.core.enums import RecordType, Strand
 
 
 def test_strand_values_are_stable() -> None:
@@ -12,15 +13,23 @@ def test_strand_values_are_stable() -> None:
     assert Strand.UNKNOWN.value == "."
 
 
-def test_coerce_strand_accepts_symbol() -> None:
-    assert coerce_strand("+") is Strand.PLUS
+def test_coerce_enum_accepts_symbol_for_strand() -> None:
+    assert coerce_enum("+", Strand, field="strand") is Strand.PLUS
 
 
-def test_coerce_strand_rejects_invalid() -> None:
+def test_coerce_enum_rejects_invalid_strand() -> None:
     with pytest.raises(ValueError):
-        coerce_strand("?")
+        coerce_enum("?", Strand, field="strand")
 
 
-def test_coerce_record_type_rejects_unknown() -> None:
+def test_coerce_enum_rejects_unknown_record_type() -> None:
     with pytest.raises(ValueError):
-        coerce_record_type("totally_unknown_type")
+        coerce_enum("totally_unknown_type", RecordType, field="record_type")
+
+
+def test_wrapper_helpers_removed() -> None:
+    assert not hasattr(enum_coercion, "coerce_strand")
+    assert not hasattr(enum_coercion, "coerce_record_type")
+    assert not hasattr(enum_coercion, "coerce_node_disposition")
+    assert not hasattr(enum_coercion, "coerce_edge_type")
+    assert not hasattr(enum_coercion, "coerce_attr_key")


### PR DESCRIPTION
Closes #85

## Summary
- replace wrapper-specific coercion helpers with a single generic coerce_enum helper
- update SpliceGraph and GeneModel call sites to use the generic coercion helper
- simplify core exports and core enum tests to the generic API
- remove per-enum coercion wrapper surface area

## Verification
- uv run ruff check .
- uv run pytest -q