### PR TITLE
#81 Harden format_utils numeric precision and UTC defaults

### DIFF
--- a/SpliceGrapher/shared/format_utils.py
+++ b/SpliceGrapher/shared/format_utils.py
@@ -2,13 +2,22 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Iterable
-from datetime import datetime
+from datetime import datetime, timezone
+
+_INT_PATTERN = re.compile(r"^[+-]?\d+$")
+_FLOAT_PATTERN = re.compile(r"^[+-]?(?:\d+\.\d*|\.\d+|\d+)(?:[eE][+-]?\d+)?$")
 
 
 def comma_format(value: int | float | str) -> str:
-    """Format integer-compatible values using commas."""
-    return f"{int(value):,}"
+    """Format numeric values using thousands separators without truncation."""
+    if isinstance(value, str):
+        number = to_numeric(value)
+        if isinstance(number, str):
+            raise ValueError(f"Value is not numeric: {value!r}")
+        return f"{number:,}"
+    return f"{value:,}"
 
 
 def dict_string(value_dict: dict[object, object], delim: str = ",") -> str:
@@ -44,13 +53,17 @@ def substring_between(text: str, tag1: str, tag2: str) -> str | None:
 
 
 def timestamp(format_string: str = "%Y%m%d%H%M%S") -> str:
-    """Return a timestamp unique to the current second."""
-    return datetime.now().strftime(format_string)
+    """Return a UTC timestamp unique to the current second."""
+    return datetime.now(timezone.utc).strftime(format_string)
 
 
-def time_string(message: str, format_string: str = "%X", trailing_newline: bool = False) -> str:
-    """Return a message prefixed with a user-readable timestamp."""
-    ts = datetime.now().strftime(format_string)
+def time_string(
+    message: str,
+    format_string: str = "%H:%M:%S",
+    trailing_newline: bool = False,
+) -> str:
+    """Return a message prefixed with a UTC timestamp."""
+    ts = datetime.now(timezone.utc).strftime(format_string)
     result = f"{ts} {message}"
     if trailing_newline:
         result += "\n"
@@ -58,16 +71,22 @@ def time_string(message: str, format_string: str = "%X", trailing_newline: bool 
 
 
 def to_numeric(value: str) -> int | float | str:
-    """Attempt int then float conversion; return the original string on failure."""
-    try:
-        return int(value)
-    except ValueError:
-        pass
+    """Attempt numeric conversion with a regex fast path, else return original string."""
+    stripped = value.strip()
+    if not stripped:
+        return value
 
-    try:
-        return float(value)
-    except ValueError:
-        pass
+    if _INT_PATTERN.fullmatch(stripped):
+        try:
+            return int(stripped)
+        except ValueError:
+            return value
+
+    if _FLOAT_PATTERN.fullmatch(stripped):
+        try:
+            return float(stripped)
+        except ValueError:
+            return value
 
     return value
 

--- a/tests/test_format_utils.py
+++ b/tests/test_format_utils.py
@@ -16,6 +16,8 @@ from SpliceGrapher.shared.format_utils import (
 def test_comma_format_variants() -> None:
     assert comma_format("1234567") == "1,234,567"
     assert comma_format(8900) == "8,900"
+    assert comma_format(1234.56) == "1,234.56"
+    assert comma_format("1234.56") == "1,234.56"
 
 
 def test_dict_and_list_string() -> None:
@@ -43,9 +45,11 @@ def test_substring_helpers() -> None:
 def test_time_helpers() -> None:
     stamp = timestamp("%Y")
     assert len(stamp) == 4
+    assert timestamp("%z") == "+0000"
 
     message = time_string("hello", format_string="%H:%M:%S")
     assert message.endswith(" hello")
+    assert time_string("utc", format_string="%z").startswith("+0000 ")
 
     newline_message = time_string("world", format_string="%H:%M:%S", trailing_newline=True)
     assert newline_message.endswith(" world\n")
@@ -54,4 +58,7 @@ def test_time_helpers() -> None:
 def test_to_numeric() -> None:
     assert to_numeric("10") == 10
     assert to_numeric("12.5") == 12.5
+    assert to_numeric(" 42 ") == 42
+    assert to_numeric("+3.5") == 3.5
+    assert to_numeric("1e3") == 1000.0
     assert to_numeric("abc") == "abc"


### PR DESCRIPTION
Closes #81

## Summary
- preserve float precision in comma_format (no implicit int truncation)
- switch time helpers to UTC-backed timestamps and deterministic default format
- add regex fast-path handling in to_numeric and expand numeric edge-case tests

## Verification
- uv run ruff check .
- uv run pytest -q