### PR TITLE
Add overlap invariant ratchet and benchmark CI gate

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -32,6 +32,17 @@ jobs:
       - name: Enforce clean-invariant ratchet
         run: uv run python scripts/ci/check_clean_invariant.py
 
+      - name: Enforce interval overlap benchmark/parity gate
+        run: |
+          uv run python scripts/benchmarks/run_interval_overlap_benchmarks.py \
+            --interval-count 1200 \
+            --query-count 1200 \
+            --iterations 2 \
+            --assert-threshold \
+            --max-slowdown-ratio 1.35 \
+            --json-out /tmp/interval_overlap_benchmark_results.json \
+            --markdown-out /tmp/interval_overlap_benchmark_results.md
+
       - name: Ruff lint
         run: uv run ruff check .
 

--- a/SpliceGrapher/core/interval_helpers.py
+++ b/SpliceGrapher/core/interval_helpers.py
@@ -54,6 +54,12 @@ class InMemoryIntervalIndex(Sequence[_IntervalT]):
 
         self._intervals = tuple(intervals)
         self._starts = tuple(interval.minpos for interval in self._intervals)
+        prefix_maxes: list[int] = []
+        running_max = self._intervals[0].maxpos
+        for interval in self._intervals:
+            running_max = max(running_max, interval.maxpos)
+            prefix_maxes.append(running_max)
+        self._prefix_maxes = tuple(prefix_maxes)
 
     @overload
     def __getitem__(self, index: int) -> _IntervalT: ...
@@ -107,7 +113,9 @@ class InMemoryIntervalIndex(Sequence[_IntervalT]):
     ) -> list[_IntervalT]:
         """Return all indexed intervals that overlap ``query``."""
         idx = bisect.bisect_left(self._starts, query.minpos)
-        scan_start = max(0, idx - 1)
+        scan_start = idx
+        while scan_start > 0 and self._prefix_maxes[scan_start - 1] >= query.minpos:
+            scan_start -= 1
         result: list[_IntervalT] = []
         for interval in self._intervals[scan_start:]:
             if interval.minpos > query.maxpos:

--- a/docs/testing/interval-overlap-benchmark.md
+++ b/docs/testing/interval-overlap-benchmark.md
@@ -1,0 +1,46 @@
+# Interval Overlap Benchmark Gate
+
+This benchmark tracks parity and performance for interval-overlap helper paths.
+It is designed as a lightweight CI guardrail and a reproducible local check.
+
+## Default policy
+
+- parity must hold between legacy overlap scan and indexed overlap helper results
+- indexed slowdown ratio (`indexed_mean / legacy_mean`) must be `<= 1.35`
+
+The ratio threshold intentionally allows some runtime variance across CI runners
+while still blocking meaningful regressions.
+
+## Reproducible command
+
+```bash
+uv run python scripts/benchmarks/run_interval_overlap_benchmarks.py \
+  --interval-count 2000 \
+  --query-count 2000 \
+  --iterations 3 \
+  --assert-threshold \
+  --max-slowdown-ratio 1.35 \
+  --json-out docs/testing/interval_overlap_benchmark_results.json \
+  --markdown-out docs/testing/interval_overlap_benchmark_results.md
+```
+
+## CI gate command
+
+The quality-gates workflow runs the same benchmark policy with CI-friendly
+runtime parameters and fails on threshold breaches:
+
+```bash
+uv run python scripts/benchmarks/run_interval_overlap_benchmarks.py \
+  --interval-count 1200 \
+  --query-count 1200 \
+  --iterations 2 \
+  --assert-threshold \
+  --max-slowdown-ratio 1.35 \
+  --json-out /tmp/interval_overlap_benchmark_results.json \
+  --markdown-out /tmp/interval_overlap_benchmark_results.md
+```
+
+## Artifacts
+
+- JSON result payload: metrics + threshold fields
+- Markdown report: human-readable status summary

