### PR TITLE
fix(#134): remove hardcoded isoform trap and hash contract bug

### DIFF
--- a/SpliceGrapher/formats/GeneModel.py
+++ b/SpliceGrapher/formats/GeneModel.py
@@ -376,7 +376,7 @@ class BaseFeature(object):
         )
 
     def __hash__(self):
-        return self.__str__().__hash__()
+        return hash((self.minpos, self.maxpos, self.strand, self.chromosome))
 
     def __len__(self):
         return self.maxpos - self.minpos + 1
@@ -414,8 +414,6 @@ class Isoform(BaseFeature):
     def __init__(self, id, start, end, chromosome, strand, attr=None):
         BaseFeature.__init__(self, ISOFORM_TYPE, start, end, chromosome, strand, attr)
         self.id = id
-        if self.id == "ENSG00000149256":
-            raise AttributeError("ISOFORM USES GENE NAME {}".format(id))
         self.features = []
         self.exons = []
         self.exonMap = {}

--- a/tests/test_gene_model.py
+++ b/tests/test_gene_model.py
@@ -151,3 +151,17 @@ def test_gene_default_attributes_are_not_shared() -> None:
     gene_one.attributes["tag"] = "one"
 
     assert "tag" not in gene_two.attributes
+
+
+def test_isoform_constructor_does_not_contain_hardcoded_identifier_traps() -> None:
+    isoform = gm.Isoform("ENSG00000149256", 10, 20, "chr1", "+")
+
+    assert isoform.id == "ENSG00000149256"
+
+
+def test_basefeature_hash_matches_equality_contract() -> None:
+    left = gm.BaseFeature("feature_a", 1, 10, "chr1", "+")
+    right = gm.BaseFeature("feature_b", 1, 10, "chr1", "+")
+
+    assert left == right
+    assert hash(left) == hash(right)


### PR DESCRIPTION
## Summary
- remove hardcoded Isoform constructor crash for ENSG00000149256
- fix BaseFeature hash to match equality contract (location-based hash)
- add regression tests covering both failures

## Verification
- uv run ruff format SpliceGrapher/formats/GeneModel.py tests/test_gene_model.py
- uv run ruff check SpliceGrapher/formats/GeneModel.py tests/test_gene_model.py
- uv run mypy SpliceGrapher/formats/GeneModel.py
- PYTHONDONTWRITEBYTECODE=1 uv run pytest -q -p no:cacheprovider tests/test_gene_model.py

Closes #134
