### PR TITLE
Add interval overlap helpers and migrate core call sites

### DIFF
--- a/SpliceGrapher/SpliceGraph.py
+++ b/SpliceGrapher/SpliceGraph.py
@@ -6,6 +6,7 @@ import sys
 
 from SpliceGrapher.core.enum_coercion import coerce_enum
 from SpliceGrapher.core.enums import AttrKey, EdgeType, NodeDisposition, RecordType, Strand
+from SpliceGrapher.core.interval_helpers import interval_contains, intervals_overlap
 from SpliceGrapher.shared.collection_utils import as_list
 from SpliceGrapher.shared.file_utils import ez_open
 from SpliceGrapher.shared.format_utils import list_string
@@ -120,13 +121,13 @@ def acceptor(node):
 def containsEdge(node, edge):
     """Returns true if the Node contains the given Edge; false otherwise.  Note
     that the edge must be completely contained within the node (<,>)."""
-    return node.minpos < edge.minpos and edge.maxpos < node.maxpos
+    return interval_contains(node, edge, strict=True)
 
 
 def containsNode(edge, node):
     """Returns true if the Edge contains the given Node; false otherwise.  Note
     that the node must be completely contained within the edge (<,>)."""
-    return edge.minpos < node.minpos and node.maxpos < edge.maxpos
+    return interval_contains(edge, node, strict=True)
 
 
 def childEdges(n):
@@ -157,7 +158,7 @@ def intronSet(G):
 
 def overlap(a, b):
     """Returns true if the two nodes overlap and are distinct; false otherwise."""
-    return a.id != b.id and a.maxpos > b.minpos and a.minpos < b.maxpos
+    return a.id != b.id and intervals_overlap(a, b, inclusive=False)
 
 
 def overlapsAll(A, nodeList):

--- a/SpliceGrapher/core/__init__.py
+++ b/SpliceGrapher/core/__init__.py
@@ -2,15 +2,27 @@
 
 from SpliceGrapher.core.enum_coercion import coerce_enum
 from SpliceGrapher.core.enums import AttrKey, EdgeType, NodeDisposition, RecordType, Strand
+from SpliceGrapher.core.interval_helpers import (
+    InMemoryIntervalIndex,
+    IntervalBounds,
+    batch_overlaps,
+    interval_contains,
+    intervals_overlap,
+)
 from SpliceGrapher.core.types import GenomicInterval, IntervalCoordinates
 
 __all__ = [
     "AttrKey",
     "EdgeType",
     "GenomicInterval",
+    "InMemoryIntervalIndex",
+    "IntervalBounds",
     "IntervalCoordinates",
     "NodeDisposition",
     "RecordType",
     "Strand",
+    "batch_overlaps",
     "coerce_enum",
+    "interval_contains",
+    "intervals_overlap",
 ]