--- a/scripts/benchmarks/run_interval_overlap_benchmarks.py
+++ b/scripts/benchmarks/run_interval_overlap_benchmarks.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Run reproducible overlap parity/performance benchmarks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from time import perf_counter
+
+from SpliceGrapher.core.interval_helpers import InMemoryIntervalIndex
+
+DEFAULT_INTERVAL_COUNT = 2000
+DEFAULT_QUERY_COUNT = 2000
+DEFAULT_ITERATIONS = 3
+DEFAULT_MAX_SLOWDOWN_RATIO = 1.35
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class _Interval:
+    minpos: int
+    maxpos: int
+
+
+@dataclass(frozen=True, slots=True)
+class OverlapBenchmarkResult:
+    """Serializable overlap benchmark result payload."""
+
+    interval_count: int
+    query_count: int
+    iterations: int
+    legacy_mean_seconds: float
+    indexed_mean_seconds: float
+    indexed_slowdown_ratio: float
+    parity_ok: bool
+    max_slowdown_ratio: float
+
+    @property
+    def threshold_ok(self) -> bool:
+        return self.parity_ok and self.indexed_slowdown_ratio <= self.max_slowdown_ratio
+
+
+def _build_intervals(count: int) -> list[_Interval]:
+    intervals: list[_Interval] = []
+    for idx in range(count):
+        start = (idx * 7) + 1
+        end = start + 10 + (idx % 5)
+        intervals.append(_Interval(minpos=start, maxpos=end))
+    return intervals
+
+
+def _build_queries(count: int) -> list[_Interval]:
+    queries: list[_Interval] = []
+    for idx in range(count):
+        start = (idx * 5) + 3
+        end = start + 8 + (idx % 3)
+        queries.append(_Interval(minpos=start, maxpos=end))
+    return queries
+
+
+def _legacy_overlaps(intervals: list[_Interval], query: _Interval) -> list[_Interval]:
+    return [
+        interval
+        for interval in intervals
+        if interval.minpos <= query.maxpos and query.minpos <= interval.maxpos
+    ]
+
+
+def _run_legacy(
+    intervals: list[_Interval],
+    queries: list[_Interval],
+    *,
+    iterations: int,
+) -> float:
+    timings: list[float] = []
+    for _ in range(iterations):
+        start = perf_counter()
+        checksum = 0
+        for query in queries:
+            checksum += len(_legacy_overlaps(intervals, query))
+        _ = checksum
+        timings.append(perf_counter() - start)
+    return sum(timings) / len(timings)
+
+
+def _run_indexed(
+    intervals: list[_Interval],
+    queries: list[_Interval],
+    *,
+    iterations: int,
+) -> float:
+    index = InMemoryIntervalIndex(intervals)
+    timings: list[float] = []
+    for _ in range(iterations):
+        start = perf_counter()
+        checksum = 0
+        for query in queries:
+            checksum += len(index.overlaps(query))
+        _ = checksum
+        timings.append(perf_counter() - start)
+    return sum(timings) / len(timings)
+
+
+def _parity_check(intervals: list[_Interval], queries: list[_Interval]) -> bool:
+    index = InMemoryIntervalIndex(intervals)
+    for query in queries:
+        legacy = _legacy_overlaps(intervals, query)
+        indexed = index.overlaps(query)
+        if legacy != indexed:
+            return False
+    return True
+
+
+def _to_markdown(result: OverlapBenchmarkResult) -> str:
+    status = "pass" if result.threshold_ok else "fail"
+    return "\n".join(
+        [
+            "# Interval Overlap Benchmark",
+            "",
+            f"- Status: **{status}**",
+            f"- Parity: `{result.parity_ok}`",
+            f"- Legacy mean seconds: `{result.legacy_mean_seconds:.6f}`",
+            f"- Indexed mean seconds: `{result.indexed_mean_seconds:.6f}`",
+            f"- Indexed slowdown ratio: `{result.indexed_slowdown_ratio:.3f}`",
+            f"- Max slowdown ratio: `{result.max_slowdown_ratio:.3f}`",
+            f"- Interval count: `{result.interval_count}`",
+            f"- Query count: `{result.query_count}`",
+            f"- Iterations: `{result.iterations}`",
+        ]
+    )
+
+
+def run_benchmark(
+    *,
+    interval_count: int,
+    query_count: int,
+    iterations: int,
+    max_slowdown_ratio: float,
+) -> OverlapBenchmarkResult:
+    if interval_count <= 0:
+        raise ValueError("interval_count must be >= 1")
+    if query_count <= 0:
+        raise ValueError("query_count must be >= 1")
+    if iterations <= 0:
+        raise ValueError("iterations must be >= 1")
+    if max_slowdown_ratio <= 0.0:
+        raise ValueError("max_slowdown_ratio must be > 0.0")
+
+    intervals = _build_intervals(interval_count)
+    queries = _build_queries(query_count)
+    legacy_mean = _run_legacy(intervals, queries, iterations=iterations)
+    indexed_mean = _run_indexed(intervals, queries, iterations=iterations)
+    slowdown = indexed_mean / legacy_mean if legacy_mean > 0.0 else float("inf")
+    parity_ok = _parity_check(intervals, queries)
+
+    return OverlapBenchmarkResult(
+        interval_count=interval_count,
+        query_count=query_count,
+        iterations=iterations,
+        legacy_mean_seconds=legacy_mean,
+        indexed_mean_seconds=indexed_mean,
+        indexed_slowdown_ratio=slowdown,
+        parity_ok=parity_ok,
+        max_slowdown_ratio=max_slowdown_ratio,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--interval-count", type=int, default=DEFAULT_INTERVAL_COUNT)
+    parser.add_argument("--query-count", type=int, default=DEFAULT_QUERY_COUNT)
+    parser.add_argument("--iterations", type=int, default=DEFAULT_ITERATIONS)
+    parser.add_argument(
+        "--max-slowdown-ratio",
+        type=float,
+        default=DEFAULT_MAX_SLOWDOWN_RATIO,
+        help="Fail threshold for indexed/legacy runtime ratio when --assert-threshold is set.",
+    )
+    parser.add_argument(
+        "--assert-threshold",
+        action="store_true",
+        help="Exit non-zero when parity fails or slowdown ratio exceeds threshold.",
+    )
+    parser.add_argument(
+        "--json-out",
+        type=Path,
+        default=Path("docs") / "testing" / "interval_overlap_benchmark_results.json",
+    )
+    parser.add_argument(
+        "--markdown-out",
+        type=Path,
+        default=Path("docs") / "testing" / "interval_overlap_benchmark_results.md",
+    )
+    args = parser.parse_args()
+
+    result = run_benchmark(
+        interval_count=args.interval_count,
+        query_count=args.query_count,
+        iterations=args.iterations,
+        max_slowdown_ratio=args.max_slowdown_ratio,
+    )
+
+    args.json_out.parent.mkdir(parents=True, exist_ok=True)
+    args.json_out.write_text(json.dumps(asdict(result), indent=2) + "\n", encoding="utf-8")
+
+    args.markdown_out.parent.mkdir(parents=True, exist_ok=True)
+    args.markdown_out.write_text(_to_markdown(result) + "\n", encoding="utf-8")
+
+    sys.stderr.write(f"Wrote JSON benchmark report: {args.json_out}\n")
+    sys.stderr.write(f"Wrote markdown benchmark report: {args.markdown_out}\n")
+    sys.stderr.write(
+        "Threshold check: "
+        f"{'pass' if result.threshold_ok else 'fail'} "
+        f"(ratio={result.indexed_slowdown_ratio:.3f}, limit={result.max_slowdown_ratio:.3f})\n"
+    )
+
+    if args.assert_threshold and not result.threshold_ok:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check_clean_invariant.py
+++ b/scripts/ci/check_clean_invariant.py
@@ -40,6 +40,22 @@ MAGIC_STRING_CONTROL_FLOW_LITERALS: tuple[str, ...] = (
     "predicted",
     "unresolved",
 )
+OVERLAP_CONTROL_FLOW_PATHS: tuple[str, ...] = (
+    "SpliceGrapher/SpliceGraph.py",
+    "SpliceGrapher/formats/GeneModel.py",
+)
+# Ratchet baseline: existing manual overlap logic is tolerated, but new instances
+# in protected modules must route through interval helper abstractions.
+BASELINE_MANUAL_OVERLAP_LINES: dict[str, set[str]] = {
+    "SpliceGrapher/SpliceGraph.py": {
+        "if e.minpos < n.minpos and n.maxpos < e.maxpos:",
+        "return self.maxpos > o.minpos and self.minpos < o.maxpos",
+    },
+    "SpliceGrapher/formats/GeneModel.py": {
+        "return strand == self.strand and self.minpos <= pos <= self.maxpos",
+        "if g.maxpos < minpos or g.minpos > maxpos:",
+    },
+}
 
 
 def _is_allowed_new_ignore_target(path: str) -> bool:
@@ -153,6 +169,54 @@ def find_magic_string_control_flow(
     return violations
 
 
+def _looks_like_manual_overlap_line(stripped: str) -> bool:
+    if stripped.startswith("#"):
+        return False
+    if not ("if " in stripped or "elif " in stripped or stripped.startswith("return ")):
+        return False
+    if "minpos" not in stripped or "maxpos" not in stripped:
+        return False
+    if " and " not in stripped and " or " not in stripped:
+        return False
+    if not any(token in stripped for token in ("<", ">", "<=", ">=")):
+        return False
+    if "intervals_overlap(" in stripped or "interval_contains(" in stripped:
+        return False
+    return True
+
+
+def find_manual_overlap_lines(
+    *,
+    source_by_path: dict[str, str],
+    protected_paths: tuple[str, ...],
+) -> dict[str, set[str]]:
+    """Collect normalized manual overlap control-flow lines per protected path."""
+    result: dict[str, set[str]] = {}
+    for rel_path in protected_paths:
+        source = source_by_path.get(rel_path, "")
+        for line in source.splitlines():
+            stripped = line.strip()
+            if not _looks_like_manual_overlap_line(stripped):
+                continue
+            result.setdefault(rel_path, set()).add(stripped)
+    return result
+
+
+def detect_manual_overlap_growth(
+    *,
+    current: dict[str, set[str]],
+    baseline: dict[str, set[str]],
+) -> list[str]:
+    """Return violations where manual overlap logic expands in protected modules."""
+    violations: list[str] = []
+    for path in sorted(current):
+        known = baseline.get(path, set())
+        unexpected = sorted(current[path] - known)
+        for line in unexpected:
+            violations.append(f"{path}: unexpected manual-overlap control flow -> {line}")
+    return violations
+
+
 def main() -> int:
     repo_root = Path(__file__).resolve().parents[2]
     current_ignores = load_per_file_ignores(repo_root / "pyproject.toml")
@@ -170,6 +234,15 @@ def main() -> int:
     magic_string_violations = find_magic_string_control_flow(
         source_by_path=source_by_path,
         protected_paths=ENUM_CONTROL_FLOW_PATHS,
+    )
+    overlap_sources = _load_sources(repo_root, OVERLAP_CONTROL_FLOW_PATHS)
+    current_manual_overlap = find_manual_overlap_lines(
+        source_by_path=overlap_sources,
+        protected_paths=OVERLAP_CONTROL_FLOW_PATHS,
+    )
+    manual_overlap_violations = detect_manual_overlap_growth(
+        current=current_manual_overlap,
+        baseline=BASELINE_MANUAL_OVERLAP_LINES,
     )
 
     if ignore_violations:
@@ -191,7 +264,19 @@ def main() -> int:
         for violation in magic_string_violations:
             sys.stdout.write(f"- {violation}\n")
 
-    if ignore_violations or executable_violations or magic_string_violations:
+    if manual_overlap_violations:
+        sys.stdout.write(
+            "Clean-invariant failure: new manual overlap control flow found in protected modules.\n"
+        )
+        for violation in manual_overlap_violations:
+            sys.stdout.write(f"- {violation}\n")
+
+    if (
+        ignore_violations
+        or executable_violations
+        or magic_string_violations
+        or manual_overlap_violations
+    ):
         return 1
 
     sys.stdout.write("Clean-invariant checks passed.\n")

--- a/tests/test_clean_invariant_guard.py
+++ b/tests/test_clean_invariant_guard.py
@@ -86,3 +86,50 @@ def test_find_magic_string_control_flow_flags_literal_branching() -> None:
 
     assert violations
     assert "SpliceGrapher/SpliceGraph.py:1" in violations[0]
+
+
+def test_find_manual_overlap_lines_detects_raw_coordinate_logic() -> None:
+    module = _load_guard_module()
+    sources = {
+        "SpliceGrapher/SpliceGraph.py": (
+            "if a.minpos < b.maxpos and a.maxpos > b.minpos:\n    pass\n"
+        ),
+    }
+
+    found = module.find_manual_overlap_lines(
+        source_by_path=sources,
+        protected_paths=("SpliceGrapher/SpliceGraph.py",),
+    )
+
+    assert found["SpliceGrapher/SpliceGraph.py"] == {
+        "if a.minpos < b.maxpos and a.maxpos > b.minpos:"
+    }
+
+
+def test_detect_manual_overlap_growth_rejects_new_lines() -> None:
+    module = _load_guard_module()
+    baseline = {"a.py": {"if x.minpos < y.maxpos and x.maxpos > y.minpos:"}}
+    current = {
+        "a.py": {
+            "if x.minpos < y.maxpos and x.maxpos > y.minpos:",
+            "return x.maxpos >= y.minpos and x.minpos <= y.maxpos",
+        }
+    }
+
+    violations = module.detect_manual_overlap_growth(current=current, baseline=baseline)
+
+    assert len(violations) == 1
+    assert "unexpected manual-overlap" in violations[0]
+
+
+def test_detect_manual_overlap_growth_allows_removal() -> None:
+    module = _load_guard_module()
+    baseline = {
+        "a.py": {
+            "if x.minpos < y.maxpos and x.maxpos > y.minpos:",
+            "return x.maxpos >= y.minpos and x.minpos <= y.maxpos",
+        }
+    }
+    current = {"a.py": {"if x.minpos < y.maxpos and x.maxpos > y.minpos:"}}
+
+    assert module.detect_manual_overlap_growth(current=current, baseline=baseline) == []

--- a/tests/test_interval_helpers.py
+++ b/tests/test_interval_helpers.py
@@ -53,3 +53,23 @@ def test_batch_overlaps_uses_shared_interval_index() -> None:
     result = batch_overlaps(index, queries, inclusive=True)
 
     assert result == [[intervals[0]], [intervals[1], intervals[2]]]
+
+
+def test_in_memory_interval_index_overlap_parity_handles_nested_long_intervals() -> None:
+    intervals = [
+        _Interval(1, 100),
+        _Interval(50, 60),
+        _Interval(70, 80),
+        _Interval(90, 95),
+        _Interval(110, 120),
+    ]
+    query = _Interval(92, 93)
+    index = InMemoryIntervalIndex(intervals)
+
+    legacy = [
+        interval
+        for interval in intervals
+        if interval.minpos <= query.maxpos and query.minpos <= interval.maxpos
+    ]
+
+    assert index.overlaps(query) == legacy

--- a/tests/test_interval_overlap_benchmark_runner.py
+++ b/tests/test_interval_overlap_benchmark_runner.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _script_path() -> Path:
+    return _repo_root() / "scripts" / "benchmarks" / "run_interval_overlap_benchmarks.py"
+
+
+def test_interval_overlap_benchmark_runner_writes_outputs(tmp_path: Path) -> None:
+    script = _script_path()
+    json_out = tmp_path / "result.json"
+    markdown_out = tmp_path / "result.md"
+
+    cmd = [
+        sys.executable,
+        str(script),
+        "--interval-count",
+        "200",
+        "--query-count",
+        "200",
+        "--iterations",
+        "1",
+        "--assert-threshold",
+        "--max-slowdown-ratio",
+        "5.0",
+        "--json-out",
+        str(json_out),
+        "--markdown-out",
+        str(markdown_out),
+    ]
+
+    result = subprocess.run(
+        cmd,
+        cwd=_repo_root(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert json_out.is_file()
+    assert markdown_out.is_file()
+
+    payload = json.loads(json_out.read_text(encoding="utf-8"))
+    assert payload["parity_ok"] is True
+    assert payload["indexed_slowdown_ratio"] > 0.0
+    assert "Threshold check: pass" in result.stderr
+
+
+def test_interval_overlap_benchmark_runner_fails_on_strict_threshold(tmp_path: Path) -> None:
+    script = _script_path()
+
+    cmd = [
+        sys.executable,
+        str(script),
+        "--interval-count",
+        "200",
+        "--query-count",
+        "200",
+        "--iterations",
+        "1",
+        "--assert-threshold",
+        "--max-slowdown-ratio",
+        "0.01",
+        "--json-out",
+        str(tmp_path / "result.json"),
+        "--markdown-out",
+        str(tmp_path / "result.md"),
+    ]
+
+    result = subprocess.run(
+        cmd,
+        cwd=_repo_root(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "Threshold check: fail" in result.stderr


### PR DESCRIPTION
## Summary
- extend clean-invariant guard to ratchet manual overlap control-flow growth in protected core modules
- add overlap benchmark runner (`scripts/benchmarks/run_interval_overlap_benchmarks.py`) with parity + slowdown threshold assertion
- add reproducible benchmark documentation (`docs/testing/interval-overlap-benchmark.md`)
- wire CI quality-gates workflow to run overlap benchmark threshold check
- add focused tests for new clean-invariant overlap ratchet and benchmark script runner
- harden `InMemoryIntervalIndex.overlaps` parity with prefix-max backscan and regression test

## Validation
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy scripts/ci/check_clean_invariant.py scripts/benchmarks/run_interval_overlap_benchmarks.py SpliceGrapher/core/interval_helpers.py tests/test_clean_invariant_guard.py tests/test_interval_overlap_benchmark_runner.py tests/test_interval_helpers.py`
- `uv run pytest -q tests/test_clean_invariant_guard.py tests/test_interval_overlap_benchmark_runner.py tests/test_interval_helpers.py tests/test_polars_gff_benchmark_runner.py`
- `uv run python scripts/ci/check_clean_invariant.py`
- `uv run python scripts/benchmarks/run_interval_overlap_benchmarks.py --interval-count 1200 --query-count 1200 --iterations 2 --assert-threshold --max-slowdown-ratio 1.35 --json-out /tmp/interval_overlap_benchmark_results.json --markdown-out /tmp/interval_overlap_benchmark_results.md`

Closes #106
Refs #103