### PR TITLE
Enforce enum coercion at polars_gff parser ingress

### DIFF
--- a/SpliceGrapher/formats/polars_gff.py
+++ b/SpliceGrapher/formats/polars_gff.py
@@ -7,6 +7,9 @@ from collections.abc import Iterable, Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from SpliceGrapher.core.enum_coercion import coerce_enum
+from SpliceGrapher.core.enums import RecordType, Strand
+
 if TYPE_CHECKING:
     import polars as pl
 
@@ -22,6 +25,8 @@ _GFF_COLUMNS = (
     "phase",
     "attributes",
 )
+
+_RECORD_TYPE_BY_CASEFOLD = {record_type.value.casefold(): record_type for record_type in RecordType}
 
 
 class PolarsNotInstalledError(ImportError):
@@ -63,21 +68,31 @@ def _row_from_parts(parts: list[str]) -> dict[str, str | int | None]:
         raise ValueError("start/end must be integers") from exc
 
     attributes = parse_gff_attributes(parts[8])
+    record_type = _coerce_record_type(parts[2])
+    strand = coerce_enum(parts[6], Strand, field="strand")
 
     return {
         "chrom": parts[0],
         "source": parts[1],
-        "type": parts[2],
+        "type": record_type,
         "start": start,
         "end": end,
         "score": parts[5],
-        "strand": parts[6],
+        "strand": strand,
         "phase": parts[7],
         "attributes": parts[8],
         "feature_id": attributes.get("ID"),
         "parent_id": attributes.get("Parent"),
         "name": attributes.get("Name"),
     }
+
+
+def _coerce_record_type(value: str) -> RecordType:
+    normalized = value.strip()
+    try:
+        return _RECORD_TYPE_BY_CASEFOLD[normalized.casefold()]
+    except KeyError:
+        return coerce_enum(normalized, RecordType, field="record_type")
 
 
 def iter_gff_records(

--- a/tests/test_polars_gff.py
+++ b/tests/test_polars_gff.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 import SpliceGrapher.formats.polars_gff as polars_gff
+from SpliceGrapher.core.enums import RecordType, Strand
 
 
 def test_parse_gff_attributes_ignores_malformed_tokens_and_splits_once() -> None:
@@ -61,3 +62,34 @@ def test_load_gff_to_polars_raises_without_polars(monkeypatch, tmp_path: Path) -
 
     with pytest.raises(polars_gff.PolarsNotInstalledError):
         polars_gff.load_gff_to_polars(gff_path)
+
+
+def test_iter_gff_records_normalizes_record_type_and_strand_domains() -> None:
+    records = list(
+        polars_gff.iter_gff_records(
+            [
+                "chr1\tsource\tmRNA\t1\t10\t.\t+\t.\tID=TX1;Parent=GENE1\n",
+            ]
+        )
+    )
+
+    assert records[0]["type"] == RecordType.MRNA
+    assert records[0]["strand"] == Strand.PLUS
+
+
+def test_iter_gff_records_rejects_unknown_record_type() -> None:
+    with pytest.raises(ValueError, match="line 1: .*record_type"):
+        list(
+            polars_gff.iter_gff_records(
+                ["chr1\tsource\tunknown_type\t1\t10\t.\t+\t.\tID=TX1;Parent=GENE1\n"]
+            )
+        )
+
+
+def test_iter_gff_records_rejects_unknown_strand() -> None:
+    with pytest.raises(ValueError, match="line 1: .*strand"):
+        list(
+            polars_gff.iter_gff_records(
+                ["chr1\tsource\tgene\t1\t10\t.\t?\t.\tID=GENE1;Name=GENE1\n"]
+            )
+        )


### PR DESCRIPTION
## Summary
- coerce GFF record type and strand at parser ingress in polars_gff
- normalize record types case-insensitively to canonical RecordType members
- reject unknown record/strand values with explicit ValueError at line boundary
- add tests for normalization and invalid-value rejection

## Validation
- uv run ruff check .
- uv run ruff format --check .
- uv run pytest -q tests/test_polars_gff.py tests/test_annotation_io.py
- uv run mypy SpliceGrapher/formats/polars_gff.py tests/test_polars_gff.py

Closes #109
Refs #103