### PR TITLE
depth_io: stream parse + bounded RLE decode + numpy depth arrays

### DIFF
--- a/SpliceGrapher/formats/alignment_io.py
+++ b/SpliceGrapher/formats/alignment_io.py
@@ -4,7 +4,6 @@ import io
 import os
 import re
 import sys
-import tempfile
 from collections.abc import Iterator
 from contextlib import contextmanager
 
@@ -111,10 +110,11 @@ def _synthesize_sq_headers(records: list[str]) -> list[str]:
 
 
 @contextmanager
-def _materialized_alignment_path(source: object) -> Iterator[str]:
-    """Materialize list/stream SAM inputs into a temporary SAM file for pysam."""
+def _open_alignment_source(source: object, *, reference_fasta=None):
+    """Open paths directly and wrap in-memory SAM lines in a BytesIO buffer."""
     if _is_alignment_path(source):
-        yield str(source)
+        with _open_alignment_file(str(source), reference_fasta=reference_fasta) as alignment:
+            yield alignment
         return
 
     if isinstance(source, str):
@@ -122,7 +122,6 @@ def _materialized_alignment_path(source: object) -> Iterator[str]:
 
     headers: list[str] = []
     records: list[str] = []
-
     for raw_line in _iter_sam_lines(source):
         line = raw_line if raw_line.endswith("\n") else f"{raw_line}\n"
         if line.startswith("@"):
@@ -130,22 +129,22 @@ def _materialized_alignment_path(source: object) -> Iterator[str]:
         elif line.strip():
             records.append(line)
 
-    if not any(line.startswith("@HD") for line in headers):
-        headers.insert(0, "@HD\tVN:1.6\tSO:unknown\n")
     if not any(line.startswith("@SQ") for line in headers):
         headers.extend(_synthesize_sq_headers(records))
+    if not any(line.startswith("@HD") for line in headers):
+        headers.insert(0, "@HD\tVN:1.6\tSO:unknown\n")
 
-    tmp = tempfile.NamedTemporaryFile("w", suffix=".sam", delete=False)
+    memory_buffer = io.BytesIO()
     try:
-        with tmp as handle:
-            handle.writelines(headers)
-            handle.writelines(records)
-        yield tmp.name
+        for header in headers:
+            memory_buffer.write(header.encode("utf-8"))
+        for record in records:
+            memory_buffer.write(record.encode("utf-8"))
+        memory_buffer.seek(0)
+        with pysam.AlignmentFile(memory_buffer, "r") as alignment:
+            yield alignment
     finally:
-        try:
-            os.unlink(tmp.name)
-        except FileNotFoundError:
-            pass
+        memory_buffer.close()
 
 
 def _open_alignment_file(path, *, reference_fasta=None):
@@ -199,9 +198,8 @@ class AlignmentStreamer:
 
     @contextmanager
     def open_alignment(self):
-        with _materialized_alignment_path(self.source) as path:
-            with _open_alignment_file(path, reference_fasta=self.reference_fasta) as alignment:
-                yield alignment
+        with _open_alignment_source(self.source, reference_fasta=self.reference_fasta) as alignment:
+            yield alignment
 
     def stream(self, *, chromosomes=None):
         chrom_set = makeChromosomeSet(chromosomes)
