### PR TITLE
Isolate ShortRead dependency behind alignment compatibility boundary

### DIFF
--- a/SpliceGrapher/formats/alignment_io.py
+++ b/SpliceGrapher/formats/alignment_io.py
@@ -9,14 +9,14 @@ import pysam
 import structlog
 
 from SpliceGrapher.core.enums import SamHeaderLine, SamHeaderTag
-from SpliceGrapher.shared.file_utils import ez_open
-from SpliceGrapher.shared.process_utils import getAttribute
-from SpliceGrapher.shared.progress import ProgressIndicator
-from SpliceGrapher.shared.ShortRead import (
+from SpliceGrapher.formats.shortread_compat import (
     SpliceJunction,
     isDepthsFile,
     readDepths,
 )
+from SpliceGrapher.shared.file_utils import ez_open
+from SpliceGrapher.shared.process_utils import getAttribute
+from SpliceGrapher.shared.progress import ProgressIndicator
 
 LOGGER = structlog.get_logger(__name__)
 

--- a/SpliceGrapher/formats/shortread_compat.py
+++ b/SpliceGrapher/formats/shortread_compat.py
@@ -1,0 +1,59 @@
+"""Compatibility boundary for legacy ``shared.ShortRead`` APIs.
+
+This module centralizes legacy read-depth/junction imports so downstream
+alignment logic can migrate away from ``shared.ShortRead`` incrementally.
+"""
+
+from __future__ import annotations
+
+from os import PathLike
+from typing import BinaryIO, TextIO, TypeAlias
+
+from SpliceGrapher.shared.ShortRead import (
+    SpliceJunction,
+)
+from SpliceGrapher.shared.ShortRead import (
+    isDepthsFile as _is_depths_file_legacy,
+)
+from SpliceGrapher.shared.ShortRead import (
+    readDepths as _read_depths_legacy,
+)
+
+DepthValues: TypeAlias = list[int]
+DepthMap: TypeAlias = dict[str, DepthValues]
+JunctionMap: TypeAlias = dict[str, list[SpliceJunction]]
+DepthSource: TypeAlias = str | PathLike[str] | TextIO | BinaryIO
+
+
+def is_depths_file(source: DepthSource) -> bool:
+    """Return ``True`` when a source contains SGN depth records."""
+    return bool(_is_depths_file_legacy(source))
+
+
+def read_depths(source: DepthSource, **args: object) -> tuple[DepthMap, JunctionMap]:
+    """Read SGN depth records through the legacy parser boundary."""
+    depths, junctions = _read_depths_legacy(source, **args)
+    return depths, junctions
+
+
+def isDepthsFile(source: DepthSource) -> bool:
+    """Compatibility wrapper for legacy camelCase API."""
+    return is_depths_file(source)
+
+
+def readDepths(source: DepthSource, **args: object) -> tuple[DepthMap, JunctionMap]:
+    """Compatibility wrapper for legacy camelCase API."""
+    return read_depths(source, **args)
+
+
+__all__ = [
+    "DepthMap",
+    "DepthSource",
+    "DepthValues",
+    "JunctionMap",
+    "SpliceJunction",
+    "is_depths_file",
+    "isDepthsFile",
+    "read_depths",
+    "readDepths",
+]

--- a/tests/test_shortread_compat.py
+++ b/tests/test_shortread_compat.py
@@ -1,0 +1,37 @@
+"""Compatibility-boundary tests for ShortRead deprecation slices."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_alignment_io_imports_shortread_compat_boundary() -> None:
+    alignment_io_path = (
+        Path(__file__).resolve().parents[1] / "SpliceGrapher" / "formats" / "alignment_io.py"
+    )
+    source = alignment_io_path.read_text(encoding="utf-8")
+
+    assert "from SpliceGrapher.shared.ShortRead import" not in source
+    assert "from SpliceGrapher.formats.shortread_compat import" in source
+
+
+def test_shortread_compat_round_trips_depth_file(tmp_path: Path) -> None:
+    from SpliceGrapher.formats.shortread_compat import is_depths_file, read_depths
+
+    depths_path = tmp_path / "sample.depths"
+    depths_path.write_text(
+        "\n".join(
+            [
+                "C\tchr1\t5",
+                "D\tchr1\t2:0,3:4",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert is_depths_file(depths_path)
+    depths, junctions = read_depths(depths_path)
+    assert "chr1" in depths
+    assert len(depths["chr1"]) == 5
+    assert junctions == {}


### PR DESCRIPTION
## Summary
- add `SpliceGrapher/formats/shortread_compat.py` as an explicit compatibility boundary for legacy `shared.ShortRead` APIs used by alignment workflows
- switch `SpliceGrapher/formats/alignment_io.py` to import `SpliceJunction`/`isDepthsFile`/`readDepths` via `formats.shortread_compat` instead of importing `shared.ShortRead` directly
- add `tests/test_shortread_compat.py` to enforce the new boundary and smoke-test depth-file parity through the adapter

## Test Plan
- [x] `uv run ruff check . --fix`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy SpliceGrapher/formats/shortread_compat.py SpliceGrapher/formats/alignment_io.py`
- [x] `PYTHONDONTWRITEBYTECODE=1 uv run pytest -q -p no:cacheprovider`

Refs #45