--- a/SpliceGrapher/core/interval_helpers.py
+++ b/SpliceGrapher/core/interval_helpers.py
@@ -1,0 +1,136 @@
+"""Reusable interval overlap helpers and in-memory indexing utilities."""
+
+from __future__ import annotations
+
+import bisect
+from collections.abc import Iterable, Sequence
+from typing import Protocol, TypeVar, overload, runtime_checkable
+
+
+@runtime_checkable
+class IntervalBounds(Protocol):
+    """Protocol for objects exposing interval start/end bounds."""
+
+    @property
+    def minpos(self) -> int: ...
+
+    @property
+    def maxpos(self) -> int: ...
+
+
+_IntervalT = TypeVar("_IntervalT", bound=IntervalBounds)
+
+
+def intervals_overlap(
+    left: IntervalBounds,
+    right: IntervalBounds,
+    *,
+    inclusive: bool = True,
+) -> bool:
+    """Return True when two interval bounds overlap."""
+    if inclusive:
+        return left.minpos <= right.maxpos and right.minpos <= left.maxpos
+    return left.minpos < right.maxpos and right.minpos < left.maxpos
+
+
+def interval_contains(
+    container: IntervalBounds,
+    candidate: IntervalBounds,
+    *,
+    strict: bool = False,
+) -> bool:
+    """Return True when ``container`` fully contains ``candidate``."""
+    if strict:
+        return container.minpos < candidate.minpos and container.maxpos > candidate.maxpos
+    return container.minpos <= candidate.minpos and container.maxpos >= candidate.maxpos
+
+
+class InMemoryIntervalIndex(Sequence[_IntervalT]):
+    """Bisect-backed in-memory interval index over a sorted interval list."""
+
+    def __init__(self, intervals: Sequence[_IntervalT]):
+        if not intervals:
+            raise ValueError("Cannot index an empty interval list")
+
+        self._intervals = tuple(intervals)
+        self._starts = tuple(interval.minpos for interval in self._intervals)
+
+    @overload
+    def __getitem__(self, index: int) -> _IntervalT: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> Sequence[_IntervalT]: ...
+
+    def __getitem__(self, index: int | slice) -> _IntervalT | Sequence[_IntervalT]:
+        return self._intervals[index]
+
+    def __len__(self) -> int:
+        return len(self._intervals)
+
+    def predecessor_or_containing(
+        self,
+        query: IntervalBounds,
+        *,
+        lo: int = 0,
+        hi: int | None = None,
+        overlap_window: int = 8,
+    ) -> _IntervalT:
+        """Return an interval that contains ``query`` or its immediate predecessor."""
+        if hi is None:
+            hi = len(self._intervals) - 1
+
+        lo = max(0, lo)
+        hi = min(hi, len(self._intervals) - 1)
+        if lo > hi:
+            raise ValueError("Invalid search bounds")
+
+        idx = bisect.bisect_left(self._starts, query.minpos, lo=lo, hi=hi + 1)
+
+        left = max(lo, idx - overlap_window)
+        right = min(hi, idx + overlap_window)
+        for i in range(left, right + 1):
+            if interval_contains(self._intervals[i], query):
+                return self._intervals[i]
+
+        pred_idx = idx - 1
+        if pred_idx < lo:
+            return self._intervals[lo]
+        if pred_idx > hi:
+            return self._intervals[hi]
+        return self._intervals[pred_idx]
+
+    def overlaps(
+        self,
+        query: IntervalBounds,
+        *,
+        inclusive: bool = True,
+    ) -> list[_IntervalT]:
+        """Return all indexed intervals that overlap ``query``."""
+        idx = bisect.bisect_left(self._starts, query.minpos)
+        scan_start = max(0, idx - 1)
+        result: list[_IntervalT] = []
+        for interval in self._intervals[scan_start:]:
+            if interval.minpos > query.maxpos:
+                break
+            if intervals_overlap(interval, query, inclusive=inclusive):
+                result.append(interval)
+        return result
+
+
+def batch_overlaps(
+    index: InMemoryIntervalIndex[_IntervalT],
+    queries: Iterable[IntervalBounds],
+    *,
+    inclusive: bool = True,
+) -> list[list[_IntervalT]]:
+    """Bulk-overlap hook over a shared in-memory index."""
+    return [index.overlaps(query, inclusive=inclusive) for query in queries]
+
+
+__all__ = [
+    "InMemoryIntervalIndex",
+    "IntervalBounds",
+    "batch_overlaps",
+    "interval_contains",
+    "intervals_overlap",
+]

--- a/SpliceGrapher/formats/GeneModel.py
+++ b/SpliceGrapher/formats/GeneModel.py
@@ -6,13 +6,17 @@ file and provides methods for searching on the data.
 from __future__ import annotations
 
 # TRYING A NEW WAY TO IDENTIFY GENES:
-import bisect
 import os
 import sys
 from urllib.parse import unquote
 
 from SpliceGrapher.core.enum_coercion import coerce_enum
 from SpliceGrapher.core.enums import AttrKey, RecordType, Strand
+from SpliceGrapher.core.interval_helpers import (
+    InMemoryIntervalIndex,
+    interval_contains,
+    intervals_overlap,
+)
 from SpliceGrapher.shared.file_utils import ez_open
 from SpliceGrapher.shared.format_utils import comma_format
 from SpliceGrapher.shared.process_utils import getAttribute
@@ -195,7 +199,7 @@ def featureOverlaps(a, b):
     """
     if not (a and b):
         return False
-    return a.minpos <= b.minpos <= a.maxpos or b.minpos <= a.minpos <= b.maxpos
+    return intervals_overlap(a, b)
 
 
 def featureContains(a, b):
@@ -206,7 +210,7 @@ def featureContains(a, b):
     """
     if not (a and b):
         return False
-    return a.minpos <= b.minpos and a.maxpos >= b.maxpos
+    return interval_contains(a, b)
 
 
 def feature_search(features, query, lo=0, hi=None, overlap_window=8):
@@ -227,21 +231,13 @@ def feature_search(features, query, lo=0, hi=None, overlap_window=8):
     if lo > hi:
         raise ValueError("Invalid search bounds")
 
-    starts = [f.minpos for f in features]
-    idx = bisect.bisect_left(starts, query.minpos, lo=lo, hi=hi + 1)
-
-    left = max(lo, idx - overlap_window)
-    right = min(hi, idx + overlap_window)
-    for i in range(left, right + 1):
-        if featureContains(features[i], query):
-            return features[i]
-
-    pred_idx = idx - 1
-    if pred_idx < lo:
-        return features[lo]
-    if pred_idx > hi:
-        return features[hi]
-    return features[pred_idx]
+    index = InMemoryIntervalIndex(features)
+    return index.predecessor_or_containing(
+        query,
+        lo=lo,
+        hi=hi,
+        overlap_window=overlap_window,
+    )
 
 
 def featureSearch(features, query, lo=0, hi=None):