@@ -279,9 +277,17 @@ def _build_splice_junctions(chromosome, start_pos, cigar_tuples, strand, jct_cod
     return junctions
 
 
-def _initial_depth_capacity(required_size: int, maxpos: int) -> int:
+def _record_strand(record) -> str:
+    if record.has_tag(STRAND_TAG):
+        return record.get_tag(STRAND_TAG)
+    return "-" if record.is_reverse else "+"
+
+
+def _initial_depth_capacity(required_size: int, maxpos: int, reference_length: int | None) -> int:
     if maxpos < sys.maxsize:
         return maxpos + 1
+    if reference_length is not None and reference_length >= 0:
+        return max(required_size, reference_length + 2)
     return max(required_size, 1024)
 
 
@@ -293,6 +299,14 @@ def _ensure_depth_capacity(depth_array: numpy.ndarray, required_size: int) -> nu
     expanded = numpy.zeros(new_size, dtype=depth_array.dtype)
     expanded[: depth_array.size] = depth_array
     return expanded
+
+
+def _depth_map_to_arrays(depths: dict[str, list[int] | numpy.ndarray]) -> dict[str, numpy.ndarray]:
+    """Normalize depth maps to int32 NumPy arrays."""
+    return {
+        chrom: numpy.asarray(chrom_depths, dtype=numpy.int32)
+        for chrom, chrom_depths in depths.items()
+    }
 
 
 def _collect_pysam_data(
@@ -339,8 +353,13 @@ def _collect_pysam_data(
             required_size = reference_end + 2
 
             if chrom not in depths:
+                reference_length = None
+                try:
+                    reference_length = alignment.get_reference_length(chrom_name)
+                except (KeyError, ValueError):
+                    reference_length = None
                 depths[chrom] = numpy.zeros(
-                    _initial_depth_capacity(required_size, maxpos),
+                    _initial_depth_capacity(required_size, maxpos, reference_length),
                     dtype=numpy.int32,
                 )
                 limit[chrom] = 0
@@ -378,11 +397,7 @@ def _collect_pysam_data(
             if not junctions or not rec.cigartuples:
                 continue
 
-            strand = (
-                rec.get_tag(STRAND_TAG)
-                if rec.has_tag(STRAND_TAG)
-                else ("-" if rec.is_reverse else "+")
-            )
+            strand = _record_strand(rec)
             jct_code = rec.get_tag(JCT_CODE_TAG) if rec.has_tag(JCT_CODE_TAG) else ""
             jct_list = _build_splice_junctions(chrom, start_pos, rec.cigartuples, strand, jct_code)
             if not jct_list:
@@ -406,7 +421,7 @@ def _collect_pysam_data(
         else:
             keep = min(limit[chrom], depth_array.size)
 
-        normalized_depths[chrom] = depth_array[:keep].tolist()
+        normalized_depths[chrom] = depth_array[:keep].copy()
 
     normalized_junctions = {}
     if junctions:
@@ -427,12 +442,9 @@ def _collect_pysam_data(
 
 def pysamStrand(pysamRecord, tagDict=None):
     """Convenience method returns the strand given by the pysam record."""
-    if not tagDict:
-        tagDict = dict(pysamRecord.tags)
-    try:
+    if tagDict and STRAND_TAG in tagDict:
         return tagDict[STRAND_TAG]
-    except KeyError:
-        return "-" if pysamRecord.is_reverse else "+"
+    return _record_strand(pysamRecord)
 
 
 def pysamReadDepths(bamFile, chromosome, gene, *, margin=0, verbose=False):
@@ -470,7 +482,7 @@ def pysamReadDepths(bamFile, chromosome, gene, *, margin=0, verbose=False):
             gene_id=gene.id,
         )
 
-    return loBound, result.tolist()
+    return loBound, result
 
 
 def getSamAlignments(
@@ -510,7 +522,7 @@ def getSamDepths(
             junctions=False,
             verbose=verbose,
         )
-        return depths
+        return _depth_map_to_arrays(depths)
 
     depths, _ = _collect_pysam_data(
         samRecords,
@@ -526,7 +538,7 @@ def getSamHeaders(samRecords, *, reference_fasta=None):
     """Reads a SAM file and returns just the header strings as a list."""
     streamer = AlignmentStreamer(samRecords, reference_fasta=reference_fasta)
     with streamer.open_alignment() as sam_stream:
-        return [line.strip() for line in sam_stream.text.splitlines() if line.strip()]
+        return [line.strip() for line in str(sam_stream.header).splitlines() if line.strip()]
 
 
 def getSamHeaderInfo(samStream, *, verbose=False, reference_fasta=None):
@@ -598,7 +610,7 @@ def getSamReadData(
             junctions=junctions,
             verbose=verbose,
         )
-        return depths, jcts
+        return _depth_map_to_arrays(depths), jcts
 
     _ = verbose
     return _collect_pysam_data(

--- a/SpliceGrapher/formats/depth_io.py
+++ b/SpliceGrapher/formats/depth_io.py
@@ -4,16 +4,18 @@ from __future__ import annotations
 
 import os
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from os import PathLike
 from pathlib import Path
 from typing import BinaryIO, Protocol, TextIO, TypeAlias, TypeVar
+
+import numpy
 
 from SpliceGrapher.core.enums import ShortReadCode
 from SpliceGrapher.shared.file_utils import ez_open
 from SpliceGrapher.shared.progress import ProgressIndicator
 
-DepthValues: TypeAlias = list[int]
+DepthValues: TypeAlias = numpy.ndarray
 DepthMap: TypeAlias = dict[str, DepthValues]
 DepthSource: TypeAlias = str | PathLike[str] | TextIO | BinaryIO
 
@@ -36,12 +38,23 @@ def _as_text(line: str | bytes) -> str:
     return line.decode("utf-8") if isinstance(line, bytes) else line
 
 
-def _load_lines(source: DepthSource) -> list[str]:
+def _load_lines(source: DepthSource) -> Iterator[str]:
     if isinstance(source, (str, os.PathLike)):
         with ez_open(Path(source)) as stream:
-            return list(stream.readlines())
-    if hasattr(source, "readlines"):
-        return [_as_text(line) for line in source.readlines()]
+            for line in stream:
+                yield _as_text(line)
+        return
+    if hasattr(source, "__iter__"):
+        for line in source:
+            yield _as_text(line)
+        return
+    if hasattr(source, "readline"):
+        while True:
+            line = source.readline()
+            if line == "" or line == b"":
+                break
+            yield _as_text(line)
+        return
     raise ValueError(f"Unrecognized depth record source: {type(source)!r}")
 
 
@@ -63,9 +76,15 @@ def is_depths_file(
         with ez_open(path) as stream:
             first_line = stream.readline()
     elif hasattr(source, "read"):
+        reset_position = None
+        if hasattr(source, "tell") and hasattr(source, "seek"):
+            try:
+                reset_position = source.tell()
+            except (OSError, ValueError):
+                reset_position = None
         first_line = source.readline()
-        if hasattr(source, "seek"):
-            source.seek(0)
+        if reset_position is not None:
+            source.seek(reset_position)
     else:
         return False
 
@@ -92,7 +111,7 @@ def read_depths(
 
     depth_map: DepthMap = {}
     junction_map: JunctionMap[TJunction] = {}
-    chromosome_limit = maxpos
+    chromosome_limits: dict[str, int] = {}
 
     indicator = ProgressIndicator(1000000, verbose=verbose)
     for text_line in _load_lines(source):
@@ -107,7 +126,8 @@ def read_depths(
             if not depths:
                 continue
             chromosome_limit = min(maxpos, int(parts[2]))
-            depth_map[chrom] = [0] * chromosome_limit
+            chromosome_limits[chrom] = chromosome_limit
+            depth_map[chrom] = numpy.zeros(chromosome_limit, dtype=numpy.int32)
             continue
 
         if record_type == jct_code:
@@ -119,6 +139,7 @@ def read_depths(
                 continue
             if junction.minAnchor() < minanchor:
                 continue
+            chromosome_limit = chromosome_limits.get(chrom, maxpos)
             if junction.minpos > chromosome_limit:
                 continue
             junction_map.setdefault(chrom, []).append(junction)
@@ -131,12 +152,16 @@ def read_depths(
 
         run_length_string = parts[2]
         position = 0
+        chrom_limit = len(depth_map[chrom])
         for run_length_pair in run_length_string.split(","):
-            run_length, height = [int(item) for item in run_length_pair.split(":")]
-            upper_bound = min(maxpos, position + run_length)
-            depth_map[chrom][position:upper_bound] = [height] * run_length
+            run_length_str, height_str = run_length_pair.split(":", 1)
+            run_length = int(run_length_str)
+            height = int(height_str)
+            upper_bound = min(chrom_limit, position + run_length)
+            if upper_bound > position:
+                depth_map[chrom][position:upper_bound] = height
             position += run_length
-            if position >= maxpos:
+            if position >= chrom_limit:
                 break
 
     indicator.finish()

--- a/tests/test_alignment_io_parity.py
+++ b/tests/test_alignment_io_parity.py
@@ -8,7 +8,7 @@ from tests.helpers.legacy_depth_reference import compute_depths_and_junctions
 
 
 def _depth_window(
-    depths_by_chrom: dict[str, list[int]], chrom: str, start: int, end: int
+    depths_by_chrom: dict[str, numpy.ndarray], chrom: str, start: int, end: int
 ) -> numpy.ndarray:
     return numpy.array(depths_by_chrom[chrom][start : end + 1], dtype=int)
 

--- a/tests/test_alignment_io_process_utils_boundary.py
+++ b/tests/test_alignment_io_process_utils_boundary.py
@@ -24,6 +24,7 @@ def test_alignment_io_removes_manual_record_parser_and_list_growth_antipattern()
     ).read_text(encoding="utf-8")
     assert "class AlignmentRecord" not in source
     assert "+= [0] * len(" not in source
+    assert ".tolist()" not in source
 
 
 @pytest.mark.parametrize(

--- a/tests/test_depth_io.py
+++ b/tests/test_depth_io.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import io
 from pathlib import Path
 
+import numpy
+
 
 def _junction_signature(junction: object) -> tuple[object, ...]:
     return (
@@ -56,7 +58,22 @@ def test_depth_io_read_depths_matches_legacy_parser(tmp_path: Path) -> None:
     legacy_depths, legacy_junctions = readDepths(depths_path)
     new_depths, new_junctions = read_depths(depths_path, parse_junction=stringToJunction)
 
-    assert new_depths == legacy_depths
+    assert new_depths.keys() == legacy_depths.keys()
+    for chrom in new_depths:
+        assert numpy.array_equal(new_depths[chrom], numpy.asarray(legacy_depths[chrom]))
     assert sorted(_junction_signature(j) for j in new_junctions["chr1"]) == sorted(
         _junction_signature(j) for j in legacy_junctions["chr1"]
     )
+
+
+def test_depth_io_read_depths_respects_maxpos_without_extending_depth_array() -> None:
+    from SpliceGrapher.formats.depth_io import read_depths
+
+    stream = io.StringIO("C\tchr1\t10\nD\tchr1\t10:5\n")
+
+    depths, junctions = read_depths(stream, maxpos=3, junctions=False)
+
+    assert "chr1" in depths
+    assert len(depths["chr1"]) == 3
+    assert numpy.array_equal(depths["chr1"], numpy.array([5, 5, 5], dtype=numpy.int32))
+    assert junctions == {}

--- a/tests/test_splicegrapher_alignment_io.py
+++ b/tests/test_splicegrapher_alignment_io.py
@@ -1,7 +1,10 @@
 from pathlib import Path
 
+import numpy
+
 from SpliceGrapher.formats.alignment_io import (
     getSamDepths,
+    getSamHeaders,
     getSamJunctions,
     getSamReadData,
 )
@@ -16,6 +19,15 @@ def _junction_signature(junctions_by_chrom):
     return signature
 
 
+def _depth_maps_match(
+    left_depths: dict[str, numpy.ndarray],
+    right_depths: dict[str, numpy.ndarray],
+) -> bool:
+    if left_depths.keys() != right_depths.keys():
+        return False
+    return all(numpy.array_equal(left_depths[chrom], right_depths[chrom]) for chrom in left_depths)
+
+
 def test_get_sam_read_data_matches_between_sam_and_bam(tmp_path: Path):
     """SAM and BAM inputs should produce equivalent depth/junction summaries."""
     fixture = build_alignment_fixture(tmp_path, repeat_scale=24)
@@ -23,9 +35,7 @@ def test_get_sam_read_data_matches_between_sam_and_bam(tmp_path: Path):
     sam_depths, sam_junctions = getSamReadData(str(fixture.sam))
     bam_depths, bam_junctions = getSamReadData(str(fixture.bam))
 
-    assert sam_depths.keys() == bam_depths.keys()
-    chrom = fixture.chrom
-    assert sam_depths[chrom] == bam_depths[chrom]
+    assert _depth_maps_match(sam_depths, bam_depths)
     assert _junction_signature(sam_junctions) == _junction_signature(bam_junctions)
 
 
@@ -39,8 +49,7 @@ def test_get_sam_read_data_supports_cram_with_reference(tmp_path: Path):
         reference_fasta=str(fixture.reference_fasta),
     )
 
-    chrom = fixture.chrom
-    assert cram_depths[chrom] == bam_depths[chrom]
+    assert _depth_maps_match(cram_depths, bam_depths)
     assert _junction_signature(cram_junctions) == _junction_signature(bam_junctions)
 
 
@@ -69,3 +78,16 @@ def test_get_sam_depths_and_junctions_respect_chromosome_filter(tmp_path: Path):
     assert set(depths.keys()) == {fixture.chrom}
     assert set(junctions.keys()) == {fixture.chrom}
     assert junctions[fixture.chrom]
+
+
+def test_get_sam_headers_reads_bam_and_sam_headers(tmp_path: Path):
+    """Header helper should work for both SAM text and BAM binary inputs."""
+    fixture = build_alignment_fixture(tmp_path, repeat_scale=8)
+
+    sam_headers = getSamHeaders(str(fixture.sam))
+    bam_headers = getSamHeaders(str(fixture.bam))
+
+    assert any(line.startswith("@HD") for line in sam_headers)
+    assert any(line.startswith("@SQ") for line in sam_headers)
+    assert any(line.startswith("@HD") for line in bam_headers)
+    assert any(line.startswith("@SQ") for line in bam_headers)


### PR DESCRIPTION
## Summary
- fix `depth_io.read_depths` truncation behavior so run-length decode cannot extend arrays past chromosome/maxpos bounds
- switch depth parsing to streaming iteration (no full-file `readlines()` load)
- move depth storage in `depth_io` to `numpy.ndarray` (`int32`) and use vectorized RLE fill assignment
- preserve stream position handling in `is_depths_file` when `tell/seek` are available
- align tests and alignment/depth parity expectations to numpy depth outputs
- keep `alignment_io` depth map behavior consistent with numpy-first contract and robust header extraction

## Validation
- `uv run ruff check SpliceGrapher/formats/depth_io.py SpliceGrapher/formats/alignment_io.py tests/test_depth_io.py tests/test_alignment_io_parity.py tests/test_alignment_io_process_utils_boundary.py tests/test_splicegrapher_alignment_io.py`
- `uv run ruff format --check SpliceGrapher/formats/depth_io.py SpliceGrapher/formats/alignment_io.py tests/test_depth_io.py tests/test_alignment_io_parity.py tests/test_alignment_io_process_utils_boundary.py tests/test_splicegrapher_alignment_io.py`
- `PYTHONDONTWRITEBYTECODE=1 ./.venv/bin/pytest -q -p no:cacheprovider tests/test_depth_io.py tests/test_shortread_compat.py tests/test_alignment_io_constants.py tests/test_alignment_io_process_utils_boundary.py tests/test_splicegrapher_alignment_io.py tests/test_alignment_io_parity.py`

Closes #141
