### PR TITLE
refactor(#45): drop python2 __cmp__ debt in ShortRead ordering

### DIFF
--- a/SpliceGrapher/shared/ShortRead.py
+++ b/SpliceGrapher/shared/ShortRead.py
@@ -244,13 +244,12 @@ class Read(object):
             and self.p2 == other.p2
         )
 
-    def __cmp__(self, other):
-        if self.chromosome < other.chromosome:
-            return -1
-        elif self.minpos == other.minpos:
-            return self.maxpos - other.maxpos
-        else:
-            return self.minpos - other.minpos
+    def __lt__(self, other):
+        if self.chromosome != other.chromosome:
+            return self.chromosome < other.chromosome
+        if self.minpos != other.minpos:
+            return self.minpos < other.minpos
+        return self.maxpos < other.maxpos
 
     def __hash__(self):
         return self.__str__().__hash__()
@@ -504,12 +503,10 @@ class Cluster(object):
         self.depths[pos] = totDepth
         # assert(self.minpos <= self.maxpos)
 
-    def __cmp__(self, other):
-        return (
-            self.minpos - other.minpos
-            if self.minpos != other.minpos
-            else self.maxpos - other.maxpos
-        )
+    def __lt__(self, other):
+        if self.minpos != other.minpos:
+            return self.minpos < other.minpos
+        return self.maxpos < other.maxpos
 
     def __eq__(self, other):
         return self.id == other.id

--- a/tests/test_shortread_io.py
+++ b/tests/test_shortread_io.py
@@ -11,7 +11,7 @@ from typing import cast
 import pytest
 
 from SpliceGrapher.shared import ShortRead as shortread
-from SpliceGrapher.shared.ShortRead import isDepthsFile, writeDepths
+from SpliceGrapher.shared.ShortRead import Cluster, Read, SpliceJunction, isDepthsFile, writeDepths
 
 
 def test_shortread_source_does_not_use_fasta_star_import() -> None:
@@ -68,3 +68,44 @@ def test_write_depths_accepts_text_io_stream() -> None:
 
     assert payload.startswith("C\tchr1\t3\n")
     assert "D\tchr1\t" in payload
+
+
+def test_shortread_read_objects_sort_by_chromosome_and_coordinates() -> None:
+    reads = [
+        Read("chr2", 10, 12, "+"),
+        Read("chr1", 20, 22, "+"),
+        Read("chr1", 5, 7, "+"),
+    ]
+
+    ordered = sorted(reads)
+
+    assert [r.chromosome for r in ordered] == ["chr1", "chr1", "chr2"]
+    assert [r.minpos for r in ordered] == [5, 20, 10]
+
+
+def test_shortread_cluster_objects_sort_by_coordinates() -> None:
+    cluster_a = Cluster("chr1", 20, 1, id="a")
+    cluster_a.addPosition(22, 1)
+    cluster_b = Cluster("chr1", 5, 1, id="b")
+    cluster_b.addPosition(6, 1)
+
+    ordered = sorted([cluster_a, cluster_b])
+
+    assert [c.id for c in ordered] == ["b", "a"]
+
+
+def test_write_depths_sorts_junctions_without_python2_cmp() -> None:
+    out_stream = io.StringIO()
+    jct_late = SpliceJunction("chr1", 30, 40, (2, 2), shortread.KNOWN_JCT, "+")
+    jct_early = SpliceJunction("chr1", 10, 20, (2, 2), shortread.KNOWN_JCT, "+")
+
+    writeDepths(
+        out_stream,
+        {"chr1": [0, 0, 1, 1]},
+        {"chr1": [jct_late, jct_early]},
+        verbose=False,
+    )
+
+    junction_lines = [line for line in out_stream.getvalue().splitlines() if line.startswith("J\t")]
+    assert len(junction_lines) == 2
+    assert int(junction_lines[0].split("\t")[3]) < int(junction_lines[1].split("\t")[3])


### PR DESCRIPTION
## Summary
- remove Python 2 dead ordering methods from `SpliceGrapher/shared/ShortRead.py`
  - replace `Read.__cmp__` with Python 3 `Read.__lt__`
  - replace `Cluster.__cmp__` with Python 3 `Cluster.__lt__`
- keep ordering semantics parity for sorting in legacy paths (`writeDepths` junction sorting)
- add regression tests for:
  - `Read` sorting order
  - `Cluster` sorting order
  - `writeDepths` sorting of splice junction records

## Verification
- `uv run ruff format SpliceGrapher/shared/ShortRead.py tests/test_shortread_io.py`
- `uv run ruff check SpliceGrapher/shared/ShortRead.py tests/test_shortread_io.py --fix`
- `uv run mypy SpliceGrapher/shared/ShortRead.py tests/test_shortread_io.py`
- `/bin/zsh -lc 'PYTHONDONTWRITEBYTECODE=1 uv run pytest -q -p no:cacheprovider tests/test_shortread_io.py tests/test_depth_io.py tests/test_shortread_compat.py tests/test_alignment_io_process_utils_boundary.py'`

Refs #45