--- a/tests/test_gene_model.py
+++ b/tests/test_gene_model.py
@@ -42,6 +42,16 @@ def test_feature_search_snake_case_api_returns_expected_match() -> None:
     assert feature_search(features, query) is features[1]
 
 
+def test_feature_overlap_and_contains_match_interval_helper_semantics() -> None:
+    left = Exon(10, 20, "chr1", "+")
+    right = Exon(20, 30, "chr1", "+")
+    nested = Exon(12, 18, "chr1", "+")
+
+    assert gm.featureOverlaps(left, right)
+    assert gm.featureContains(left, nested)
+    assert not gm.featureContains(left, right)
+
+
 def test_feature_search_returns_preceding_feature_when_not_contained() -> None:
     features = [
         Exon(1, 10, "chr1", "+"),

--- a/tests/test_interval_helpers.py
+++ b/tests/test_interval_helpers.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from SpliceGrapher.core.interval_helpers import (
+    InMemoryIntervalIndex,
+    batch_overlaps,
+    interval_contains,
+    intervals_overlap,
+)
+
+
+@dataclass(slots=True)
+class _Interval:
+    minpos: int
+    maxpos: int
+
+
+def test_intervals_overlap_supports_inclusive_and_exclusive_modes() -> None:
+    left = _Interval(10, 20)
+    right = _Interval(20, 30)
+
+    assert intervals_overlap(left, right, inclusive=True)
+    assert not intervals_overlap(left, right, inclusive=False)
+
+
+def test_interval_contains_supports_strict_and_non_strict_modes() -> None:
+    container = _Interval(10, 20)
+    strict_child = _Interval(11, 19)
+    boundary_child = _Interval(10, 20)
+
+    assert interval_contains(container, strict_child, strict=True)
+    assert not interval_contains(container, boundary_child, strict=True)
+    assert interval_contains(container, boundary_child, strict=False)
+
+
+def test_in_memory_interval_index_returns_containing_or_predecessor() -> None:
+    intervals = [_Interval(1, 10), _Interval(20, 30), _Interval(40, 50)]
+    index = InMemoryIntervalIndex(intervals)
+
+    contained = index.predecessor_or_containing(_Interval(21, 22))
+    predecessor = index.predecessor_or_containing(_Interval(32, 33))
+
+    assert contained == intervals[1]
+    assert predecessor == intervals[1]
+
+
+def test_batch_overlaps_uses_shared_interval_index() -> None:
+    intervals = [_Interval(1, 10), _Interval(20, 30), _Interval(40, 50)]
+    index = InMemoryIntervalIndex(intervals)
+    queries = [_Interval(2, 4), _Interval(25, 45)]
+
+    result = batch_overlaps(index, queries, inclusive=True)
+
+    assert result == [[intervals[0]], [intervals[1], intervals[2]]]

--- a/tests/test_splice_graph.py
+++ b/tests/test_splice_graph.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from SpliceGrapher.SpliceGraph import SpliceGraph
+from SpliceGrapher.SpliceGraph import SpliceGraph, overlap
 
 
 def test_union_uses_resolved_strand_when_merging_unknown_strand_graph() -> None:
@@ -27,3 +27,13 @@ def test_union_rejects_invalid_runtime_strand_value() -> None:
 
     with pytest.raises(ValueError):
         left.union(right)
+
+
+def test_overlap_helper_preserves_strict_boundary_behavior() -> None:
+    graph = SpliceGraph("g", "chr1", "+")
+    left = graph.addNode("L", 10, 20)
+    touching = graph.addNode("T", 20, 30)
+    crossing = graph.addNode("C", 19, 25)
+
+    assert not overlap(left, touching)
+    assert overlap(left, crossing)


### PR DESCRIPTION
## Summary
- add `SpliceGrapher/core/interval_helpers.py` with overlap/containment primitives, `InMemoryIntervalIndex`, and bulk overlap hook
- migrate one high-value `GeneModel` path (`feature_search`, plus overlap/contains wrappers) to interval helper abstraction
- migrate one high-value `SpliceGraph` path (`overlap`, with strict edge/node containment wrappers) to interval helper abstraction
- add parity-focused tests for helper semantics and migrated call-sites

## Validation
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy SpliceGrapher/core/interval_helpers.py SpliceGrapher/formats/GeneModel.py SpliceGrapher/SpliceGraph.py tests/test_interval_helpers.py tests/test_gene_model.py tests/test_splice_graph.py`
- `uv run pytest -q tests/test_interval_helpers.py tests/test_gene_model.py tests/test_splice_graph.py tests/test_annotation_io.py tests/test_integration_simple.py`

Closes #107
Refs #103