### PR TITLE
Add GenomicInterval value object and interval protocol

### DIFF
--- a/SpliceGrapher/core/__init__.py
+++ b/SpliceGrapher/core/__init__.py
@@ -2,10 +2,13 @@
 
 from SpliceGrapher.core.enum_coercion import coerce_enum
 from SpliceGrapher.core.enums import AttrKey, EdgeType, NodeDisposition, RecordType, Strand
+from SpliceGrapher.core.types import GenomicInterval, IntervalCoordinates
 
 __all__ = [
     "AttrKey",
     "EdgeType",
+    "GenomicInterval",
+    "IntervalCoordinates",
     "NodeDisposition",
     "RecordType",
     "Strand",

--- a/SpliceGrapher/core/types.py
+++ b/SpliceGrapher/core/types.py
@@ -1,0 +1,98 @@
+"""Typed interval value objects and protocols shared across SpliceGrapher."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+from SpliceGrapher.core.enum_coercion import coerce_enum
+from SpliceGrapher.core.enums import Strand
+
+
+@runtime_checkable
+class IntervalCoordinates(Protocol):
+    """Protocol contract for overlap-capable coordinate objects."""
+
+    @property
+    def chromosome(self) -> str: ...
+
+    @property
+    def minpos(self) -> int: ...
+
+    @property
+    def maxpos(self) -> int: ...
+
+    @property
+    def strand(self) -> Strand | str: ...
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class GenomicInterval:
+    """Immutable, ordered interval value object."""
+
+    chromosome: str
+    start: int
+    end: int
+    strand: Strand = Strand.UNKNOWN
+
+    def __post_init__(self) -> None:
+        chromosome = self.chromosome.strip()
+        if not chromosome:
+            raise ValueError("chromosome must be non-empty")
+        if self.start < 1 or self.end < 1:
+            raise ValueError("interval coordinates must be >= 1")
+        if self.start > self.end:
+            raise ValueError("interval start must be <= end")
+
+        object.__setattr__(self, "chromosome", chromosome)
+        object.__setattr__(self, "strand", coerce_enum(self.strand, Strand, field="strand"))
+
+    @classmethod
+    def from_raw(
+        cls,
+        chromosome: str,
+        start: int,
+        end: int,
+        strand: Strand | str = Strand.UNKNOWN,
+    ) -> GenomicInterval:
+        """Create an interval from raw parser-style values."""
+        return cls(
+            chromosome=chromosome,
+            start=start,
+            end=end,
+            strand=coerce_enum(strand, Strand, field="strand"),
+        )
+
+    @classmethod
+    def from_interval(cls, interval: IntervalCoordinates) -> GenomicInterval:
+        """Create a value object from any protocol-compatible interval."""
+        return cls.from_raw(
+            chromosome=interval.chromosome,
+            start=interval.minpos,
+            end=interval.maxpos,
+            strand=interval.strand,
+        )
+
+    @property
+    def minpos(self) -> int:
+        return self.start
+
+    @property
+    def maxpos(self) -> int:
+        return self.end
+
+    def overlaps(self, other: IntervalCoordinates) -> bool:
+        if self.chromosome != other.chromosome:
+            return False
+        return self.minpos <= other.maxpos and other.minpos <= self.maxpos
+
+    def contains(self, other: IntervalCoordinates) -> bool:
+        if self.chromosome != other.chromosome:
+            return False
+        return self.minpos <= other.minpos and self.maxpos >= other.maxpos
+
+    def __len__(self) -> int:
+        return self.maxpos - self.minpos + 1
+
+
+__all__ = ["GenomicInterval", "IntervalCoordinates"]

--- a/tests/test_core_types.py
+++ b/tests/test_core_types.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from SpliceGrapher.core.enums import Strand
+from SpliceGrapher.core.types import GenomicInterval, IntervalCoordinates
+
+
+@dataclass(slots=True)
+class _LegacyInterval:
+    chromosome: str
+    minpos: int
+    maxpos: int
+    strand: str
+
+
+def test_genomic_interval_orders_and_compares_as_value_object() -> None:
+    left = GenomicInterval.from_raw("chr1", 5, 10, "+")
+    right = GenomicInterval.from_raw("chr1", 11, 20, "+")
+    same_as_left = GenomicInterval.from_raw("chr1", 5, 10, "+")
+
+    assert left < right
+    assert left == same_as_left
+    assert len({left, same_as_left, right}) == 2
+
+
+def test_genomic_interval_rejects_invalid_coordinates() -> None:
+    with pytest.raises(ValueError, match=">= 1"):
+        GenomicInterval.from_raw("chr1", 0, 10, "+")
+    with pytest.raises(ValueError, match="start must be <= end"):
+        GenomicInterval.from_raw("chr1", 11, 10, "+")
+
+
+def test_genomic_interval_rejects_invalid_strand() -> None:
+    with pytest.raises(ValueError, match="strand"):
+        GenomicInterval.from_raw("chr1", 1, 10, "?")
+
+
+def test_genomic_interval_interval_operations() -> None:
+    parent = GenomicInterval.from_raw("chr1", 1, 20, Strand.PLUS)
+    child = GenomicInterval.from_raw("chr1", 5, 10, Strand.PLUS)
+    disjoint = GenomicInterval.from_raw("chr1", 21, 30, Strand.PLUS)
+
+    assert parent.contains(child)
+    assert parent.overlaps(child)
+    assert not parent.overlaps(disjoint)
+
+
+def test_genomic_interval_accepts_protocol_compatible_inputs() -> None:
+    legacy = _LegacyInterval(chromosome="chr2", minpos=3, maxpos=8, strand="+")
+
+    assert isinstance(legacy, IntervalCoordinates)
+
+    interval = GenomicInterval.from_interval(legacy)
+    assert interval.chromosome == "chr2"
+    assert interval.minpos == 3
+    assert interval.maxpos == 8
+    assert interval.strand is Strand.PLUS


### PR DESCRIPTION
## Summary
- add `SpliceGrapher/core/types.py` with `GenomicInterval` as a slotted, ordered dataclass value object
- add `IntervalCoordinates` protocol contract for overlap-capable coordinate objects
- include conversion helpers (`from_raw`, `from_interval`) and interval operations (`overlaps`, `contains`)
- export new interval types via `SpliceGrapher.core`
- add unit coverage for ordering/equality/invariants/protocol compatibility

## Validation
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy SpliceGrapher/core/types.py tests/test_core_types.py`
- `uv run pytest -q tests/test_core_types.py tests/test_core_enums.py tests/test_annotation_io.py tests/test_gene_model.py`

Closes #108
Refs #103