### PR TITLE
#94 Single-cycle go/no-go benchmark for Polars GFF path

### DIFF
--- a/SpliceGrapher/formats/polars_gff_benchmark.py
+++ b/SpliceGrapher/formats/polars_gff_benchmark.py
@@ -1,0 +1,734 @@
+"""Benchmark helpers for optional Polars GFF ingestion workflows."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import tracemalloc
+from dataclasses import dataclass
+from pathlib import Path
+from time import perf_counter
+from typing import Callable
+
+from SpliceGrapher.formats.GeneModel import GeneModel
+from SpliceGrapher.formats.polars_gff import (
+    PolarsNotInstalledError,
+    load_gff_rows,
+    load_gff_to_polars,
+)
+
+DEFAULT_DATASET_SIZES: dict[str, int] = {
+    "small": 100,
+    "medium": 750,
+    "large": 3000,
+}
+
+RUNTIME_SPEEDUP_THRESHOLD = 0.20
+MEMORY_REGRESSION_THRESHOLD = 0.10
+REQUIRED_REAL_DATASETS = 3
+MIN_WINNING_DATASETS = 2
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkMetrics:
+    """Single loader benchmark metrics."""
+
+    mean_seconds: float
+    max_seconds: float
+    peak_mebibytes: float
+    rows: int
+    status: str = "ok"
+    analytics_signature: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class GoNoGoDecision:
+    """Explicit decision record for the Polars go/no-go policy."""
+
+    recommendation: str
+    decision: str
+    evaluated_real_datasets: int
+    compared_real_datasets: int
+    winning_datasets: int
+    runtime_speedup_threshold: float = RUNTIME_SPEEDUP_THRESHOLD
+    memory_regression_threshold: float = MEMORY_REGRESSION_THRESHOLD
+    required_real_datasets: int = REQUIRED_REAL_DATASETS
+    min_winning_datasets: int = MIN_WINNING_DATASETS
+    notes: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class SingleCycleEvaluation:
+    """Single-cycle benchmark output for synthetic + real workloads."""
+
+    synthetic: dict[str, dict[str, dict[str, BenchmarkMetrics]]]
+    real: dict[str, dict[str, dict[str, BenchmarkMetrics]]]
+    decision: GoNoGoDecision
+
+
+def _count_data_rows(path: Path) -> int:
+    with path.open("r", encoding="utf-8") as handle:
+        return sum(1 for line in handle if line.strip() and not line.startswith("#"))
+
+
+def _measure_loader(
+    loader: Callable[[Path], object],
+    path: Path,
+    *,
+    iterations: int,
+    rows: int,
+) -> BenchmarkMetrics:
+    # Warm up once so one-time import/init overhead does not dominate metrics.
+    _ = loader(path)
+
+    timings: list[float] = []
+    peaks: list[int] = []
+
+    for _ in range(iterations):
+        tracemalloc.start()
+        start = perf_counter()
+        _ = loader(path)
+        elapsed = perf_counter() - start
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+
+        timings.append(elapsed)
+        peaks.append(peak)
+
+    return BenchmarkMetrics(
+        mean_seconds=sum(timings) / len(timings),
+        max_seconds=max(timings),
+        peak_mebibytes=max(peaks) / (1024.0 * 1024.0),
+        rows=rows,
+    )
+
+
+def _error_metrics(
+    rows: int,
+    *,
+    exception: Exception,
+    analytics_signature: str | None = None,
+) -> BenchmarkMetrics:
+    return BenchmarkMetrics(
+        mean_seconds=0.0,
+        max_seconds=0.0,
+        peak_mebibytes=0.0,
+        rows=rows,
+        status=f"error:{type(exception).__name__}",
+        analytics_signature=analytics_signature,
+    )
+
+
+def _measure_analytics_workload(
+    workload: Callable[[Path], tuple[int, str]],
+    path: Path,
+    *,
+    iterations: int,
+) -> BenchmarkMetrics:
+    # Warm up once so one-time import/init overhead does not dominate metrics.
+    warm_rows, warm_signature = workload(path)
+
+    timings: list[float] = []
+    peaks: list[int] = []
+    rows = warm_rows
+    signature = warm_signature
+
+    for _ in range(iterations):
+        tracemalloc.start()
+        start = perf_counter()
+        rows_i, signature_i = workload(path)
+        elapsed = perf_counter() - start
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+
+        if signature_i != signature:
+            raise ValueError("analytics signature drift within a single workload")
+
+        rows = rows_i
+        timings.append(elapsed)
+        peaks.append(peak)
+
+    return BenchmarkMetrics(
+        mean_seconds=sum(timings) / len(timings),
+        max_seconds=max(timings),
+        peak_mebibytes=max(peaks) / (1024.0 * 1024.0),
+        rows=rows,
+        analytics_signature=signature,
+    )
+
+
+def _normalize_parent_ids(value: str | None) -> list[str]:
+    if not value:
+        return []
+    return [part for part in value.split(",") if part]
+
+
+def _exon_records_from_rows(path: Path) -> list[tuple[str, str, int, int, str]]:
+    rows = load_gff_rows(path, ignore_malformed=False)
+    result: list[tuple[str, str, int, int, str]] = []
+    for row in rows:
+        if row["type"] != "exon":
+            continue
+        chrom = str(row["chrom"])
+        strand = str(row["strand"])
+        start = int(row["start"])
+        end = int(row["end"])
+        parent_value = row["parent_id"] if isinstance(row["parent_id"], str) else None
+        for parent_id in _normalize_parent_ids(parent_value):
+            result.append((chrom, strand, start, end, parent_id))
+    return result
+
+
+def _exon_records_from_polars(path: Path) -> list[tuple[str, str, int, int, str]]:
+    data_frame = load_gff_to_polars(path, ignore_malformed=False)
+    result: list[tuple[str, str, int, int, str]] = []
+    for row in data_frame.to_dicts():
+        if row["type"] != "exon":
+            continue
+        chrom = str(row["chrom"])
+        strand = str(row["strand"])
+        start = int(row["start"])
+        end = int(row["end"])
+        for parent_id in _normalize_parent_ids(
+            row["parent_id"] if isinstance(row["parent_id"], str) else None
+        ):
+            result.append((chrom, strand, start, end, parent_id))
+    return result
+
+
+def _exon_records_from_gene_model(path: Path) -> list[tuple[str, str, int, int, str]]:
+    model = GeneModel(str(path), verbose=False)
+    result: list[tuple[str, str, int, int, str]] = []
+
+    for gene in model.allGenes.values():
+        for exon in gene.exons:
+            for isoform in exon.parents:
+                result.append((exon.chromosome, exon.strand, exon.minpos, exon.maxpos, isoform.id))
+
+    return result
+
+
+def _analytics_signature(exon_records: list[tuple[str, str, int, int, str]]) -> str:
+    if not exon_records:
+        payload = {"shared_exons": [], "transcript_exons": [], "junctions": []}
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    exon_group_map: dict[tuple[str, str, int, int], set[str]] = {}
+    transcript_map: dict[str, list[tuple[int, int, str, str]]] = {}
+
+    for chrom, strand, start, end, parent_id in exon_records:
+        exon_group_map.setdefault((chrom, strand, start, end), set()).add(parent_id)
+        transcript_map.setdefault(parent_id, []).append((start, end, strand, chrom))
+
+    shared_exons = sorted(
+        (chrom, strand, start, end, len(parents))
+        for (chrom, strand, start, end), parents in exon_group_map.items()
+        if len(parents) > 1
+    )
+
+    transcript_exons: list[dict[str, object]] = []
+    junctions: list[tuple[str, int, int]] = []
+
+    for transcript_id, exons in sorted(transcript_map.items()):
+        strand = exons[0][2]
+        chrom = exons[0][3]
+        ordered = sorted(((start, end) for start, end, _, _ in exons), reverse=(strand == "-"))
+        transcript_exons.append(
+            {
+                "transcript": transcript_id,
+                "strand": strand,
+                "chrom": chrom,
+                "exons": ordered,
+            }
+        )
+
+        if len(ordered) < 2:
+            continue
+
+        prev_start, prev_end = ordered[0]
+        for curr_start, curr_end in ordered[1:]:
+            if strand == "+":
+                donor = prev_end
+                acceptor = curr_start - 2
+            else:
+                donor = prev_start - 2
+                acceptor = curr_end
+            junctions.append((transcript_id, donor, acceptor))
+            prev_start, prev_end = curr_start, curr_end
+
+    payload = {
+        "shared_exons": shared_exons,
+        "transcript_exons": transcript_exons,
+        "junctions": sorted(junctions),
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _workload_rows(path: Path) -> tuple[int, str]:
+    records = _exon_records_from_rows(path)
+    return len(records), _analytics_signature(records)
+
+
+def _workload_polars(path: Path) -> tuple[int, str]:
+    records = _exon_records_from_polars(path)
+    return len(records), _analytics_signature(records)
+
+
+def _workload_gene_model(path: Path) -> tuple[int, str]:
+    records = _exon_records_from_gene_model(path)
+    return len(records), _analytics_signature(records)
+
+
+def _benchmark_classes_for_path(
+    path: Path,
+    *,
+    iterations: int,
+    include_polars: bool,
+) -> dict[str, dict[str, BenchmarkMetrics]]:
+    return {
+        "ingest": benchmark_gff_path(path, iterations=iterations, include_polars=include_polars),
+        "end_to_end": benchmark_end_to_end_gff_path(
+            path,
+            iterations=iterations,
+            include_polars=include_polars,
+        ),
+    }
+
+
+def write_synthetic_gff(path: str | Path, *, gene_count: int, exons_per_gene: int = 3) -> int:
+    """Write a deterministic synthetic GFF file and return record count."""
+    if gene_count <= 0:
+        raise ValueError("gene_count must be >= 1")
+    if exons_per_gene <= 0:
+        raise ValueError("exons_per_gene must be >= 1")
+
+    out_path = Path(path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    record_count = 0
+    with out_path.open("w", encoding="utf-8") as handle:
+        handle.write("##gff-version 3\n")
+        for gene_idx in range(1, gene_count + 1):
+            gene_start = (gene_idx - 1) * 1000 + 1
+            gene_end = gene_start + (exons_per_gene * 100)
+            gene_id = f"GENE{gene_idx}"
+            transcript_id = f"TX{gene_idx}"
+
+            handle.write(
+                f"chr1\tbenchmark\tgene\t{gene_start}\t{gene_end}\t.\t+\t."
+                f"\tID={gene_id};Name={gene_id}\n"
+            )
+            record_count += 1
+
+            handle.write(
+                f"chr1\tbenchmark\tmrna\t{gene_start}\t{gene_end}\t.\t+\t."
+                f"\tID={transcript_id};Parent={gene_id};Name={transcript_id}\n"
+            )
+            record_count += 1
+
+            for exon_idx in range(1, exons_per_gene + 1):
+                exon_start = gene_start + ((exon_idx - 1) * 100)
+                exon_end = exon_start + 79
+                exon_id = f"EX{gene_idx}.{exon_idx}"
+                handle.write(
+                    f"chr1\tbenchmark\texon\t{exon_start}\t{exon_end}\t.\t+\t."
+                    f"\tID={exon_id};Parent={transcript_id}\n"
+                )
+                record_count += 1
+
+    return record_count
+
+
+def benchmark_gff_path(
+    path: str | Path,
+    *,
+    iterations: int = 3,
+    include_polars: bool = True,
+) -> dict[str, BenchmarkMetrics]:
+    """Benchmark available ingest loaders for a single GFF file."""
+    if iterations <= 0:
+        raise ValueError("iterations must be >= 1")
+
+    gff_path = Path(path)
+    rows = _count_data_rows(gff_path)
+
+    results: dict[str, BenchmarkMetrics] = {}
+
+    try:
+        results["gene_model"] = _measure_loader(
+            lambda p: GeneModel(str(p), verbose=False),
+            gff_path,
+            iterations=iterations,
+            rows=rows,
+        )
+    except Exception as exc:  # pragma: no cover - defensive for heterogeneous fixtures
+        results["gene_model"] = _error_metrics(rows, exception=exc)
+
+    try:
+        results["rows"] = _measure_loader(
+            lambda p: load_gff_rows(p, ignore_malformed=False),
+            gff_path,
+            iterations=iterations,
+            rows=rows,
+        )
+    except Exception as exc:  # pragma: no cover - defensive for heterogeneous fixtures
+        results["rows"] = _error_metrics(rows, exception=exc)
+
+    if include_polars:
+        try:
+            results["polars_df"] = _measure_loader(
+                lambda p: load_gff_to_polars(p, ignore_malformed=False),
+                gff_path,
+                iterations=iterations,
+                rows=rows,
+            )
+        except PolarsNotInstalledError:
+            results["polars_df"] = BenchmarkMetrics(
+                mean_seconds=0.0,
+                max_seconds=0.0,
+                peak_mebibytes=0.0,
+                rows=rows,
+                status="unavailable",
+            )
+        except Exception as exc:  # pragma: no cover - defensive for heterogeneous fixtures
+            results["polars_df"] = _error_metrics(rows, exception=exc)
+
+    return results
+
+
+def benchmark_end_to_end_gff_path(
+    path: str | Path,
+    *,
+    iterations: int = 3,
+    include_polars: bool = True,
+) -> dict[str, BenchmarkMetrics]:
+    """Benchmark end-to-end analytics workloads for a single GFF file."""
+    if iterations <= 0:
+        raise ValueError("iterations must be >= 1")
+
+    gff_path = Path(path)
+
+    results: dict[str, BenchmarkMetrics] = {}
+
+    try:
+        results["gene_model"] = _measure_analytics_workload(
+            _workload_gene_model,
+            gff_path,
+            iterations=iterations,
+        )
+    except Exception as exc:  # pragma: no cover - defensive for heterogeneous fixtures
+        results["gene_model"] = _error_metrics(_count_data_rows(gff_path), exception=exc)
+
+    try:
+        results["rows"] = _measure_analytics_workload(
+            _workload_rows,
+            gff_path,
+            iterations=iterations,
+        )
+    except Exception as exc:  # pragma: no cover - defensive for heterogeneous fixtures
+        results["rows"] = _error_metrics(_count_data_rows(gff_path), exception=exc)
+
+    if include_polars:
+        try:
+            results["polars_df"] = _measure_analytics_workload(
+                _workload_polars,
+                gff_path,
+                iterations=iterations,
+            )
+        except PolarsNotInstalledError:
+            results["polars_df"] = BenchmarkMetrics(
+                mean_seconds=0.0,
+                max_seconds=0.0,
+                peak_mebibytes=0.0,
+                rows=results["rows"].rows,
+                status="unavailable",
+                analytics_signature=None,
+            )
+        except Exception as exc:  # pragma: no cover - defensive for heterogeneous fixtures
+            results["polars_df"] = _error_metrics(
+                results["rows"].rows,
+                exception=exc,
+            )
+
+    return results
+
+
+def benchmark_matrix(
+    work_dir: str | Path,
+    *,
+    dataset_sizes: dict[str, int] | None = None,
+    exons_per_gene: int = 3,
+    iterations: int = 3,
+    include_polars: bool = True,
+) -> dict[str, dict[str, BenchmarkMetrics]]:
+    """Benchmark ingest loaders for multiple synthetic dataset sizes."""
+    base_dir = Path(work_dir)
+    base_dir.mkdir(parents=True, exist_ok=True)
+
+    sizes = dataset_sizes if dataset_sizes is not None else DEFAULT_DATASET_SIZES
+    result: dict[str, dict[str, BenchmarkMetrics]] = {}
+
+    for label, gene_count in sizes.items():
+        gff_path = base_dir / f"{label}.synthetic.gff3"
+        write_synthetic_gff(gff_path, gene_count=gene_count, exons_per_gene=exons_per_gene)
+        result[label] = benchmark_gff_path(
+            gff_path,
+            iterations=iterations,
+            include_polars=include_polars,
+        )
+
+    return result
+
+
+def evaluate_go_no_go(real_end_to_end: dict[str, dict[str, BenchmarkMetrics]]) -> GoNoGoDecision:
+    """Apply explicit go/no-go rule for Polars adoption."""
+    evaluated = len(real_end_to_end)
+    if evaluated < REQUIRED_REAL_DATASETS:
+        return GoNoGoDecision(
+            recommendation="defer",
+            decision="insufficient_data",
+            evaluated_real_datasets=evaluated,
+            compared_real_datasets=0,
+            winning_datasets=0,
+            notes="need at least three real datasets for final decision",
+        )
+
+    compared = 0
+    winners = 0
+
+    for loaders in real_end_to_end.values():
+        baseline = loaders.get("rows")
+        polars = loaders.get("polars_df")
+
+        if not baseline or not polars:
+            continue
+        if baseline.status != "ok" or polars.status != "ok":
+            continue
+
+        compared += 1
+
+        if baseline.analytics_signature != polars.analytics_signature:
+            return GoNoGoDecision(
+                recommendation="defer",
+                decision="correctness_drift",
+                evaluated_real_datasets=evaluated,
+                compared_real_datasets=compared,
+                winning_datasets=winners,
+                notes="analytics signature mismatch between baseline and polars",
+            )
+
+        if baseline.mean_seconds <= 0:
+            continue
+
+        runtime_speedup = 1.0 - (polars.mean_seconds / baseline.mean_seconds)
+        memory_ratio = (
+            polars.peak_mebibytes / baseline.peak_mebibytes if baseline.peak_mebibytes > 0 else 1.0
+        )
+
+        if runtime_speedup >= RUNTIME_SPEEDUP_THRESHOLD and memory_ratio <= (
+            1.0 + MEMORY_REGRESSION_THRESHOLD
+        ):
+            winners += 1
+
+    if compared < REQUIRED_REAL_DATASETS:
+        return GoNoGoDecision(
+            recommendation="defer",
+            decision="insufficient_data",
+            evaluated_real_datasets=evaluated,
+            compared_real_datasets=compared,
+            winning_datasets=winners,
+            notes="fewer than three comparable real datasets",
+        )
+
+    if winners >= MIN_WINNING_DATASETS:
+        return GoNoGoDecision(
+            recommendation="adopt",
+            decision="threshold_met",
+            evaluated_real_datasets=evaluated,
+            compared_real_datasets=compared,
+            winning_datasets=winners,
+            notes="runtime and memory thresholds met on required dataset count",
+        )
+
+    return GoNoGoDecision(
+        recommendation="defer",
+        decision="threshold_not_met",
+        evaluated_real_datasets=evaluated,
+        compared_real_datasets=compared,
+        winning_datasets=winners,
+        notes="required runtime and memory win thresholds not met",
+    )
+
+
+def run_single_cycle_evaluation(
+    *,
+    synthetic_work_dir: str | Path,
+    real_datasets: dict[str, str | Path],
+    synthetic_dataset_sizes: dict[str, int] | None = None,
+    exons_per_gene: int = 3,
+    iterations: int = 3,
+    include_polars: bool = True,
+) -> SingleCycleEvaluation:
+    """Run one complete synthetic + real benchmark cycle."""
+    work_dir = Path(synthetic_work_dir)
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    sizes = (
+        synthetic_dataset_sizes if synthetic_dataset_sizes is not None else DEFAULT_DATASET_SIZES
+    )
+
+    synthetic: dict[str, dict[str, dict[str, BenchmarkMetrics]]] = {}
+    for label, gene_count in sizes.items():
+        path = work_dir / f"{label}.synthetic.gff3"
+        write_synthetic_gff(path, gene_count=gene_count, exons_per_gene=exons_per_gene)
+        synthetic[label] = _benchmark_classes_for_path(
+            path,
+            iterations=iterations,
+            include_polars=include_polars,
+        )
+
+    real: dict[str, dict[str, dict[str, BenchmarkMetrics]]] = {}
+    for label, path_value in real_datasets.items():
+        path = Path(path_value)
+        if not path.is_file():
+            raise FileNotFoundError(f"real dataset path not found: {path}")
+        real[label] = _benchmark_classes_for_path(
+            path,
+            iterations=iterations,
+            include_polars=include_polars,
+        )
+
+    end_to_end_real = {name: classes["end_to_end"] for name, classes in real.items()}
+    decision = evaluate_go_no_go(end_to_end_real)
+
+    return SingleCycleEvaluation(synthetic=synthetic, real=real, decision=decision)
+
+
+def _metrics_to_dict(metrics: BenchmarkMetrics) -> dict[str, object]:
+    return {
+        "status": metrics.status,
+        "rows": metrics.rows,
+        "mean_seconds": metrics.mean_seconds,
+        "max_seconds": metrics.max_seconds,
+        "peak_mebibytes": metrics.peak_mebibytes,
+        "analytics_signature": metrics.analytics_signature,
+    }
+
+
+def evaluation_to_json_dict(evaluation: SingleCycleEvaluation) -> dict[str, object]:
+    """Convert single-cycle evaluation to JSON-safe dictionary payload."""
+
+    def convert_dataset(
+        section: dict[str, dict[str, dict[str, BenchmarkMetrics]]],
+    ) -> dict[str, dict[str, dict[str, dict[str, object]]]]:
+        payload: dict[str, dict[str, dict[str, dict[str, object]]]] = {}
+        for dataset, classes in section.items():
+            payload[dataset] = {}
+            for class_name, loaders in classes.items():
+                payload[dataset][class_name] = {
+                    loader_name: _metrics_to_dict(loader_metrics)
+                    for loader_name, loader_metrics in loaders.items()
+                }
+        return payload
+
+    return {
+        "synthetic": convert_dataset(evaluation.synthetic),
+        "real": convert_dataset(evaluation.real),
+        "decision": {
+            "recommendation": evaluation.decision.recommendation,
+            "decision": evaluation.decision.decision,
+            "evaluated_real_datasets": evaluation.decision.evaluated_real_datasets,
+            "compared_real_datasets": evaluation.decision.compared_real_datasets,
+            "winning_datasets": evaluation.decision.winning_datasets,
+            "runtime_speedup_threshold": evaluation.decision.runtime_speedup_threshold,
+            "memory_regression_threshold": evaluation.decision.memory_regression_threshold,
+            "required_real_datasets": evaluation.decision.required_real_datasets,
+            "min_winning_datasets": evaluation.decision.min_winning_datasets,
+            "notes": evaluation.decision.notes,
+        },
+    }
+
+
+def matrix_to_markdown(matrix: dict[str, dict[str, BenchmarkMetrics]]) -> str:
+    """Render benchmark matrix as a markdown table."""
+    lines = [
+        "| dataset | loader | status | rows | mean_s | max_s | peak_mib |",
+        "|---|---|---:|---:|---:|---:|---:|",
+    ]
+
+    for dataset, loaders in matrix.items():
+        for loader_name, metrics in loaders.items():
+            lines.append(
+                "| "
+                f"{dataset} | {loader_name} | {metrics.status} | {metrics.rows} | "
+                f"{metrics.mean_seconds:.6f} | {metrics.max_seconds:.6f} | "
+                f"{metrics.peak_mebibytes:.3f} |"
+            )
+
+    return "\n".join(lines)
+
+
+def _section_to_markdown(
+    title: str,
+    section: dict[str, dict[str, dict[str, BenchmarkMetrics]]],
+) -> str:
+    blocks = [f"## {title}"]
+    for dataset, classes in section.items():
+        blocks.append(f"### {dataset}")
+        for class_name, loaders in classes.items():
+            blocks.append(f"#### {class_name}")
+            blocks.append(matrix_to_markdown({dataset: loaders}))
+            blocks.append("")
+    return "\n".join(blocks).rstrip()
+
+
+def evaluation_to_markdown(evaluation: SingleCycleEvaluation) -> str:
+    """Render single-cycle evaluation as markdown report."""
+    decision = evaluation.decision
+    lines = [
+        "# Polars GFF Single-Cycle Evaluation",
+        "",
+        "## Decision",
+        f"- recommendation: `{decision.recommendation}`",
+        f"- decision: `{decision.decision}`",
+        f"- evaluated real datasets: `{decision.evaluated_real_datasets}`",
+        f"- compared real datasets: `{decision.compared_real_datasets}`",
+        f"- winning datasets: `{decision.winning_datasets}`",
+        f"- thresholds: runtime>={int(decision.runtime_speedup_threshold * 100)}%, "
+        f"memory<=+{int(decision.memory_regression_threshold * 100)}%",
+    ]
+    if decision.notes:
+        lines.append(f"- notes: {decision.notes}")
+
+    lines.extend(
+        [
+            "",
+            _section_to_markdown("Synthetic", evaluation.synthetic),
+            "",
+            _section_to_markdown("Real", evaluation.real),
+        ]
+    )
+    return "\n".join(lines)
+
+
+__all__ = [
+    "BenchmarkMetrics",
+    "DEFAULT_DATASET_SIZES",
+    "GoNoGoDecision",
+    "MEMORY_REGRESSION_THRESHOLD",
+    "MIN_WINNING_DATASETS",
+    "REQUIRED_REAL_DATASETS",
+    "RUNTIME_SPEEDUP_THRESHOLD",
+    "SingleCycleEvaluation",
+    "benchmark_end_to_end_gff_path",
+    "benchmark_gff_path",
+    "benchmark_matrix",
+    "evaluate_go_no_go",
+    "evaluation_to_json_dict",
+    "evaluation_to_markdown",
+    "matrix_to_markdown",
+    "run_single_cycle_evaluation",
+    "write_synthetic_gff",
+]

--- a/docs/testing/polars-gff-benchmark.md
+++ b/docs/testing/polars-gff-benchmark.md
@@ -1,0 +1,90 @@
+# Polars GFF Single-Cycle Go/No-Go Evaluation
+
+Issue: #94 (follow-up from #62)
+
+## Scope
+
+This benchmark implements SGN's timeboxed go/no-go policy for optional backend paths.
+
+Compared paths:
+
+- baseline object path: `SpliceGrapher.formats.GeneModel.GeneModel`
+- baseline row path: `SpliceGrapher.formats.polars_gff.load_gff_rows`
+- candidate path: `SpliceGrapher.formats.polars_gff.load_gff_to_polars`
+
+Measured workload classes:
+
+- ingest microbenchmark
+- end-to-end analytics benchmark with shared exon grouping, transcript/exon aggregation,
+  and donor/acceptor-style coordinate derivations
+
+## Decision Rule
+
+Polars is adoptable only if all are true:
+
+- >=20% runtime win on at least 2 of 3 real datasets
+- <=10% peak memory regression on winning datasets
+- no correctness drift against baseline analytics signatures
+
+If not met, recommendation is `defer` and Polars remains optional analysis helper only.
+
+## Methodology
+
+- One warm-up run per loader/workload before measurement.
+- 3 timed iterations per loader/workload.
+- Metrics captured:
+  - mean and max wall-clock seconds
+  - peak traced Python heap MiB (`tracemalloc`)
+  - analytics signature for end-to-end correctness checks
+- Synthetic defaults:
+  - `small`: 100 genes
+  - `medium`: 750 genes
+  - `large`: 3000 genes
+
+## Real Dataset Set (This Cycle)
+
+From local idiffir SpliceGrapher corpus:
+
+- `at5`: `iDiffIR/SpliceGrapher/examples/AT5G03770_model.gff`
+- `at1`: `iDiffIR/SpliceGrapher/examples/AT1G13440_model.gff`
+- `at2`: `iDiffIR/SpliceGrapher/tutorial/AT2G04700.gff`
+
+## Reproducible Command
+
+From repository root:
+
+```bash
+uv run --with polars python scripts/benchmarks/run_gff_loader_benchmarks.py \
+  --iterations 3 \
+  --synthetic-work-dir .benchmarks/gff \
+  --real-dataset at5=/Users/mikeh/repos/idiffir/iDiffIR/SpliceGrapher/examples/AT5G03770_model.gff \
+  --real-dataset at1=/Users/mikeh/repos/idiffir/iDiffIR/SpliceGrapher/examples/AT1G13440_model.gff \
+  --real-dataset at2=/Users/mikeh/repos/idiffir/iDiffIR/SpliceGrapher/tutorial/AT2G04700.gff
+```
+
+Generated artifacts:
+
+- `docs/testing/polars_gff_benchmark_results.json`
+- `docs/testing/polars_gff_benchmark_results.md`
+
+## Result (Single Cycle)
+
+Current decision: **`defer (threshold_not_met)`**
+
+- evaluated real datasets: 3
+- compared real datasets: 3
+- winning datasets: 0
+
+Observed notes:
+
+- Polars did not hit the >=20% end-to-end runtime win threshold on required real datasets.
+- For `at2`, `GeneModel` reports `No gene models found`; row and Polars paths still benchmark successfully and are compared for go/no-go decision.
+- No default path migration is recommended.
+
+## Recommendation
+
+Keep Polars path as optional helper only.
+
+- Keep `SpliceGrapher.formats.polars_gff` for analysis/experimentation.
+- Do not switch SGN default GFF loader/model path based on this cycle.
+- Re-open adoption only if a future cycle meets runtime/memory/correctness gates.

--- a/docs/testing/polars_gff_benchmark_results.json
+++ b/docs/testing/polars_gff_benchmark_results.json
@@ -1,0 +1,342 @@
+{
+  "synthetic": {
+    "small": {
+      "ingest": {
+        "gene_model": {
+          "status": "ok",
+          "rows": 500,
+          "mean_seconds": 0.01965047197882086,
+          "max_seconds": 0.02538087498396635,
+          "peak_mebibytes": 0.5528221130371094,
+          "analytics_signature": null
+        },
+        "rows": {
+          "status": "ok",
+          "rows": 500,
+          "mean_seconds": 0.0034313476644456387,
+          "max_seconds": 0.004310459014959633,
+          "peak_mebibytes": 0.4066305160522461,
+          "analytics_signature": null
+        },
+        "polars_df": {
+          "status": "ok",
+          "rows": 500,
+          "mean_seconds": 0.003964402712881565,
+          "max_seconds": 0.004979416960850358,
+          "peak_mebibytes": 0.4065847396850586,
+          "analytics_signature": null
+        }
+      },
+      "end_to_end": {
+        "gene_model": {
+          "status": "ok",
+          "rows": 300,
+          "mean_seconds": 0.018961347018678982,
+          "max_seconds": 0.019425750011578202,
+          "peak_mebibytes": 0.6449785232543945,
+          "analytics_signature": "582a38b8970acc14a4ed6fbe91c987586aa607616fb8a860159d7b3c87ab735e"
+        },
+        "rows": {
+          "status": "ok",
+          "rows": 300,
+          "mean_seconds": 0.007098138681612909,
+          "max_seconds": 0.00844112504273653,
+          "peak_mebibytes": 0.40651607513427734,
+          "analytics_signature": "582a38b8970acc14a4ed6fbe91c987586aa607616fb8a860159d7b3c87ab735e"
+        },
+        "polars_df": {
+          "status": "ok",
+          "rows": 300,
+          "mean_seconds": 0.008121041697449982,
+          "max_seconds": 0.008185458020307124,
+          "peak_mebibytes": 0.4110898971557617,
+          "analytics_signature": "582a38b8970acc14a4ed6fbe91c987586aa607616fb8a860159d7b3c87ab735e"
+        }
+      }
+    },
+    "medium": {
+      "ingest": {
+        "gene_model": {
+          "status": "ok",
+          "rows": 3750,
+          "mean_seconds": 0.13648152797638127,
+          "max_seconds": 0.14178437495138496,
+          "peak_mebibytes": 4.25760555267334,
+          "analytics_signature": null
+        },
+        "rows": {
+          "status": "ok",
+          "rows": 3750,
+          "mean_seconds": 0.02239227764463673,
+          "max_seconds": 0.022468084003776312,
+          "peak_mebibytes": 3.0058975219726562,
+          "analytics_signature": null
+        },
+        "polars_df": {
+          "status": "ok",
+          "rows": 3750,
+          "mean_seconds": 0.026144430002508063,
+          "max_seconds": 0.027002166025340557,
+          "peak_mebibytes": 3.00592041015625,
+          "analytics_signature": null
+        }
+      },
+      "end_to_end": {
+        "gene_model": {
+          "status": "ok",
+          "rows": 2250,
+          "mean_seconds": 0.15657365302710483,
+          "max_seconds": 0.17096433404367417,
+          "peak_mebibytes": 5.296962738037109,
+          "analytics_signature": "220c793f246682bab9ca01e1f62118a610fb5598486ec0037c7e7a1b06e111c1"
+        },
+        "rows": {
+          "status": "ok",
+          "rows": 2250,
+          "mean_seconds": 0.04831026401370764,
+          "max_seconds": 0.04943891707807779,
+          "peak_mebibytes": 3.0285463333129883,
+          "analytics_signature": "220c793f246682bab9ca01e1f62118a610fb5598486ec0037c7e7a1b06e111c1"
+        },
+        "polars_df": {
+          "status": "ok",
+          "rows": 2250,
+          "mean_seconds": 0.06313645831930141,
+          "max_seconds": 0.06369462492875755,
+          "peak_mebibytes": 3.2943010330200195,
+          "analytics_signature": "220c793f246682bab9ca01e1f62118a610fb5598486ec0037c7e7a1b06e111c1"
+        }
+      }
+    },
+    "large": {
+      "ingest": {
+        "gene_model": {
+          "status": "ok",
+          "rows": 15000,
+          "mean_seconds": 0.5577873469640812,
+          "max_seconds": 0.5909064579755068,
+          "peak_mebibytes": 17.282137870788574,
+          "analytics_signature": null
+        },
+        "rows": {
+          "status": "ok",
+          "rows": 15000,
+          "mean_seconds": 0.090896666670839,
+          "max_seconds": 0.09128024999517947,
+          "peak_mebibytes": 12.034989356994629,
+          "analytics_signature": null
+        },
+        "polars_df": {
+          "status": "ok",
+          "rows": 15000,
+          "mean_seconds": 0.10894900001585484,
+          "max_seconds": 0.11054487503133714,
+          "peak_mebibytes": 12.034989356994629,
+          "analytics_signature": null
+        }
+      },
+      "end_to_end": {
+        "gene_model": {
+          "status": "ok",
+          "rows": 9000,
+          "mean_seconds": 0.6609913052913422,
+          "max_seconds": 0.6797455829801038,
+          "peak_mebibytes": 22.778586387634277,
+          "analytics_signature": "c06fd61c65e95953d423e2a1a694beb14db7d5a36b9ba0541e93d5c5b4d5c3dc"
+        },
+        "rows": {
+          "status": "ok",
+          "rows": 9000,
+          "mean_seconds": 0.21792238900282732,
+          "max_seconds": 0.23326262494083494,
+          "peak_mebibytes": 12.627484321594238,
+          "analytics_signature": "c06fd61c65e95953d423e2a1a694beb14db7d5a36b9ba0541e93d5c5b4d5c3dc"
+        },
+        "polars_df": {
+          "status": "ok",
+          "rows": 9000,
+          "mean_seconds": 0.27766454200415563,
+          "max_seconds": 0.2836833340115845,
+          "peak_mebibytes": 14.20629596710205,
+          "analytics_signature": "c06fd61c65e95953d423e2a1a694beb14db7d5a36b9ba0541e93d5c5b4d5c3dc"
+        }
+      }
+    }
+  },
+  "real": {
+    "at5": {
+      "ingest": {
+        "gene_model": {
+          "status": "ok",
+          "rows": 27,
+          "mean_seconds": 0.0009563750354573131,
+          "max_seconds": 0.000974416034296155,
+          "peak_mebibytes": 0.0357208251953125,
+          "analytics_signature": null
+        },
+        "rows": {
+          "status": "ok",
+          "rows": 27,
+          "mean_seconds": 0.0001735413291802009,
+          "max_seconds": 0.00017829099670052528,
+          "peak_mebibytes": 0.03313732147216797,
+          "analytics_signature": null
+        },
+        "polars_df": {
+          "status": "ok",
+          "rows": 27,
+          "mean_seconds": 0.00022102772103001675,
+          "max_seconds": 0.00022770802024751902,
+          "peak_mebibytes": 0.03316020965576172,
+          "analytics_signature": null
+        }
+      },
+      "end_to_end": {
+        "gene_model": {
+          "status": "ok",
+          "rows": 11,
+          "mean_seconds": 0.0010901389565939705,
+          "max_seconds": 0.0010946670081466436,
+          "peak_mebibytes": 0.03590106964111328,
+          "analytics_signature": "e88fb367e4e1dadc02e855f2cfa723c82597c83602644c81a4d2f57ecdd91047"
+        },
+        "rows": {
+          "status": "ok",
+          "rows": 11,
+          "mean_seconds": 0.0003169723010311524,
+          "max_seconds": 0.0003313340712338686,
+          "peak_mebibytes": 0.03313732147216797,
+          "analytics_signature": "3b686ff65a35b2d9524a865726643561aedb768d0c4e3928bfb9427e35993191"
+        },
+        "polars_df": {
+          "status": "ok",
+          "rows": 11,
+          "mean_seconds": 0.0004798193695023656,
+          "max_seconds": 0.0004887500545009971,
+          "peak_mebibytes": 0.03316020965576172,
+          "analytics_signature": "3b686ff65a35b2d9524a865726643561aedb768d0c4e3928bfb9427e35993191"
+        }
+      }
+    },
+    "at1": {
+      "ingest": {
+        "gene_model": {
+          "status": "ok",
+          "rows": 53,
+          "mean_seconds": 0.001748249982483685,
+          "max_seconds": 0.001799750025384128,
+          "peak_mebibytes": 0.041769981384277344,
+          "analytics_signature": null
+        },
+        "rows": {
+          "status": "ok",
+          "rows": 53,
+          "mean_seconds": 0.00030058366246521473,
+          "max_seconds": 0.0003070420352742076,
+          "peak_mebibytes": 0.051474571228027344,
+          "analytics_signature": null
+        },
+        "polars_df": {
+          "status": "ok",
+          "rows": 53,
+          "mean_seconds": 0.00038112533123542863,
+          "max_seconds": 0.0003992919810116291,
+          "peak_mebibytes": 0.051497459411621094,
+          "analytics_signature": null
+        }
+      },
+      "end_to_end": {
+        "gene_model": {
+          "status": "ok",
+          "rows": 22,
+          "mean_seconds": 0.0019774440055092177,
+          "max_seconds": 0.00198937498498708,
+          "peak_mebibytes": 0.041716575622558594,
+          "analytics_signature": "95bcd319707173d36087a389a595ac4f63d24554c30b17fef7d6ff658385bde2"
+        },
+        "rows": {
+          "status": "ok",
+          "rows": 22,
+          "mean_seconds": 0.0006107920004675785,
+          "max_seconds": 0.0006365419831126928,
+          "peak_mebibytes": 0.051474571228027344,
+          "analytics_signature": "dbd95b744e282bffed21651b668ed90190ed126919b651ef3dd35b68fa45a985"
+        },
+        "polars_df": {
+          "status": "ok",
+          "rows": 22,
+          "mean_seconds": 0.0007703469988579551,
+          "max_seconds": 0.0007767500355839729,
+          "peak_mebibytes": 0.051497459411621094,
+          "analytics_signature": "dbd95b744e282bffed21651b668ed90190ed126919b651ef3dd35b68fa45a985"
+        }
+      }
+    },
+    "at2": {
+      "ingest": {
+        "gene_model": {
+          "status": "error:ValueError",
+          "rows": 8,
+          "mean_seconds": 0.0,
+          "max_seconds": 0.0,
+          "peak_mebibytes": 0.0,
+          "analytics_signature": null
+        },
+        "rows": {
+          "status": "ok",
+          "rows": 8,
+          "mean_seconds": 9.234730775157611e-05,
+          "max_seconds": 9.724998380988836e-05,
+          "peak_mebibytes": 0.020219802856445312,
+          "analytics_signature": null
+        },
+        "polars_df": {
+          "status": "ok",
+          "rows": 8,
+          "mean_seconds": 0.00012513863233228525,
+          "max_seconds": 0.00012845790479332209,
+          "peak_mebibytes": 0.020242691040039062,
+          "analytics_signature": null
+        }
+      },
+      "end_to_end": {
+        "gene_model": {
+          "status": "error:ValueError",
+          "rows": 8,
+          "mean_seconds": 0.0,
+          "max_seconds": 0.0,
+          "peak_mebibytes": 0.0,
+          "analytics_signature": null
+        },
+        "rows": {
+          "status": "ok",
+          "rows": 0,
+          "mean_seconds": 0.00010627803082267444,
+          "max_seconds": 0.00010966695845127106,
+          "peak_mebibytes": 0.020219802856445312,
+          "analytics_signature": "be754e446b70ea14ae007e250145f3c0f9200a7af1bd7e03d0eec43f393c91fe"
+        },
+        "polars_df": {
+          "status": "ok",
+          "rows": 0,
+          "mean_seconds": 0.00017112431426843008,
+          "max_seconds": 0.00017454102635383606,
+          "peak_mebibytes": 0.020219802856445312,
+          "analytics_signature": "be754e446b70ea14ae007e250145f3c0f9200a7af1bd7e03d0eec43f393c91fe"
+        }
+      }
+    }
+  },
+  "decision": {
+    "recommendation": "defer",
+    "decision": "threshold_not_met",
+    "evaluated_real_datasets": 3,
+    "compared_real_datasets": 3,
+    "winning_datasets": 0,
+    "runtime_speedup_threshold": 0.2,
+    "memory_regression_threshold": 0.1,
+    "required_real_datasets": 3,
+    "min_winning_datasets": 2,
+    "notes": "required runtime and memory win thresholds not met"
+  }
+}

--- a/docs/testing/polars_gff_benchmark_results.md
+++ b/docs/testing/polars_gff_benchmark_results.md
@@ -1,0 +1,102 @@
+# Polars GFF Single-Cycle Evaluation
+
+## Decision
+- recommendation: `defer`
+- decision: `threshold_not_met`
+- evaluated real datasets: `3`
+- compared real datasets: `3`
+- winning datasets: `0`
+- thresholds: runtime>=20%, memory<=+10%
+- notes: required runtime and memory win thresholds not met
+
+## Synthetic
+### small
+#### ingest
+| dataset | loader | status | rows | mean_s | max_s | peak_mib |
+|---|---|---:|---:|---:|---:|---:|
+| small | gene_model | ok | 500 | 0.019650 | 0.025381 | 0.553 |
+| small | rows | ok | 500 | 0.003431 | 0.004310 | 0.407 |
+| small | polars_df | ok | 500 | 0.003964 | 0.004979 | 0.407 |
+
+#### end_to_end
+| dataset | loader | status | rows | mean_s | max_s | peak_mib |
+|---|---|---:|---:|---:|---:|---:|
+| small | gene_model | ok | 300 | 0.018961 | 0.019426 | 0.645 |
+| small | rows | ok | 300 | 0.007098 | 0.008441 | 0.407 |
+| small | polars_df | ok | 300 | 0.008121 | 0.008185 | 0.411 |
+
+### medium
+#### ingest
+| dataset | loader | status | rows | mean_s | max_s | peak_mib |
+|---|---|---:|---:|---:|---:|---:|
+| medium | gene_model | ok | 3750 | 0.136482 | 0.141784 | 4.258 |
+| medium | rows | ok | 3750 | 0.022392 | 0.022468 | 3.006 |
+| medium | polars_df | ok | 3750 | 0.026144 | 0.027002 | 3.006 |
+
+#### end_to_end
+| dataset | loader | status | rows | mean_s | max_s | peak_mib |
+|---|---|---:|---:|---:|---:|---:|
+| medium | gene_model | ok | 2250 | 0.156574 | 0.170964 | 5.297 |
+| medium | rows | ok | 2250 | 0.048310 | 0.049439 | 3.029 |
+| medium | polars_df | ok | 2250 | 0.063136 | 0.063695 | 3.294 |
+
+### large
+#### ingest
+| dataset | loader | status | rows | mean_s | max_s | peak_mib |
+|---|---|---:|---:|---:|---:|---:|
+| large | gene_model | ok | 15000 | 0.557787 | 0.590906 | 17.282 |
+| large | rows | ok | 15000 | 0.090897 | 0.091280 | 12.035 |
+| large | polars_df | ok | 15000 | 0.108949 | 0.110545 | 12.035 |
+
+#### end_to_end
+| dataset | loader | status | rows | mean_s | max_s | peak_mib |
+|---|---|---:|---:|---:|---:|---:|
+| large | gene_model | ok | 9000 | 0.660991 | 0.679746 | 22.779 |
+| large | rows | ok | 9000 | 0.217922 | 0.233263 | 12.627 |
+| large | polars_df | ok | 9000 | 0.277665 | 0.283683 | 14.206 |
+
+## Real
+### at5
+#### ingest
+| dataset | loader | status | rows | mean_s | max_s | peak_mib |
+|---|---|---:|---:|---:|---:|---:|
+| at5 | gene_model | ok | 27 | 0.000956 | 0.000974 | 0.036 |
+| at5 | rows | ok | 27 | 0.000174 | 0.000178 | 0.033 |
+| at5 | polars_df | ok | 27 | 0.000221 | 0.000228 | 0.033 |
+
+#### end_to_end
+| dataset | loader | status | rows | mean_s | max_s | peak_mib |
+|---|---|---:|---:|---:|---:|---:|
+| at5 | gene_model | ok | 11 | 0.001090 | 0.001095 | 0.036 |
+| at5 | rows | ok | 11 | 0.000317 | 0.000331 | 0.033 |
+| at5 | polars_df | ok | 11 | 0.000480 | 0.000489 | 0.033 |
+
+### at1
+#### ingest
+| dataset | loader | status | rows | mean_s | max_s | peak_mib |
+|---|---|---:|---:|---:|---:|---:|
+| at1 | gene_model | ok | 53 | 0.001748 | 0.001800 | 0.042 |
+| at1 | rows | ok | 53 | 0.000301 | 0.000307 | 0.051 |
+| at1 | polars_df | ok | 53 | 0.000381 | 0.000399 | 0.051 |
+
+#### end_to_end
+| dataset | loader | status | rows | mean_s | max_s | peak_mib |
+|---|---|---:|---:|---:|---:|---:|
+| at1 | gene_model | ok | 22 | 0.001977 | 0.001989 | 0.042 |
+| at1 | rows | ok | 22 | 0.000611 | 0.000637 | 0.051 |
+| at1 | polars_df | ok | 22 | 0.000770 | 0.000777 | 0.051 |
+
+### at2
+#### ingest
+| dataset | loader | status | rows | mean_s | max_s | peak_mib |
+|---|---|---:|---:|---:|---:|---:|
+| at2 | gene_model | error:ValueError | 8 | 0.000000 | 0.000000 | 0.000 |
+| at2 | rows | ok | 8 | 0.000092 | 0.000097 | 0.020 |
+| at2 | polars_df | ok | 8 | 0.000125 | 0.000128 | 0.020 |
+
+#### end_to_end
+| dataset | loader | status | rows | mean_s | max_s | peak_mib |
+|---|---|---:|---:|---:|---:|---:|
+| at2 | gene_model | error:ValueError | 8 | 0.000000 | 0.000000 | 0.000 |
+| at2 | rows | ok | 0 | 0.000106 | 0.000110 | 0.020 |
+| at2 | polars_df | ok | 0 | 0.000171 | 0.000175 | 0.020 |

--- a/scripts/benchmarks/run_gff_loader_benchmarks.py
+++ b/scripts/benchmarks/run_gff_loader_benchmarks.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Run reproducible benchmark comparisons for GFF loaders."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from SpliceGrapher.formats.polars_gff_benchmark import (
+    DEFAULT_DATASET_SIZES,
+    REQUIRED_REAL_DATASETS,
+    evaluation_to_json_dict,
+    evaluation_to_markdown,
+    run_single_cycle_evaluation,
+)
+
+
+def _parse_sizes(raw_values: list[str] | None) -> dict[str, int]:
+    if not raw_values:
+        return dict(DEFAULT_DATASET_SIZES)
+
+    result: dict[str, int] = {}
+    for value in raw_values:
+        if "=" not in value:
+            raise ValueError(f"Invalid --size value '{value}'; expected label=count")
+
+        label, raw_count = value.split("=", 1)
+        label = label.strip()
+        if not label:
+            raise ValueError("Dataset label cannot be empty")
+
+        count = int(raw_count)
+        if count <= 0:
+            raise ValueError("Dataset gene count must be >= 1")
+
+        result[label] = count
+
+    return result
+
+
+def _parse_real_datasets(raw_values: list[str]) -> dict[str, Path]:
+    result: dict[str, Path] = {}
+    for value in raw_values:
+        if "=" not in value:
+            raise ValueError(
+                f"Invalid --real-dataset value '{value}'; expected label=/path/to/file.gff3"
+            )
+
+        label, raw_path = value.split("=", 1)
+        label = label.strip()
+        if not label:
+            raise ValueError("Real dataset label cannot be empty")
+
+        path = Path(raw_path).expanduser()
+        if not path.is_file():
+            raise FileNotFoundError(f"Real dataset file not found: {path}")
+
+        result[label] = path
+
+    if len(result) < REQUIRED_REAL_DATASETS:
+        raise ValueError(
+            f"At least {REQUIRED_REAL_DATASETS} real datasets are required "
+            "for final go/no-go decision"
+        )
+
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--synthetic-work-dir",
+        type=Path,
+        default=Path(".benchmarks") / "gff",
+        help="Synthetic fixture output directory.",
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=3,
+        help="Number of benchmark repetitions per loader/workload.",
+    )
+    parser.add_argument(
+        "--exons-per-gene",
+        type=int,
+        default=3,
+        help="Synthetic exon count per transcript.",
+    )
+    parser.add_argument(
+        "--size",
+        action="append",
+        default=None,
+        help="Synthetic dataset override as label=count; may be passed multiple times.",
+    )
+    parser.add_argument(
+        "--real-dataset",
+        action="append",
+        default=[],
+        help="Real dataset input as label=/absolute/or/relative/path.gff[3].",
+    )
+    parser.add_argument(
+        "--skip-polars",
+        action="store_true",
+        help="Skip polars dataframe loader benchmark even if polars is installed.",
+    )
+    parser.add_argument(
+        "--json-out",
+        type=Path,
+        default=Path("docs") / "testing" / "polars_gff_benchmark_results.json",
+        help="JSON output file.",
+    )
+    parser.add_argument(
+        "--markdown-out",
+        type=Path,
+        default=Path("docs") / "testing" / "polars_gff_benchmark_results.md",
+        help="Markdown output file.",
+    )
+    args = parser.parse_args()
+
+    sizes = _parse_sizes(args.size)
+    real_datasets = _parse_real_datasets(args.real_dataset)
+
+    evaluation = run_single_cycle_evaluation(
+        synthetic_work_dir=args.synthetic_work_dir,
+        real_datasets=real_datasets,
+        synthetic_dataset_sizes=sizes,
+        exons_per_gene=args.exons_per_gene,
+        iterations=args.iterations,
+        include_polars=not args.skip_polars,
+    )
+
+    args.json_out.parent.mkdir(parents=True, exist_ok=True)
+    args.json_out.write_text(
+        json.dumps(evaluation_to_json_dict(evaluation), indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    args.markdown_out.parent.mkdir(parents=True, exist_ok=True)
+    args.markdown_out.write_text(
+        evaluation_to_markdown(evaluation) + "\n",
+        encoding="utf-8",
+    )
+
+    sys.stderr.write(f"Wrote JSON benchmark report: {args.json_out}\n")
+    sys.stderr.write(f"Wrote markdown benchmark report: {args.markdown_out}\n")
+    sys.stderr.write(
+        f"Decision: {evaluation.decision.recommendation} ({evaluation.decision.decision})\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_polars_gff_benchmark.py
+++ b/tests/test_polars_gff_benchmark.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from SpliceGrapher.formats import polars_gff
+from SpliceGrapher.formats import polars_gff_benchmark as benchmark
+
+
+def test_write_synthetic_gff_generates_expected_record_count(tmp_path: Path) -> None:
+    gff_path = tmp_path / "synthetic.gff3"
+    row_count = benchmark.write_synthetic_gff(gff_path, gene_count=3, exons_per_gene=2)
+
+    # per gene: gene + mrna + exons
+    assert row_count == 3 * (1 + 1 + 2)
+
+    rows = polars_gff.load_gff_rows(gff_path)
+    assert len(rows) == row_count
+    assert rows[0]["type"] == "gene"
+    assert rows[1]["type"] == "mrna"
+
+
+def test_benchmark_gff_path_without_polars_returns_core_loaders(tmp_path: Path) -> None:
+    gff_path = tmp_path / "sample.gff3"
+    benchmark.write_synthetic_gff(gff_path, gene_count=2, exons_per_gene=2)
+
+    results = benchmark.benchmark_gff_path(gff_path, iterations=1, include_polars=False)
+
+    assert set(results.keys()) == {"gene_model", "rows"}
+    assert results["gene_model"].status == "ok"
+    assert results["rows"].status == "ok"
+
+
+def test_benchmark_matrix_marks_polars_unavailable(tmp_path: Path, monkeypatch) -> None:
+    def _raise_missing(path: str | Path, *, ignore_malformed: bool = False):
+        raise polars_gff.PolarsNotInstalledError("missing")
+
+    monkeypatch.setattr(benchmark, "load_gff_to_polars", _raise_missing)
+
+    matrix = benchmark.benchmark_matrix(
+        tmp_path,
+        dataset_sizes={"tiny": 2},
+        exons_per_gene=2,
+        iterations=1,
+        include_polars=True,
+    )
+
+    tiny = matrix["tiny"]
+    assert tiny["polars_df"].status == "unavailable"
+    assert tiny["gene_model"].status == "ok"
+    assert tiny["rows"].status == "ok"
+
+
+def test_end_to_end_benchmark_exposes_analytics_signature(tmp_path: Path) -> None:
+    gff_path = tmp_path / "sample.gff3"
+    benchmark.write_synthetic_gff(gff_path, gene_count=3, exons_per_gene=2)
+
+    results = benchmark.benchmark_end_to_end_gff_path(
+        gff_path,
+        iterations=1,
+        include_polars=False,
+    )
+
+    assert set(results.keys()) == {"gene_model", "rows"}
+    assert results["gene_model"].analytics_signature is not None
+    assert results["rows"].analytics_signature is not None
+    assert results["gene_model"].analytics_signature == results["rows"].analytics_signature
+
+
+def test_go_no_go_requires_three_real_datasets() -> None:
+    metrics = benchmark.BenchmarkMetrics(
+        mean_seconds=0.1,
+        max_seconds=0.1,
+        peak_mebibytes=1.0,
+        rows=100,
+        status="ok",
+        analytics_signature="abc123",
+    )
+    real_results = {
+        "real1": {"rows": metrics, "polars_df": metrics},
+        "real2": {"rows": metrics, "polars_df": metrics},
+    }
+
+    decision = benchmark.evaluate_go_no_go(real_results)
+    assert decision.recommendation == "defer"
+    assert decision.decision == "insufficient_data"
+
+
+def test_evaluation_json_contains_decision_and_two_classes(tmp_path: Path) -> None:
+    gff_path = tmp_path / "real.gff3"
+    benchmark.write_synthetic_gff(gff_path, gene_count=2, exons_per_gene=2)
+
+    evaluation = benchmark.run_single_cycle_evaluation(
+        synthetic_work_dir=tmp_path / "synthetic",
+        real_datasets={"realA": gff_path, "realB": gff_path, "realC": gff_path},
+        synthetic_dataset_sizes={"small": 2},
+        exons_per_gene=2,
+        iterations=1,
+        include_polars=False,
+    )
+
+    payload = benchmark.evaluation_to_json_dict(evaluation)
+    assert set(payload.keys()) == {"synthetic", "real", "decision"}
+    assert set(payload["synthetic"]["small"].keys()) == {"ingest", "end_to_end"}
+    assert set(payload["real"]["realA"].keys()) == {"ingest", "end_to_end"}
+    assert isinstance(payload["decision"]["recommendation"], str)
+    # Ensure payload is cleanly serializable for report emission.
+    json.dumps(payload)

--- a/tests/test_polars_gff_benchmark_runner.py
+++ b/tests/test_polars_gff_benchmark_runner.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from SpliceGrapher.formats.polars_gff_benchmark import write_synthetic_gff
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _script_path() -> Path:
+    return _repo_root() / "scripts" / "benchmarks" / "run_gff_loader_benchmarks.py"
+
+
+def _create_real_dataset_files(tmp_path: Path, *, count: int) -> list[Path]:
+    result: list[Path] = []
+    for idx in range(1, count + 1):
+        path = tmp_path / f"real{idx}.gff3"
+        write_synthetic_gff(path, gene_count=idx + 1, exons_per_gene=2)
+        result.append(path)
+    return result
+
+
+def test_runner_writes_outputs_with_skip_polars(tmp_path: Path) -> None:
+    script = _script_path()
+    synthetic_dir = tmp_path / "synthetic"
+    json_out = tmp_path / "result.json"
+    markdown_out = tmp_path / "result.md"
+    real_paths = _create_real_dataset_files(tmp_path, count=3)
+
+    cmd = [
+        sys.executable,
+        str(script),
+        "--iterations",
+        "1",
+        "--synthetic-work-dir",
+        str(synthetic_dir),
+        "--size",
+        "small=2",
+        "--skip-polars",
+        "--json-out",
+        str(json_out),
+        "--markdown-out",
+        str(markdown_out),
+    ]
+    for idx, path in enumerate(real_paths, start=1):
+        cmd.extend(["--real-dataset", f"real{idx}={path}"])
+
+    result = subprocess.run(
+        cmd,
+        cwd=_repo_root(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert json_out.is_file()
+    assert markdown_out.is_file()
+
+    payload = json.loads(json_out.read_text(encoding="utf-8"))
+    assert payload["decision"]["recommendation"] == "defer"
+    assert payload["decision"]["decision"] == "insufficient_data"
+    assert "Decision: defer (insufficient_data)" in result.stderr
+
+
+def test_runner_rejects_less_than_three_real_datasets(tmp_path: Path) -> None:
+    script = _script_path()
+    real_paths = _create_real_dataset_files(tmp_path, count=2)
+
+    cmd = [
+        sys.executable,
+        str(script),
+        "--iterations",
+        "1",
+        "--synthetic-work-dir",
+        str(tmp_path / "synthetic"),
+        "--size",
+        "small=2",
+        "--skip-polars",
+        "--json-out",
+        str(tmp_path / "result.json"),
+        "--markdown-out",
+        str(tmp_path / "result.md"),
+    ]
+    for idx, path in enumerate(real_paths, start=1):
+        cmd.extend(["--real-dataset", f"real{idx}={path}"])
+
+    result = subprocess.run(
+        cmd,
+        cwd=_repo_root(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "At least 3 real datasets are required" in result.stderr


### PR DESCRIPTION
Closes #94

## Summary
- add single-cycle benchmark core for optional Polars GFF evaluation in `SpliceGrapher/formats/polars_gff_benchmark.py`
- benchmark both classes across loaders:
  - ingest microbenchmark
  - end-to-end analytics workload (shared exon grouping, transcript/exon aggregation, donor/acceptor-style derivations)
- add explicit go/no-go decision engine with fixed policy thresholds:
  - runtime >=20% win on >=2/3 real datasets
  - memory <=+10% on winners
  - no correctness drift via analytics signatures
- add reproducible CLI runner in `scripts/benchmarks/run_gff_loader_benchmarks.py` with required real-dataset inputs
- add focused tests:
  - `tests/test_polars_gff_benchmark.py`
  - `tests/test_polars_gff_benchmark_runner.py`
- publish results + report docs:
  - `docs/testing/polars_gff_benchmark_results.json`
  - `docs/testing/polars_gff_benchmark_results.md`
  - `docs/testing/polars-gff-benchmark.md`

## Decision outcome (this cycle)
- recommendation: `defer`
- decision: `threshold_not_met`
- compared real datasets: `3`
- winning datasets: `0`

This keeps Polars as optional analysis helper only; no default parser/model-path migration.

## Verification
- `uv run pytest -q tests/test_polars_gff_benchmark.py tests/test_polars_gff_benchmark_runner.py`
- `uv run pytest -q`
- `uv run ruff check .`
- `uv run ruff format --check .`
- benchmark run:
  - `uv run --with polars python scripts/benchmarks/run_gff_loader_benchmarks.py --iterations 3 --synthetic-work-dir .benchmarks/gff --real-dataset at5=/Users/mikeh/repos/idiffir/iDiffIR/SpliceGrapher/examples/AT5G03770_model.gff --real-dataset at1=/Users/mikeh/repos/idiffir/iDiffIR/SpliceGrapher/examples/AT1G13440_model.gff --real-dataset at2=/Users/mikeh/repos/idiffir/iDiffIR/SpliceGrapher/tutorial/AT2G04700.gff`
