### PR TITLE
refactor: extract typed depth I/O boundary for #45 tranche B

### DIFF
--- a/SpliceGrapher/formats/alignment_io.py
+++ b/SpliceGrapher/formats/alignment_io.py
@@ -11,8 +11,8 @@ import structlog
 from SpliceGrapher.core.enums import SamHeaderLine, SamHeaderTag
 from SpliceGrapher.formats.shortread_compat import (
     SpliceJunction,
-    isDepthsFile,
-    readDepths,
+    is_depths_file,
+    read_depths,
 )
 from SpliceGrapher.shared.file_utils import ez_open
 from SpliceGrapher.shared.process_utils import getAttribute
@@ -840,8 +840,8 @@ def getSamDepths(samRecords, **args):
         depths, _ = _collect_pysam_data(samRecords, junctions=False, **args)
         return depths
 
-    if isDepthsFile(samRecords):
-        depths, jcts = readDepths(samRecords, junctions=False, **args)
+    if is_depths_file(samRecords):
+        depths, jcts = read_depths(samRecords, junctions=False, **args)
         return depths
 
     depths = {}
@@ -990,8 +990,8 @@ def getSamJunctions(samRecords, **args):
         _, junctions = _collect_pysam_data(samRecords, **args)
         return junctions
 
-    if isDepthsFile(samRecords):
-        depths, jcts = readDepths(samRecords, depths=False, **args)
+    if is_depths_file(samRecords):
+        depths, jcts = read_depths(samRecords, depths=False, **args)
         return jcts
 
     # Restrict records to the given chromosomes
@@ -1081,8 +1081,8 @@ def getSamReadData(samRecords, **args):
     if _is_alignment_path(samRecords) and is_native_alignment:
         return _collect_pysam_data(samRecords, **args)
 
-    if isDepthsFile(samRecords):
-        depths, jcts = readDepths(samRecords, **args)
+    if is_depths_file(samRecords):
+        depths, jcts = read_depths(samRecords, **args)
         return depths, jcts
 
     align = {}

