### PR TITLE
refactor(#45): remove python2 class-base syntax in ShortRead

### DIFF
--- a/SpliceGrapher/shared/ShortRead.py
+++ b/SpliceGrapher/shared/ShortRead.py
@@ -214,7 +214,7 @@ def writeDepths(ostr, depthDict, jctDict={}, verbose=False):
 #################################################
 #  Classes
 #################################################
-class Read(object):
+class Read:
     """
     Class that encapsulates non-spliced reads.
     """
@@ -294,7 +294,7 @@ class Read(object):
         return self.id
 
 
-class ReadPair(object):
+class ReadPair:
     """
     Class that encapsulates paired-end reads.
     """
@@ -483,7 +483,7 @@ class SpliceJunction(Read):
 
 
 # Cluster is a collection of reads
-class Cluster(object):
+class Cluster:
     """
     A cluster summarizes the information for overlapping reads that map to the same
     gene region.  Unlike reads, clusters make no distinction about strand: reads on

--- a/tests/test_shortread_io.py
+++ b/tests/test_shortread_io.py
@@ -33,6 +33,17 @@ def test_shortread_source_no_longer_uses_process_utils_getattribute() -> None:
     assert "getAttribute(" not in source
 
 
+def test_shortread_source_no_longer_uses_python2_object_bases() -> None:
+    shortread_path = (
+        Path(__file__).resolve().parents[1] / "SpliceGrapher" / "shared" / "ShortRead.py"
+    )
+    source = shortread_path.read_text(encoding="utf-8")
+
+    assert "class Read(object):" not in source
+    assert "class ReadPair(object):" not in source
+    assert "class Cluster(object):" not in source
+
+
 @pytest.mark.parametrize("func_name", ["depthsToClusters", "readDepths"])
 def test_shortread_hot_path_signatures_are_explicit(func_name: str) -> None:
     signature = inspect.signature(getattr(shortread, func_name))


### PR DESCRIPTION
## Summary
- remove remaining Python 2 class base syntax from `SpliceGrapher/shared/ShortRead.py`
  - `class Read(object)` -> `class Read`
  - `class ReadPair(object)` -> `class ReadPair`
  - `class Cluster(object)` -> `class Cluster`
- add regression guard in `tests/test_shortread_io.py` that fails if old-style class declarations reappear

## Verification
- `uv run ruff format SpliceGrapher/shared/ShortRead.py tests/test_shortread_io.py`
- `uv run ruff check SpliceGrapher/shared/ShortRead.py tests/test_shortread_io.py --fix`
- `uv run mypy SpliceGrapher/shared/ShortRead.py tests/test_shortread_io.py`
- `/bin/zsh -lc 'PYTHONDONTWRITEBYTECODE=1 uv run pytest -q -p no:cacheprovider tests/test_shortread_io.py tests/test_depth_io.py tests/test_shortread_compat.py tests/test_alignment_io_process_utils_boundary.py'`

Refs #45
