### PR TITLE
fix(#124): harden SpliceGraph parser and typed hot paths

### DIFF
--- a/SpliceGrapher/SpliceGraph.py
+++ b/SpliceGrapher/SpliceGraph.py
@@ -2,7 +2,10 @@
 Module that encapsulates a splice graph.
 """
 
+from __future__ import annotations
+
 import sys
+from typing import TextIO
 
 from SpliceGrapher.core.enum_coercion import coerce_enum
 from SpliceGrapher.core.enums import AttrKey, EdgeType, NodeDisposition, RecordType, Strand
@@ -691,7 +694,16 @@ class NullNode(object):
 class SpliceGraphNode(object):
     """This is the node class to use for constructing splice graphs for GFF input/output."""
 
-    def __init__(self, id, start, end, strand, chrom, parents=[], children=[]):
+    def __init__(
+        self,
+        id: str,
+        start: int,
+        end: int,
+        strand: str | Strand,
+        chrom: str,
+        parents: list[SpliceGraphNode] | None = None,
+        children: list[SpliceGraphNode] | None = None,
+    ) -> None:
         self.id = id
         self.strand = coerce_enum(strand, Strand, field="strand").value
         self.chromosome = chrom
@@ -700,11 +712,11 @@ class SpliceGraphNode(object):
         (self.start, self.end) = (
             (self.minpos, self.maxpos) if strand == "+" else (self.maxpos, self.minpos)
         )
-        self.parents = list(parents)
-        self.children = list(children)
-        self.attrs = {}
-        self.altFormSet = set()
-        self.isoformSet = set()
+        self.parents: list[SpliceGraphNode] = list(parents) if parents is not None else []
+        self.children: list[SpliceGraphNode] = list(children) if children is not None else []
+        self.attrs: dict[str, object] = {}
+        self.altFormSet: set[str] = set()
+        self.isoformSet: set[str] = set()
         # Added for adjustable ranges
         self.origStart = self.start
         self.origEnd = self.end
@@ -1510,7 +1522,7 @@ class SpliceGraph(object):
         self.name = name
         self.attrs[ID_ATTR] = name
 
-    def union(self, other, **args):
+    def union(self, other: SpliceGraph, **args: object) -> SpliceGraph:
         """Merges two graphs into one.  Adds nodes that are distinct and merges nodes
         that have the same start/end positions.  Merged nodes will share AS
         information.  New attributes may be added, but conflicts will be resolved
@@ -1525,7 +1537,7 @@ class SpliceGraph(object):
         strand = self_strand
         if self_strand.value in VALID_STRANDS:
             if other_strand.value in VALID_STRANDS and self_strand != other_strand:
-                raise AttributeError("Cannot merge graphs with conflicting strands.\n")
+                raise ValueError("Cannot merge graphs with conflicting strands.")
         elif other_strand.value in VALID_STRANDS:
             strand = other_strand
 
@@ -1678,7 +1690,7 @@ class SpliceGraphParser(object):
     """Class that parses a GFF file filled with splice graphs and provides an
     iterator over each graph in the file."""
 
-    def __init__(self, fileRef, **args):
+    def __init__(self, fileRef: str | TextIO, **args: object) -> None:
         """Parses a GFF file filled with splice graphs and returns each graph in an iterator.
         The file may be given either as an input stream or as a file path."""
         self.verbose = getAttribute("verbose", False, **args)
@@ -1691,117 +1703,129 @@ class SpliceGraphParser(object):
         if self.instream is None:
             raise ValueError("No input file stream given.")
 
-        self.graphDict = {}
+        self.graphDict: dict[str, SpliceGraph] = {}
+        self._graph_keys: list[str] = []
         self.loadFromFile()
 
-    def __iter__(self):
+    def __iter__(self) -> SpliceGraphParser:
         """Iterator implementation."""
         return self
 
-    def __next__(self):
+    def __next__(self) -> SpliceGraph:
         """Iterator implementation."""
-        try:
-            key = list(self.graphDict.keys())[self.graphId]
-            self.graphId += 1
-            return self.graphDict[key]
-        except Exception:
+        if self.graphId >= len(self._graph_keys):
             raise StopIteration
+        key = self._graph_keys[self.graphId]
+        self.graphId += 1
+        return self.graphDict[key]
 
     # Python 2 compatibility alias
     next = __next__
 
-    def __len__(self):
+    def __len__(self) -> int:
         """Returns the number of nodes in the graph."""
         return len(self.graphDict)
 
-    def loadFromFile(self):
+    def loadFromFile(self) -> None:
         """Loads all graphs stored in a GFF file."""
         lineNo = 0
-        graph = None
+        graph: SpliceGraph | None = None
         # aliases keep track of nodes with different ids but identical start/end positions
-        alias = {}
-        edges = set([])
+        alias: dict[str, str] = {}
+        edges: set[tuple[str, str]] = set()
         indicator = ProgressIndicator(100000, verbose=self.verbose)
-        for line in self.instream:
-            indicator.update()
-            lineNo += 1
-            if line.startswith("#"):
-                continue
-            s = line.strip()
-            parts = s.split("\t")
+        try:
+            for line in self.instream:
+                indicator.update()
+                lineNo += 1
+                if line.startswith("#"):
+                    continue
+                s = line.strip()
+                parts = s.split("\t")
 
-            try:
-                recType = coerce_enum(parts[2].lower(), RecordType, field="record_type").value
-                start = int(parts[3])
-                end = int(parts[4])
-            except IndexError:
-                raise ValueError(
-                    "Illegal record in splice graph file at line %d:\n\t%s" % (lineNo, s)
-                )
-            except ValueError:
-                raise ValueError(
-                    "Illegal record type in splice graph file at line %d:\n\t%s" % (lineNo, s)
-                )
+                try:
+                    recType = coerce_enum(parts[2].lower(), RecordType, field="record_type").value
+                    start = int(parts[3])
+                    end = int(parts[4])
+                except IndexError:
+                    raise ValueError(
+                        "Illegal record in splice graph file at line %d:\n\t%s" % (lineNo, s)
+                    )
+                except ValueError:
+                    raise ValueError(
+                        "Illegal record type in splice graph file at line %d:\n\t%s" % (lineNo, s)
+                    )
 
-            if recType not in VALID_RECTYPES:
-                raise ValueError(
-                    "Illegal record type in splice graph file at line %d:\n\t%s" % (lineNo, s)
-                )
+                if recType not in VALID_RECTYPES:
+                    raise ValueError(
+                        "Illegal record type in splice graph file at line %d:\n\t%s" % (lineNo, s)
+                    )
 
-            try:
-                # Convert 'ID=ABC;Parent=X,Y,Z' into {'ID':'ABC', 'Parent':'X,Y,Z'}
-                attrs = dict([tuple(p.split("=")) for p in parts[-1].split(";") if p])
-            except Exception:
-                raise ValueError(
-                    "Illegal attribute field '%s' at line %d in GFF file." % (parts[-1], lineNo)
-                )
+                attrs = self._parse_attributes(parts[-1], lineNo)
 
-            try:
-                id = attrs["ID"]
-            except KeyError:
-                raise ValueError(
-                    "GFF attribute field '%s' has no ID at line %d" % (parts[-1], lineNo)
-                )
+                try:
+                    node_id = attrs[ID_ATTR]
+                except KeyError:
+                    raise ValueError(
+                        "GFF attribute field '%s' has no ID at line %d" % (parts[-1], lineNo)
+                    )
 
-            if recType in VALID_GENES:
-                # Add edges to previous graph
-                if graph is not None:
-                    for e in edges:
-                        graph.addEdge(alias[e[0]], alias[e[1]])
-                # Start new graph
-                graph = SpliceGraph(name=id, chromosome=parts[0], strand=parts[6])
-                graph.minpos = min(start, end)
-                graph.maxpos = max(start, end)
-                for k in attrs:
-                    if k not in KNOWN_ATTRS:
-                        graph.attrs[k] = attrs[k]
-                self.graphDict[id] = graph
-                edges = set([])
-                alias = {}
-            elif graph is None:
-                raise ValueError("Graph feature found before graph header at line %d" % lineNo)
-            else:
-                node = graph.addNode(id, start, end)
-                alias[id] = node.id
-                for k in attrs:
-                    if k == AS_KEY:
-                        node.addFormsFromString(attrs[k])
-                    elif k == ISO_KEY and attrs[k]:
-                        node.addIsoformString(attrs[k])
-                    elif k in [START_CODON_KEY, END_CODON_KEY] and attrs[k]:
-                        node.attrs[k] = set([int(x) for x in attrs[k].split(",")])
-                    elif k not in KNOWN_ATTRS:
-                        node.addAttribute(k, attrs[k])
+                if recType in VALID_GENES:
+                    # Add edges to previous graph
+                    if graph is not None:
+                        for parent_id, child_id in edges:
+                            graph.addEdge(alias[parent_id], alias[child_id])
+                    # Start new graph
+                    graph = SpliceGraph(name=node_id, chromosome=parts[0], strand=parts[6])
+                    graph.minpos = min(start, end)
+                    graph.maxpos = max(start, end)
+                    for k in attrs:
+                        if k not in KNOWN_ATTRS:
+                            graph.attrs[k] = attrs[k]
+                    self.graphDict[node_id] = graph
+                    edges = set()
+                    alias = {}
+                elif graph is None:
+                    raise ValueError("Graph feature found before graph header at line %d" % lineNo)
+                else:
+                    node = graph.addNode(node_id, start, end)
+                    alias[node_id] = node.id
+                    for k in attrs:
+                        if k == AS_KEY:
+                            node.addFormsFromString(attrs[k])
+                        elif k == ISO_KEY and attrs[k]:
+                            node.addIsoformString(attrs[k])
+                        elif k in [START_CODON_KEY, END_CODON_KEY] and attrs[k]:
+                            node.attrs[k] = set([int(x) for x in attrs[k].split(",")])
+                        elif k not in KNOWN_ATTRS:
+                            node.addAttribute(k, attrs[k])
 
-                if PARENT_ATTR in attrs:
-                    parents = attrs[PARENT_ATTR].split(",")
-                    for p in parents:
-                        edges.add((p, id))
+                    if PARENT_ATTR in attrs:
+                        parents = attrs[PARENT_ATTR].split(",")
+                        for parent in parents:
+                            edges.add((parent, node_id))
 
-        if graph is not None:
-            for e in edges:
-                graph.addEdge(alias[e[0]], alias[e[1]])
+            if graph is not None:
+                for parent_id, child_id in edges:
+                    graph.addEdge(alias[parent_id], alias[child_id])
+        finally:
+            indicator.finish()
 
-        indicator.finish()
         # Initialize iterator counter
         self.graphId = 0
+        self._graph_keys = list(self.graphDict.keys())
+
+    @staticmethod
+    def _parse_attributes(field: str, line_no: int) -> dict[str, str]:
+        """Convert `a=b;c=d` into key/value pairs while preserving '=' in values."""
+        attrs: dict[str, str] = {}
+        for pair in field.split(";"):
+            if not pair:
+                continue
+            key, sep, value = pair.partition("=")
+            if not sep or not key:
+                raise ValueError(
+                    "Illegal attribute field '%s' at line %d in GFF file." % (field, line_no)
+                )
+            attrs[key] = value
+        return attrs

--- a/tests/test_splice_graph.py
+++ b/tests/test_splice_graph.py
@@ -1,8 +1,17 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
-from SpliceGrapher.SpliceGraph import SpliceGraph, overlap
+import SpliceGrapher.SpliceGraph as splice_graph_module
+from SpliceGrapher.SpliceGraph import (
+    GENE_REC,
+    SpliceGraph,
+    SpliceGraphNode,
+    SpliceGraphParser,
+    overlap,
+)
 
 
 def test_union_uses_resolved_strand_when_merging_unknown_strand_graph() -> None:
@@ -27,6 +36,85 @@ def test_union_rejects_invalid_runtime_strand_value() -> None:
 
     with pytest.raises(ValueError):
         left.union(right)
+
+
+def test_union_rejects_conflicting_known_strands_with_value_error() -> None:
+    left = SpliceGraph("left", "chr1", "+")
+    left.addNode("L1", 10, 20)
+
+    right = SpliceGraph("right", "chr1", "-")
+    right.addNode("R1", 30, 40)
+
+    with pytest.raises(ValueError, match="conflicting strands"):
+        left.union(right)
+
+
+def test_splice_graph_node_defaults_do_not_share_parent_or_child_lists() -> None:
+    left = SpliceGraphNode("L", 10, 20, "+", "chr1")
+    right = SpliceGraphNode("R", 30, 40, "+", "chr1")
+    parent = SpliceGraphNode("P", 1, 5, "+", "chr1")
+    child = SpliceGraphNode("C", 50, 60, "+", "chr1")
+
+    left.parents.append(parent)
+    left.children.append(child)
+
+    assert right.parents == []
+    assert right.children == []
+
+
+def _write_graph_header(path: Path, attrs: str) -> None:
+    path.write_text(
+        f"chr1\tSpliceGrapher\t{GENE_REC}\t1\t20\t.\t+\t.\t{attrs}\n",
+        encoding="utf-8",
+    )
+
+
+def test_parser_preserves_equals_in_attribute_values(tmp_path: Path) -> None:
+    graph_path = tmp_path / "graph.gff3"
+    _write_graph_header(graph_path, "ID=G1;Note=alpha=beta")
+
+    parser = SpliceGraphParser(str(graph_path))
+    graph = next(iter(parser.graphDict.values()))
+
+    assert graph.attrs["Note"] == "alpha=beta"
+
+
+def test_parser_progress_indicator_finishes_on_parse_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph_path = tmp_path / "invalid.gff3"
+    _write_graph_header(graph_path, "ID")
+
+    class DummyIndicator:
+        finished = False
+
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        def update(self) -> None:
+            pass
+
+        def finish(self) -> None:
+            type(self).finished = True
+
+    monkeypatch.setattr(splice_graph_module, "ProgressIndicator", DummyIndicator)
+
+    with pytest.raises(ValueError, match="Illegal attribute field"):
+        SpliceGraphParser(str(graph_path))
+
+    assert DummyIndicator.finished is True
+
+
+def test_parser_next_does_not_mask_internal_type_errors(tmp_path: Path) -> None:
+    graph_path = tmp_path / "graph.gff3"
+    _write_graph_header(graph_path, "ID=G1")
+
+    parser = SpliceGraphParser(str(graph_path))
+    parser.graphId = "broken"  # type: ignore[assignment]
+
+    with pytest.raises(TypeError):
+        next(parser)
 
 
 def test_overlap_helper_preserves_strict_boundary_behavior() -> None:


### PR DESCRIPTION
## Summary
- harden SpliceGraphParser attribute parsing to preserve equals signs in attribute values via first-delimiter parsing
- remove broad exception masking in parser iteration and keep iterator semantics explicit
- ensure parser progress finalization runs via try/finally even on parse failure
- replace mutable defaults in SpliceGraphNode.__init__ and add explicit type hints in touched parser/node hot paths
- align merge conflict semantics by raising ValueError for conflicting known strands in SpliceGraph.union
- add focused regression tests for parser attribute parsing, progress finalization, iterator error surfacing, mutable defaults, and strand conflict behavior

## Verification
- uv run ruff check SpliceGrapher/SpliceGraph.py tests/test_splice_graph.py --fix
- uv run mypy SpliceGrapher/SpliceGraph.py tests/test_splice_graph.py
- /bin/zsh -lc 'PYTHONDONTWRITEBYTECODE=1 uv run pytest -q -p no:cacheprovider tests/test_splice_graph.py tests/test_integration_simple.py'

Closes #124
