### PR TITLE
Remove Any from shared collection/process utilities

### DIFF
--- a/SpliceGrapher/shared/collection_utils.py
+++ b/SpliceGrapher/shared/collection_utils.py
@@ -4,13 +4,28 @@ from __future__ import annotations
 
 import bisect
 from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import Protocol, TypeVar, cast, overload
+
+
+class SupportsRichComparison(Protocol):
+    def __lt__(self, other: object, /) -> bool: ...
+    def __gt__(self, other: object, /) -> bool: ...
+
 
 T = TypeVar("T")
-CollectionValue = str | list[object] | set[object] | tuple[object, ...]
+K = TypeVar("K")
+CollectionValue = str | list[T] | set[T] | tuple[T, ...]
 
 
-def as_list(value: CollectionValue, delim: str = ",") -> list[object]:
+@overload
+def as_list(value: str, delim: str = ",") -> list[str]: ...
+
+
+@overload
+def as_list(value: list[T] | set[T] | tuple[T, ...], delim: str = ",") -> list[T]: ...
+
+
+def as_list(value: CollectionValue[T], delim: str = ",") -> list[str] | list[T]:
     """Create a list from a string, list, set, or tuple."""
     if isinstance(value, str):
         return value.split(delim)
@@ -21,7 +36,15 @@ def as_list(value: CollectionValue, delim: str = ",") -> list[object]:
     raise TypeError(f"Expected a string, list, set, or tuple; received {type(value).__name__}")
 
 
-def as_set(value: CollectionValue, delim: str = ",") -> set[object]:
+@overload
+def as_set(value: str, delim: str = ",") -> set[str]: ...
+
+
+@overload
+def as_set(value: list[T] | set[T] | tuple[T, ...], delim: str = ",") -> set[T]: ...
+
+
+def as_set(value: CollectionValue[T], delim: str = ",") -> set[str] | set[T]:
     """Create a set from a string, list, set, or tuple."""
     if isinstance(value, str):
         return set(value.split(delim))
@@ -34,8 +57,8 @@ def as_set(value: CollectionValue, delim: str = ",") -> set[object]:
 
 def binary_search(
     sequence: list[T],
-    target: Any,
-    key: Callable[[T], Any] | None = None,
+    target: K,
+    key: Callable[[T], K] | None = None,
     lo: int = 0,
     hi: int | None = None,
 ) -> int:
@@ -46,7 +69,15 @@ def binary_search(
     if hi is None:
         hi = len(sequence)
 
-    return bisect.bisect_left(sequence, target, lo=lo, hi=hi, key=key)
+    comparable_target = cast(SupportsRichComparison, target)
+
+    if key is None:
+        ordered_sequence = cast(list[SupportsRichComparison], sequence)
+        return bisect.bisect_left(ordered_sequence, comparable_target, lo=lo, hi=hi)
+
+    keyed_sequence = [key(item) for item in sequence]
+    comparable_keys = cast(list[SupportsRichComparison], keyed_sequence)
+    return bisect.bisect_left(comparable_keys, comparable_target, lo=lo, hi=hi)
 
 
 __all__ = [

--- a/SpliceGrapher/shared/process_utils.py
+++ b/SpliceGrapher/shared/process_utils.py
@@ -1,35 +1,40 @@
 """Process and command execution helpers extracted from shared.utils."""
 
+from __future__ import annotations
+
 import os
 import shlex
 import subprocess
 import sys
-from collections.abc import Sequence
-from typing import Any
+from collections.abc import Iterator, Sequence
+from typing import BinaryIO, TextIO, TypeVar, cast
 
 from SpliceGrapher.shared.format_utils import time_string
 from SpliceGrapher.shared.logging_utils import get_logger
 
 LOGGER = get_logger(__name__)
+AttrT = TypeVar("AttrT")
+SubprocessStream = int | TextIO | BinaryIO | None
+CompletedProcessResult = subprocess.CompletedProcess[str] | subprocess.CompletedProcess[bytes]
 
 
-def getAttribute(key, default, **args):
+def getAttribute(key: str, default: AttrT, **args: object) -> AttrT:
     """Returns the value for the given key in the arguments dict, if found;
     otherwise returns default value."""
-    return default if key not in args else args[key]
+    return default if key not in args else cast(AttrT, args[key])
 
 
-def idFactory(pfx="", initial=1):
+def idFactory(pfx: str = "", initial: int = 1) -> Iterator[str]:
     """Generates unique ids using the given prefix.  For example,
     idFactory('ev_') will generate 'ev_1', 'ev_2', ..."""
     prefix = pfx if pfx else ""
     counter = initial
     while True:
-        yield "%s%d" % (prefix, counter)
+        yield f"{prefix}{counter}"
         counter += 1
 
 
-def logMessage(s, logstream=None):
+def logMessage(s: str, logstream: TextIO | None = None) -> None:
     """Allows log messages to be output both to stderr and a log file."""
     LOGGER.info("process_message", message=s.rstrip("\n"))
     sys.stderr.write(s)
@@ -42,10 +47,10 @@ def run_command(
     *,
     shell: bool = False,
     check: bool = False,
-    stdout: Any = None,
-    stderr: Any = None,
+    stdout: SubprocessStream = None,
+    stderr: SubprocessStream = None,
     text: bool = False,
-) -> subprocess.CompletedProcess[Any]:
+) -> CompletedProcessResult:
     """Run a command with explicit shell behavior."""
     command_args: str | list[str]
     if isinstance(command, str):
@@ -63,7 +68,7 @@ def run_command(
     )
 
 
-def runCommand(s, **args):
+def runCommand(s: str, **args: object) -> None:
     """Announces a command runs it.."""
     logstream = getAttribute("logstream", None, **args)
     debug = getAttribute("debug", False, **args)
@@ -92,10 +97,10 @@ def runCommand(s, **args):
     if exitOnError and retcode != 0:
         LOGGER.error("command_failed", command=s, return_code=retcode)
         code_type = "signal" if retcode < 0 else "code"
-        raise Exception("Error running command: returned %d %s\n%s" % (retcode, code_type, s))
+        raise RuntimeError(f"Error running command: returned {retcode} {code_type}\n{s}")
 
 
-def writeStartupMessage():
+def writeStartupMessage() -> None:
     """Standardized startup message for all scripts."""
     base = os.path.basename(sys.argv[0])
     LOGGER.info("startup", script=base)

--- a/tests/test_collection_utils.py
+++ b/tests/test_collection_utils.py
@@ -22,9 +22,9 @@ def test_as_set_handles_supported_inputs() -> None:
 
 def test_as_list_and_as_set_reject_invalid_inputs() -> None:
     with pytest.raises(TypeError):
-        as_list(123)  # type: ignore[arg-type]
+        as_list(123)  # type: ignore[call-overload]
     with pytest.raises(TypeError):
-        as_set(123)  # type: ignore[arg-type]
+        as_set(123)  # type: ignore[call-overload]
 
 
 def test_binary_search_returns_raw_insertion_index() -> None:


### PR DESCRIPTION
Closes #101

Summary
- remove typing.Any usage from SpliceGrapher/shared/process_utils.py and tighten stream/result signatures
- remove typing.Any usage from SpliceGrapher/shared/collection_utils.py and keep typed binary_search behavior without _typeshed dependency
- update tests/test_collection_utils.py ignore codes to match overload diagnostics

Verification
- uv run ruff check SpliceGrapher/shared/process_utils.py SpliceGrapher/shared/collection_utils.py tests/test_process_utils.py tests/test_collection_utils.py
- uv run ruff format --check SpliceGrapher/shared/process_utils.py SpliceGrapher/shared/collection_utils.py tests/test_process_utils.py tests/test_collection_utils.py
- uv run mypy SpliceGrapher/shared/process_utils.py SpliceGrapher/shared/collection_utils.py tests/test_process_utils.py tests/test_collection_utils.py
- uv run pytest -q tests/test_process_utils.py tests/test_collection_utils.py