### PR TITLE
refactor(#45): modernize shortread init and exception semantics

### DIFF
--- a/SpliceGrapher/shared/ShortRead.py
+++ b/SpliceGrapher/shared/ShortRead.py
@@ -317,7 +317,7 @@ class SplicedRead(Read):
     """
 
     def __init__(self, chromosome, p1, p2, p3, p4, sjCode, strand):
-        Read.__init__(self, chromosome, p1, p2, strand)
+        super().__init__(chromosome, p1, p2, strand)
 
         # NB: enforce pi < pj whenever i < j
         self.p3 = min(p3, p4)
@@ -393,7 +393,7 @@ class SpliceJunction(Read):
     """
 
     def __init__(self, chromosome, p1, p2, anchors, sjCode, strand):
-        Read.__init__(self, chromosome, p1, p2, strand)
+        super().__init__(chromosome, p1, p2, strand)
         self.code = JCT_CODE
         self.sjCode = sjCode
         self.anchors = anchors
@@ -464,7 +464,7 @@ class SpliceJunction(Read):
             or o.accval != self.accval
             or o.donval != self.donval
         ):
-            raise Exception("Splice sites do not match: %s <--> %s" % (o, self))
+            raise ValueError("Splice sites do not match: %s <--> %s" % (o, self))
 
         if o.code == SPLICE_CODE:
             self.count += o.count

--- a/tests/test_shortread_io.py
+++ b/tests/test_shortread_io.py
@@ -44,6 +44,16 @@ def test_shortread_source_no_longer_uses_python2_object_bases() -> None:
     assert "class Cluster(object):" not in source
 
 
+def test_shortread_source_no_longer_uses_legacy_base_init_or_broad_exception() -> None:
+    shortread_path = (
+        Path(__file__).resolve().parents[1] / "SpliceGrapher" / "shared" / "ShortRead.py"
+    )
+    source = shortread_path.read_text(encoding="utf-8")
+
+    assert "Read.__init__(self," not in source
+    assert 'raise Exception("Splice sites do not match:' not in source
+
+
 @pytest.mark.parametrize("func_name", ["depthsToClusters", "readDepths"])
 def test_shortread_hot_path_signatures_are_explicit(func_name: str) -> None:
     signature = inspect.signature(getattr(shortread, func_name))
@@ -126,3 +136,11 @@ def test_write_depths_sorts_junctions_without_python2_cmp() -> None:
     junction_lines = [line for line in out_stream.getvalue().splitlines() if line.startswith("J\t")]
     assert len(junction_lines) == 2
     assert int(junction_lines[0].split("\t")[3]) < int(junction_lines[1].split("\t")[3])
+
+
+def test_splice_junction_update_mismatch_raises_value_error() -> None:
+    jct = SpliceJunction("chr1", 10, 20, (2, 2), shortread.KNOWN_JCT, "+")
+    other = SpliceJunction("chr1", 12, 20, (2, 2), shortread.KNOWN_JCT, "+")
+
+    with pytest.raises(ValueError, match="Splice sites do not match"):
+        jct.update(other)


### PR DESCRIPTION
## Summary
- modernize legacy constructor dispatch in `ShortRead`:
  - replace direct `Read.__init__(...)` calls with `super().__init__(...)` in `SplicedRead` and `SpliceJunction`
- tighten exception semantics in `SpliceJunction.update`:
  - replace broad `Exception` with `ValueError` for splice-site mismatch
- add regression coverage in `tests/test_shortread_io.py` for:
  - source guard against direct base-init and broad mismatch exception
  - runtime guard that mismatch raises `ValueError`

## Verification
- `uv run ruff format SpliceGrapher/shared/ShortRead.py tests/test_shortread_io.py`
- `uv run ruff check SpliceGrapher/shared/ShortRead.py tests/test_shortread_io.py --fix`
- `uv run mypy SpliceGrapher/shared/ShortRead.py tests/test_shortread_io.py`
- `/bin/zsh -lc 'PYTHONDONTWRITEBYTECODE=1 uv run pytest -q -p no:cacheprovider tests/test_shortread_io.py tests/test_depth_io.py tests/test_shortread_compat.py tests/test_alignment_io_process_utils_boundary.py'`

Refs #45