--- a/SpliceGrapher/formats/depth_io.py
+++ b/SpliceGrapher/formats/depth_io.py
@@ -1,0 +1,154 @@
+"""Typed depth-record parsing helpers extracted from legacy ShortRead."""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Callable
+from os import PathLike
+from pathlib import Path
+from typing import BinaryIO, Protocol, TextIO, TypeAlias, TypeVar
+
+from SpliceGrapher.core.enums import ShortReadCode
+from SpliceGrapher.shared.file_utils import ez_open
+from SpliceGrapher.shared.progress import ProgressIndicator
+
+DepthValues: TypeAlias = list[int]
+DepthMap: TypeAlias = dict[str, DepthValues]
+DepthSource: TypeAlias = str | PathLike[str] | TextIO | BinaryIO
+
+
+class JunctionRecord(Protocol):
+    """Minimum protocol needed to filter parsed junction records."""
+
+    count: int
+    minpos: int
+
+    def minAnchor(self) -> int: ...  # noqa: N802
+
+
+TJunction = TypeVar("TJunction", bound=JunctionRecord)
+JunctionMap: TypeAlias = dict[str, list[TJunction]]
+ParseJunction = Callable[[str], TJunction]
+
+
+def _as_text(line: str | bytes) -> str:
+    return line.decode("utf-8") if isinstance(line, bytes) else line
+
+
+def _load_lines(source: DepthSource) -> list[str]:
+    if isinstance(source, (str, os.PathLike)):
+        with ez_open(Path(source)) as stream:
+            return list(stream.readlines())
+    if hasattr(source, "readlines"):
+        return [_as_text(line) for line in source.readlines()]
+    raise ValueError(f"Unrecognized depth record source: {type(source)!r}")
+
+
+def is_depths_file(
+    source: DepthSource,
+    *,
+    depth_codes: tuple[ShortReadCode, ...] | tuple[ShortReadCode, ShortReadCode, ShortReadCode] = (
+        ShortReadCode.CHROM,
+        ShortReadCode.DEPTH,
+        ShortReadCode.JUNCTION,
+    ),
+) -> bool:
+    """Return ``True`` when source begins with a valid SGN depth record code."""
+    first_line: str | bytes
+    if isinstance(source, (str, os.PathLike)):
+        path = os.fspath(source)
+        if not os.path.isfile(path):
+            return False
+        with ez_open(path) as stream:
+            first_line = stream.readline()
+    elif hasattr(source, "read"):
+        first_line = source.readline()
+        if hasattr(source, "seek"):
+            source.seek(0)
+    else:
+        return False
+
+    parts = _as_text(first_line).strip().split("\t")
+    return bool(parts) and parts[0] in depth_codes
+
+
+def read_depths(
+    source: DepthSource,
+    *,
+    parse_junction: ParseJunction[TJunction] | None = None,
+    maxpos: int = sys.maxsize,
+    minanchor: int = 0,
+    minjct: int = 1,
+    depths: bool = True,
+    junctions: bool = True,
+    verbose: bool = False,
+    chrom_code: ShortReadCode = ShortReadCode.CHROM,
+    jct_code: ShortReadCode = ShortReadCode.JUNCTION,
+) -> tuple[DepthMap, JunctionMap[TJunction]]:
+    """Read SGN depth records into per-chromosome depth and junction maps."""
+    if junctions and parse_junction is None:
+        raise ValueError("parse_junction is required when junctions=True")
+
+    depth_map: DepthMap = {}
+    junction_map: JunctionMap[TJunction] = {}
+    chromosome_limit = maxpos
+
+    indicator = ProgressIndicator(1000000, verbose=verbose)
+    for text_line in _load_lines(source):
+        indicator.update()
+        parts = text_line.strip().split("\t")
+        if len(parts) < 3:
+            raise ValueError(f"Bad depths record at line {indicator.ctr}:\n{text_line}")
+
+        record_type = parts[0]
+        chrom = parts[1]
+        if record_type == chrom_code:
+            if not depths:
+                continue
+            chromosome_limit = min(maxpos, int(parts[2]))
+            depth_map[chrom] = [0] * chromosome_limit
+            continue
+
+        if record_type == jct_code:
+            if not junctions:
+                continue
+            assert parse_junction is not None
+            junction = parse_junction(text_line.strip())
+            if junction.count < minjct:
+                continue
+            if junction.minAnchor() < minanchor:
+                continue
+            if junction.minpos > chromosome_limit:
+                continue
+            junction_map.setdefault(chrom, []).append(junction)
+            continue
+
+        if not depths:
+            continue
+        if chrom not in depth_map:
+            raise ValueError(f"No chromosome information specified for {chrom} depths")
+
+        run_length_string = parts[2]
+        position = 0
+        for run_length_pair in run_length_string.split(","):
+            run_length, height = [int(item) for item in run_length_pair.split(":")]
+            upper_bound = min(maxpos, position + run_length)
+            depth_map[chrom][position:upper_bound] = [height] * run_length
+            position += run_length
+            if position >= maxpos:
+                break
+
+    indicator.finish()
+    return depth_map, junction_map
+
+
+__all__ = [
+    "DepthMap",
+    "DepthSource",
+    "DepthValues",
+    "JunctionMap",
+    "JunctionRecord",
+    "is_depths_file",
+    "read_depths",
+]

--- a/SpliceGrapher/formats/shortread_compat.py
+++ b/SpliceGrapher/formats/shortread_compat.py
@@ -1,49 +1,59 @@
-"""Compatibility boundary for legacy ``shared.ShortRead`` APIs.
-
-This module centralizes legacy read-depth/junction imports so downstream
-alignment logic can migrate away from ``shared.ShortRead`` incrementally.
-"""
+"""Compatibility boundary for legacy ``shared.ShortRead`` APIs."""
 
 from __future__ import annotations
 
+import sys
 from os import PathLike
 from typing import BinaryIO, TextIO, TypeAlias
 
