### PR TITLE
refactor(#45): localize junction parsing in shortread compat

### DIFF
--- a/SpliceGrapher/formats/shortread_compat.py
+++ b/SpliceGrapher/formats/shortread_compat.py
@@ -6,6 +6,7 @@ import sys
 from os import PathLike
 from typing import BinaryIO, TextIO, TypeAlias
 
+from SpliceGrapher.core.enums import JunctionCode, ShortReadCode
 from SpliceGrapher.formats.depth_io import (
     DepthMap,
     DepthValues,
@@ -14,10 +15,11 @@ from SpliceGrapher.formats.depth_io import (
 from SpliceGrapher.formats.depth_io import (
     read_depths as _read_depths,
 )
-from SpliceGrapher.shared.ShortRead import SpliceJunction, stringToJunction
+from SpliceGrapher.shared.ShortRead import SpliceJunction
 
 JunctionMap: TypeAlias = dict[str, list[SpliceJunction]]
 DepthSource: TypeAlias = str | PathLike[str] | TextIO | BinaryIO
+_JUNCTION_CODES = frozenset(code.value for code in JunctionCode)
 
 
 def _coerce_int(value: object, *, default: int) -> int:
@@ -42,11 +44,35 @@ def _coerce_bool(value: object, *, default: bool) -> bool:
     raise ValueError(f"Expected bool-compatible value, got {type(value)!r}")
 
 
+def _parse_legacy_junction(record: str) -> SpliceJunction:
+    """Parse one legacy ``J`` depth record into a ``SpliceJunction``."""
+    parts = record.split("\t")
+    if len(parts) != 9:
+        raise ValueError(f"Invalid SpliceJunction record has {len(parts)} columns (expected 9)")
+
+    if parts[0] != ShortReadCode.JUNCTION.value:
+        raise ValueError(f"Invalid SpliceJunction code: {parts[0]}")
+
+    if parts[7] not in _JUNCTION_CODES:
+        raise ValueError(f"Invalid SpliceJunction type: {parts[7]}")
+
+    chromosome = parts[1]
+    strand = parts[2]
+    positions = [int(value) for value in parts[3:7]]
+    p1 = min(positions[0], positions[1])
+    p2 = max(positions[0], positions[1])
+    anchors = (positions[2], positions[3])
+
+    junction = SpliceJunction(chromosome, p1, p2, anchors, parts[7], strand)
+    junction.count = int(parts[8])
+    return junction
+
+
 def read_depths(source: DepthSource, **args: object) -> tuple[DepthMap, JunctionMap]:
     """Read SGN depth records while preserving legacy kwargs compatibility."""
     return _read_depths(
         source,
-        parse_junction=stringToJunction,
+        parse_junction=_parse_legacy_junction,
         maxpos=_coerce_int(args.get("maxpos"), default=sys.maxsize),
         minanchor=_coerce_int(args.get("minanchor"), default=0),
         minjct=_coerce_int(args.get("minjct"), default=1),

--- a/tests/test_shortread_compat.py
+++ b/tests/test_shortread_compat.py
@@ -37,6 +37,35 @@ def test_shortread_compat_round_trips_depth_file(tmp_path: Path) -> None:
     assert junctions == {}
 
 
+def test_shortread_compat_parses_legacy_junction_records(tmp_path: Path) -> None:
+    from SpliceGrapher.formats.shortread_compat import read_depths
+
+    depths_path = tmp_path / "with_junction.depths"
+    depths_path.write_text(
+        "\n".join(
+            [
+                "C\tchr1\t8",
+                "D\tchr1\t2:0,6:1",
+                "J\tchr1\t+\t2\t5\t2\t3\tK\t7",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    _, junctions = read_depths(depths_path)
+    assert "chr1" in junctions
+    assert len(junctions["chr1"]) == 1
+    junction = junctions["chr1"][0]
+    assert junction.chromosome == "chr1"
+    assert junction.minpos == 2
+    assert junction.maxpos == 5
+    assert tuple(junction.anchors) == (2, 3)
+    assert junction.sjCode == "K"
+    assert junction.count == 7
+    assert junction.strand == "+"
+
+
 def test_shortread_compat_imports_depth_io_boundary() -> None:
     compat_path = (
         Path(__file__).resolve().parents[1] / "SpliceGrapher" / "formats" / "shortread_compat.py"
@@ -44,5 +73,6 @@ def test_shortread_compat_imports_depth_io_boundary() -> None:
     source = compat_path.read_text(encoding="utf-8")
 
     assert "from SpliceGrapher.formats.depth_io import" in source
+    assert "stringToJunction" not in source
     assert "def isDepthsFile(" not in source
     assert "def readDepths(" not in source


### PR DESCRIPTION
## Summary
- move legacy `J`-record parsing into `formats/shortread_compat.py`
- stop importing `stringToJunction` from `shared.ShortRead` in the compatibility boundary
- add coverage for junction parsing and boundary import expectations

## Test Plan
- [x] uv run ruff format --check .
- [x] uv run ruff check .
- [x] uv run mypy SpliceGrapher/formats/shortread_compat.py tests/test_shortread_compat.py
- [x] PYTHONDONTWRITEBYTECODE=1 uv run pytest -q -p no:cacheprovider tests/test_shortread_compat.py
- [x] PYTHONDONTWRITEBYTECODE=1 uv run pytest -q -p no:cacheprovider tests/test_shortread_io.py tests/test_depth_io.py