-from SpliceGrapher.shared.ShortRead import (
-    SpliceJunction,
+from SpliceGrapher.formats.depth_io import (
+    DepthMap,
+    DepthValues,
+    is_depths_file,
 )
-from SpliceGrapher.shared.ShortRead import (
-    isDepthsFile as _is_depths_file_legacy,
+from SpliceGrapher.formats.depth_io import (
+    read_depths as _read_depths,
 )
-from SpliceGrapher.shared.ShortRead import (
-    readDepths as _read_depths_legacy,
-)
+from SpliceGrapher.shared.ShortRead import SpliceJunction, stringToJunction
 
-DepthValues: TypeAlias = list[int]
-DepthMap: TypeAlias = dict[str, DepthValues]
 JunctionMap: TypeAlias = dict[str, list[SpliceJunction]]
 DepthSource: TypeAlias = str | PathLike[str] | TextIO | BinaryIO
 
 
-def is_depths_file(source: DepthSource) -> bool:
-    """Return ``True`` when a source contains SGN depth records."""
-    return bool(_is_depths_file_legacy(source))
+def _coerce_int(value: object, *, default: int) -> int:
+    if value is None:
+        return default
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        return int(value)
+    raise ValueError(f"Expected int-compatible value, got {type(value)!r}")
+
+
+def _coerce_bool(value: object, *, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return bool(value)
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "t", "yes", "y"}
+    raise ValueError(f"Expected bool-compatible value, got {type(value)!r}")
 
 
 def read_depths(source: DepthSource, **args: object) -> tuple[DepthMap, JunctionMap]:
-    """Read SGN depth records through the legacy parser boundary."""
-    depths, junctions = _read_depths_legacy(source, **args)
-    return depths, junctions
-
-
-def isDepthsFile(source: DepthSource) -> bool:
-    """Compatibility wrapper for legacy camelCase API."""
-    return is_depths_file(source)
-
-
-def readDepths(source: DepthSource, **args: object) -> tuple[DepthMap, JunctionMap]:
-    """Compatibility wrapper for legacy camelCase API."""
-    return read_depths(source, **args)
+    """Read SGN depth records while preserving legacy kwargs compatibility."""
+    return _read_depths(
+        source,
+        parse_junction=stringToJunction,
+        maxpos=_coerce_int(args.get("maxpos"), default=sys.maxsize),
+        minanchor=_coerce_int(args.get("minanchor"), default=0),
+        minjct=_coerce_int(args.get("minjct"), default=1),
+        depths=_coerce_bool(args.get("depths"), default=True),
+        junctions=_coerce_bool(args.get("junctions"), default=True),
+        verbose=_coerce_bool(args.get("verbose"), default=False),
+    )
 
 
 __all__ = [
@@ -53,7 +63,5 @@ __all__ = [
     "JunctionMap",
     "SpliceJunction",
     "is_depths_file",
-    "isDepthsFile",
     "read_depths",
-    "readDepths",
 ]

--- a/SpliceGrapher/shared/ShortRead.py
+++ b/SpliceGrapher/shared/ShortRead.py
@@ -6,6 +6,7 @@ import os
 from sys import maxsize as MAXINT
 
 from SpliceGrapher.core.enums import JunctionCode, ShortReadCode
+from SpliceGrapher.formats.depth_io import is_depths_file, read_depths
 from SpliceGrapher.shared.file_utils import ez_open
 from SpliceGrapher.shared.process_utils import getAttribute, idFactory
 from SpliceGrapher.shared.progress import ProgressIndicator
@@ -98,99 +99,25 @@ def depthsToClusters(chromosome, depths, **args):
 
 def isDepthsFile(f):
     """Returns True if a file is a SpliceGrapher depths file; False otherwise."""
-    if isinstance(f, (str, os.PathLike)):
-        path = os.fspath(f)
-        if not os.path.isfile(path):
-            return False
-        with ez_open(path) as inStream:
-            firstLine = inStream.readline()
-    elif hasattr(f, "read"):
-        firstLine = f.readline()
-        if hasattr(f, "seek"):
-            f.seek(0)
-    else:
-        return False
-
-    if isinstance(firstLine, bytes):
-        firstLine = firstLine.decode("utf-8")
-    parts = firstLine.strip().split("\t")
-    return parts and parts[0] in DEPTH_CODES
+    return is_depths_file(f, depth_codes=tuple(DEPTH_CODES))
 
 
 def readDepths(f, **args):
     """Loads read depth data from a SpliceGrapher depth file.
     Returns a dictionary of read depth arrays, one per chromosome,
     along with a dictionary of splice junctions."""
-    limit = getAttribute("maxpos", MAXINT, **args)
-    minanchor = getAttribute("minanchor", 0, **args)
-    minjct = getAttribute("minjct", 1, **args)
-    useDepths = getAttribute("depths", True, **args)
-    useJunctions = getAttribute("junctions", True, **args)
-    verbose = getAttribute("verbose", False, **args)
-
-    d = {}
-    jcts = {}
-
-    # NB: limit is global position limit;
-    #     maxpos is chromosome-specific
-    maxpos = limit
-
-    # Loading into buffer all at once is 18-30%
-    # faster than doing millions of reads, and not
-    # too memory-intensive even for large genomes
-    lines = ez_open(f).readlines()
-    indicator = ProgressIndicator(1000000, verbose=verbose)
-    for line in lines:
-        indicator.update()
-        s = line.strip()
-        parts = s.split("\t")
-        if len(parts) < 3:
-            raise ValueError("Bad depths record at line %d:\n%s" % (indicator.ctr, line))
-        recType = parts[0]
-        c = parts[1]
-        if recType == CHROM_CODE:
-            # C	chr1	123456789
-            if not useDepths:
-                continue
-            # maxpos may change for each chromosome
-            maxpos = min(limit, int(parts[2]))
-            d[c] = [0] * maxpos
-        elif recType == JCT_CODE:
-            if not useJunctions:
-                continue
-            jct = stringToJunction(s)
-            if jct.count < minjct:
-                continue
-            if jct.minAnchor() < minanchor:
-                continue
-            if jct.minpos > maxpos:
-                continue
-            jcts.setdefault(c, [])
-            jcts[c].append(jct)
-        else:
-            if not useDepths:
-                continue
-            if c not in d:
-                raise ValueError("No chromosome information specified for %s depths" % c)
-
-            # D	chr1	1234:0,66:1,...
-            rlString = parts[2]
-
-            # Initial implementation uses split();
-            # later see if it's faster/less memory
-            # to do direct string indexing :
-            rparts = rlString.split(",")
-            pos = 0
-            for rpair in rparts:
-                [rlen, height] = [int(x) for x in rpair.split(":")]
-                ubound = min(limit, pos + rlen)
-                d[c][pos:ubound] = [height] * rlen
-                pos += rlen
-                if pos >= limit:
-                    break
-
-    indicator.finish()
-    return (d, jcts)
+    return read_depths(
+        f,
+        parse_junction=stringToJunction,
+        maxpos=getAttribute("maxpos", MAXINT, **args),
+        minanchor=getAttribute("minanchor", 0, **args),
+        minjct=getAttribute("minjct", 1, **args),
+        depths=getAttribute("depths", True, **args),
+        junctions=getAttribute("junctions", True, **args),
+        verbose=getAttribute("verbose", False, **args),
+        chrom_code=CHROM_CODE,
+        jct_code=JCT_CODE,
+    )
 
 
 def stringToJunction(s):

--- a/tests/test_depth_io.py
+++ b/tests/test_depth_io.py
@@ -1,0 +1,62 @@
+"""Parity tests for extracted SGN depth record I/O helpers."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+
+def _junction_signature(junction: object) -> tuple[object, ...]:
+    return (
+        getattr(junction, "chromosome"),
+        getattr(junction, "minpos"),
+        getattr(junction, "maxpos"),
+        tuple(getattr(junction, "anchors")),
+        getattr(junction, "sjCode"),
+        getattr(junction, "count"),
+        getattr(junction, "strand"),
+    )
+
+
+def test_depth_io_is_depths_file_matches_shortread_behavior() -> None:
+    from SpliceGrapher.formats.depth_io import is_depths_file
+    from SpliceGrapher.shared.ShortRead import isDepthsFile
+
+    stream = io.StringIO("C\tchr1\t3\nD\tchr1\t1:0,2:2\n")
+
+    assert is_depths_file(stream) is True
+    assert isDepthsFile(stream) is True
+    assert stream.tell() == 0
+
+
+def test_depth_io_read_depths_matches_legacy_parser(tmp_path: Path) -> None:
+    from SpliceGrapher.formats.depth_io import read_depths
+    from SpliceGrapher.shared.ShortRead import (
+        KNOWN_JCT,
+        SpliceJunction,
+        readDepths,
+        stringToJunction,
+    )
+
+    depths_path = tmp_path / "junction.depths"
+    junction = SpliceJunction("chr1", 2, 5, (2, 3), KNOWN_JCT, "+")
+    junction.count = 7
+    depths_path.write_text(
+        "\n".join(
+            [
+                "C\tchr1\t8",
+                "D\tchr1\t2:0,3:2,3:0",
+                junction.toString(),
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    legacy_depths, legacy_junctions = readDepths(depths_path)
+    new_depths, new_junctions = read_depths(depths_path, parse_junction=stringToJunction)
+
+    assert new_depths == legacy_depths
+    assert sorted(_junction_signature(j) for j in new_junctions["chr1"]) == sorted(
+        _junction_signature(j) for j in legacy_junctions["chr1"]
+    )

--- a/tests/test_shortread_compat.py
+++ b/tests/test_shortread_compat.py
@@ -35,3 +35,14 @@ def test_shortread_compat_round_trips_depth_file(tmp_path: Path) -> None:
     assert "chr1" in depths
     assert len(depths["chr1"]) == 5
     assert junctions == {}
+
+
+def test_shortread_compat_imports_depth_io_boundary() -> None:
+    compat_path = (
+        Path(__file__).resolve().parents[1] / "SpliceGrapher" / "formats" / "shortread_compat.py"
+    )
+    source = compat_path.read_text(encoding="utf-8")
+
+    assert "from SpliceGrapher.formats.depth_io import" in source
+    assert "def isDepthsFile(" not in source
+    assert "def readDepths(" not in source


### PR DESCRIPTION
## Summary
- extract depth-record parsing into new typed module `SpliceGrapher/formats/depth_io.py`
- route `shared/ShortRead.py` depth-file detection/parsing through the new boundary helpers
- update `formats/alignment_io.py` to consume snake_case boundary APIs from `formats/shortread_compat.py`
- keep `formats/shortread_compat.py` modern-only (no new camelCase wrappers) while preserving legacy kwargs compatibility for `read_depths`
- add parity tests for extracted helpers in `tests/test_depth_io.py` and boundary assertions in `tests/test_shortread_compat.py`

## Issue
- Refs #45 (tranche B progress: typed depth I/O extraction + boundary tightening)

## Verification
- `uv run ruff check SpliceGrapher/formats/depth_io.py SpliceGrapher/formats/shortread_compat.py SpliceGrapher/formats/alignment_io.py SpliceGrapher/shared/ShortRead.py tests/test_depth_io.py tests/test_shortread_compat.py`
- `uv run ruff format --check SpliceGrapher/formats/depth_io.py SpliceGrapher/formats/shortread_compat.py SpliceGrapher/formats/alignment_io.py SpliceGrapher/shared/ShortRead.py tests/test_depth_io.py tests/test_shortread_compat.py`
- `uv run mypy SpliceGrapher/formats/depth_io.py SpliceGrapher/formats/shortread_compat.py SpliceGrapher/formats/alignment_io.py SpliceGrapher/shared/ShortRead.py`
- `uv run pytest -q -p no:cacheprovider tests/test_depth_io.py tests/test_shortread_compat.py tests/test_shortread_io.py tests/test_splicegrapher_alignment_io.py tests/test_alignment_io_parity.py`
