### PR TITLE
refactor(#158): split GeneModel boundary and enforce one-way transcript ownership

### DIFF
--- a/SpliceGrapher/formats/annotation_io.py
+++ b/SpliceGrapher/formats/annotation_io.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import hashlib
 import tempfile
 from collections import defaultdict
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
+from itertools import pairwise
 from pathlib import Path
-from typing import TypedDict
+from typing import TypedDict, cast
 
 import gffutils
 
@@ -13,14 +14,15 @@ from SpliceGrapher.core.enum_coercion import coerce_enum
 from SpliceGrapher.core.enums import AttrKey, RecordType
 from SpliceGrapher.formats.gene_model import (
     CDS,
-    FP_UTR,
-    TP_UTR,
     Exon,
+    FpUtr,
     Gene,
     GeneModel,
     Isoform,
-    featureSortKey,
-    mRNA,
+    Mrna,
+    TpUtr,
+    TranscriptRegion,
+    feature_sort_key,
 )
 
 GENE_FEATURE_TYPES = {RecordType.GENE, RecordType.PREDICTED_GENE, RecordType.PSEUDOGENE}
@@ -77,7 +79,7 @@ def _first_attr(feature: gffutils.Feature, keys: Sequence[str]) -> str | None:
     for key in keys:
         values = feature.attributes.get(key)
         if values:
-            return values[0]
+            return str(values[0])
     return None
 
 
@@ -94,9 +96,7 @@ def _stable_db_path(source_path: Path, cache_dir: Path | None) -> Path:
 
     cache_dir.mkdir(parents=True, exist_ok=True)
     digest = hashlib.sha256(
-        f"{source_path.resolve()}::{source_path.stat().st_mtime_ns}::{source_path.stat().st_size}".encode(
-            "utf-8"
-        )
+        f"{source_path.resolve()}::{source_path.stat().st_mtime_ns}::{source_path.stat().st_size}".encode()
     ).hexdigest()[:16]
     return cache_dir / f"annotation_{digest}.db"
 
@@ -308,9 +308,9 @@ def _build_gene_model_from_db(db: gffutils.FeatureDB) -> GeneModel:
         gene = _get_or_create_gene(model, gene_records, gene_id, chrom, strand, minpos, maxpos)
 
         iso_attr = {
-            AttrKey.PARENT: gene.id,
-            AttrKey.NAME: transcript_id,
-            AttrKey.ID: transcript_id,
+            str(AttrKey.PARENT): gene.id,
+            str(AttrKey.NAME): transcript_id,
+            str(AttrKey.ID): transcript_id,
         }
         isoform = Isoform(transcript_id, minpos, maxpos, chrom, strand, attr=iso_attr)
         for exon_feature in exons:
@@ -325,13 +325,14 @@ def _build_gene_model_from_db(db: gffutils.FeatureDB) -> GeneModel:
 
         if cds_records:
             mrna_attr = {
-                AttrKey.PARENT: gene.id,
-                AttrKey.NAME: transcript_id,
-                AttrKey.ID: transcript_id,
+                str(AttrKey.PARENT): gene.id,
+                str(AttrKey.NAME): transcript_id,
+                str(AttrKey.ID): transcript_id,
             }
-            mrna_record = mRNA(transcript_id, minpos, maxpos, chrom, strand, attr=mrna_attr)
+            mrna_record = Mrna(transcript_id, minpos, maxpos, chrom, strand, attr=mrna_attr)
             for cds_feature in cds_records:
                 feature_type = _normalize_feature_type(cds_feature.featuretype)
+                cds: TranscriptRegion
                 if feature_type == RecordType.CDS:
                     cds = CDS(
                         cds_feature.start,
@@ -341,7 +342,7 @@ def _build_gene_model_from_db(db: gffutils.FeatureDB) -> GeneModel:
                         _feature_attr_map(cds_feature),
                     )
                 elif feature_type == RecordType.FIVE_PRIME_UTR:
-                    cds = FP_UTR(
+                    cds = FpUtr(
                         cds_feature.start,
                         cds_feature.end,
                         chrom,
@@ -349,7 +350,7 @@ def _build_gene_model_from_db(db: gffutils.FeatureDB) -> GeneModel:
                         _feature_attr_map(cds_feature),
                     )
                 elif feature_type == RecordType.THREE_PRIME_UTR:
-                    cds = TP_UTR(
+                    cds = TpUtr(
                         cds_feature.start,
                         cds_feature.end,
                         chrom,
@@ -364,15 +365,15 @@ def _build_gene_model_from_db(db: gffutils.FeatureDB) -> GeneModel:
     return model
 
 
-def _iter_transcript_exons(gene: Gene):
+def _iter_transcript_exons(gene: Gene) -> Iterator[tuple[str, list[Exon]]]:
     """Yield transcript IDs and sorted exon lists for intron derivation."""
     for iso in gene.isoforms.values():
-        exons = sorted(iso.exons, key=featureSortKey)
+        exons = sorted(iso.exons, key=feature_sort_key)
         if len(exons) > 1:
             yield iso.id, exons
 
     for mrna_rec in gene.mrna.values():
-        exons = sorted(mrna_rec.sortedExons(), key=featureSortKey)
+        exons = sorted(mrna_rec.sorted_exons(), key=feature_sort_key)
         if len(exons) > 1:
             yield mrna_rec.id, exons
 
@@ -390,7 +391,7 @@ def write_intron_cache(model: GeneModel, outdir: str | Path) -> Path:
             key=lambda g: (g.chromosome, g.minpos, g.maxpos, g.id),
         ):
             for transcript_id, exons in _iter_transcript_exons(gene):
-                for intron_index, (left, right) in enumerate(zip(exons[:-1], exons[1:]), start=1):
+                for intron_index, (left, right) in enumerate(pairwise(exons), start=1):
                     intron_start = left.maxpos + 1
                     intron_end = right.minpos - 1
                     if intron_start > intron_end:
@@ -404,17 +405,17 @@ def write_intron_cache(model: GeneModel, outdir: str | Path) -> Path:
     return cache_path
 
 
-def load_gene_models(path: str, **args) -> GeneModel:
+def load_gene_models(path: str, **args: object) -> GeneModel:
     """Load GTF/GFF annotations through gffutils and return a ``GeneModel``."""
     model_path = Path(path)
     if not model_path.exists():
         raise ValueError(f"Gene model file not found: {path}")
 
-    cache_dir = args.get("cache_dir")
+    cache_dir = cast(str | Path | None, args.get("cache_dir"))
     db = _create_db(model_path, Path(cache_dir) if cache_dir else None)
     model = _build_gene_model_from_db(db)
 
-    outdir = args.get("outdir")
+    outdir = cast(str | Path | None, args.get("outdir"))
     if outdir:
         write_intron_cache(model, outdir)
 

--- a/SpliceGrapher/formats/gene_model.py
+++ b/SpliceGrapher/formats/gene_model.py
@@ -1,23 +1,20 @@
-"""
-Stores gene annotation information from a GFF3 annotation
-file and provides methods for searching on the data.
+"""Gene model orchestration facade.
+
+Domain feature entities and helper constants/functions live in
+``SpliceGrapher.formats.models``. This module keeps the ``GeneModel``
+container/query API and re-exports domain symbols for compatibility.
 """
 
 from __future__ import annotations
 
-# TRYING A NEW WAY TO IDENTIFY GENES:
 import os
-from collections.abc import Callable, Iterable, Sequence
-from typing import Protocol, TextIO, TypeVar
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+from typing import TextIO, TypeVar
 from urllib.parse import unquote
 
-from SpliceGrapher.core.enums import AttrKey, RecordType, Strand
-from SpliceGrapher.core.interval_helpers import (
-    InMemoryIntervalIndex,
-    interval_contains,
-    intervals_overlap,
-)
-from SpliceGrapher.formats.parsers.gene_model_gff import load_gene_model_records
+from SpliceGrapher.core.enums import RecordType
+from SpliceGrapher.formats import models as _models
 from SpliceGrapher.formats.writers.gene_model import (
     write_gff as write_gene_model_gff,
 )
@@ -26,1207 +23,125 @@ from SpliceGrapher.formats.writers.gene_model import (
 )
 from SpliceGrapher.shared.progress import ProgressIndicator
 
-KNOWN_RECTYPES = [
-    RecordType.CDS,
-    RecordType.CHROMOSOME,
-    RecordType.EXON,
-    RecordType.FIVE_PRIME_UTR,
-    RecordType.GENE,
-    RecordType.INTRON,
-    RecordType.MRNA,
-    RecordType.MRNA_TE_GENE,
-    RecordType.NONUNIQUE,
-    RecordType.PROTEIN,
-    RecordType.CDS_PREDICTED,
-    RecordType.PREDICTED_GENE,
-    RecordType.PSEUDOGENE,
-    RecordType.PSEUDOGENIC_EXON,
-    RecordType.PSEUDOGENIC_TRANSCRIPT,
-    RecordType.THREE_PRIME_UTR,
-    RecordType.TRANS_ELE_GENE,
-]
-IGNORE_RECTYPES = {
-    RecordType.PROTEIN,
-    RecordType.INTRON,
-    RecordType.MRNA_TE_GENE,
-    RecordType.TRANS_ELE_GENE,
-    RecordType.NONUNIQUE,
-}
-CDS_TYPES = {RecordType.FIVE_PRIME_UTR, RecordType.THREE_PRIME_UTR, RecordType.CDS}
+KNOWN_RECTYPES = _models.KNOWN_RECTYPES
+IGNORE_RECTYPES = _models.IGNORE_RECTYPES
+CDS_TYPES = _models.CDS_TYPES
+GTF_GENE_ID = _models.GTF_GENE_ID
+GTF_GENE_NAME = _models.GTF_GENE_NAME
+GTF_TRANSCRIPT = _models.GTF_TRANSCRIPT
+GTF_TRANSNAME = _models.GTF_TRANSNAME
+GTF_SOURCE = _models.GTF_SOURCE
+GTF_EXON_ID = _models.GTF_EXON_ID
+GTF_PROTEIN_ID = _models.GTF_PROTEIN_ID
+RECTYPE_MAP = _models.RECTYPE_MAP
+ISOFORM_TYPE = _models.ISOFORM_TYPE
+ID_FIELD = _models.ID_FIELD
+NAME_FIELD = _models.NAME_FIELD
+NOTE_FIELD = _models.NOTE_FIELD
+PARENT_FIELD = _models.PARENT_FIELD
+POSSIBLE_GENE_FIELDS = _models.POSSIBLE_GENE_FIELDS
+POSSIBLE_FORM_FIELDS = _models.POSSIBLE_FORM_FIELDS
+GFF_ID = _models.GFF_ID
+MAX_BAD_LINES = _models.MAX_BAD_LINES
+VALID_STRANDS = _models.VALID_STRANDS
+FORM_DELIMITERS = _models.FORM_DELIMITERS
+SPLICE_DIMER_OFFSET = _models.SPLICE_DIMER_OFFSET
+GTF_ORDER_POLICY = _models.GTF_ORDER_POLICY
 
-# Special GTF types for conversions
-GTF_GENE_ID = "gene_id"
-GTF_GENE_NAME = "gene_name"
-GTF_TRANSCRIPT = "transcript_id"
-GTF_TRANSNAME = "transcript_name"
-GTF_SOURCE = "gene_biotype"
-GTF_EXON_ID = "exon_number"
-GTF_PROTEIN_ID = "protein_id"
-
-# Record type map allows mapping unusual names to known types:
-RECTYPE_MAP = {k: k for k in KNOWN_RECTYPES}
-RECTYPE_MAP[RecordType.PREDICTED_GENE] = RecordType.GENE
-RECTYPE_MAP[RecordType.CDS_PREDICTED] = RecordType.CDS
-
-# Virtual types (don't appear in GFF):
-ISOFORM_TYPE = "isoform"
-
-# Annotation fields:
-ID_FIELD = AttrKey.ID
-NAME_FIELD = AttrKey.NAME
-NOTE_FIELD = AttrKey.NOTE
-PARENT_FIELD = AttrKey.PARENT
-
-# There seems to be no consensus about how these tags are used in UCSC, ENSEMBL
-# and other forms of gene models, so we must try each kind:
-POSSIBLE_GENE_FIELDS = [PARENT_FIELD, GTF_GENE_ID, GTF_GENE_NAME]
-POSSIBLE_FORM_FIELDS = [PARENT_FIELD, GTF_TRANSCRIPT]
-
-# ID for GFF output:
-GFF_ID = "SpliceGrapher"
-MAX_BAD_LINES = 3
-
-# Some files contain '.' for an unassigned strand
-VALID_STRANDS = set(Strand)
-
-FORM_DELIMITERS = [".", "-", "_", ","]
-
-# Genes may overlap or even contain one another, so binary search
-# is performed only at a coarse resolution to get within this number
-# of genes.  Then a linear search is performed with a slight margin.
-# This makes it approximately O(lg n) + C
-GENE_SEARCH_RANGE = 16
-GENE_SEARCH_MARGIN = 8
-
-# GeneModel splice-site helpers assume canonical GT/AG-style 2nt dimer boundaries.
-# This remains a compatibility contract for existing callers and fixtures.
-SPLICE_DIMER_OFFSET = 2
-
-# GTF serialization contract: emit records in genomic coordinate order for both
-# strands (ascending minpos, then maxpos) to preserve historical output shape.
-GTF_ORDER_POLICY = "genomic_ascending"
-
-GeneFilter = Callable[["Gene"], bool]
-GffRecordSource = str | list[str] | set[str] | tuple[str, ...]
+GeneFilter = _models.GeneFilter
+GffRecordSource = _models.GffRecordSource
+AttrValue = _models.AttrValue
+AttrMap = _models.AttrMap
+ExtraAttrMap = _models.ExtraAttrMap
 AttrT = TypeVar("AttrT")
-GeneLikeT = TypeVar("GeneLikeT", bound="GeneLike")
 
-
-class GeneLike(Protocol):
-    minpos: int
-    maxpos: int
-    strand: str
-
-    def contains(self, pos: int, strand: str) -> bool: ...
-
-
-def gene_type_filter(g: Gene) -> bool:
-    """Convenience filter for getting only 'gene' records."""
-    return g.featureType == RecordType.GENE
-
-
-def defaultGeneFilter(g: Gene) -> bool:
-    """Default function for filtering genes from a list."""
-    return True
-
-
-def dict_to_gff(d: dict[str, object]) -> str:
-    """Returns a string representation of a dictionary based on the GFF3 annotation format."""
-    return ";".join(["{}={}".format(k, v) for k, v in sorted(d.items()) if k != "parent"])
-
-
-def dict_to_gtf(d: dict[str, object]) -> str:
-    """Returns a string representation of a dictionary based on the GTF annotation format."""
-    return "; ".join(['{} "{}"'.format(k, v) for k, v in sorted(d.items()) if k != "parent"])
-
-
-def cdsFactory(
-    recType: RecordType,
-    startPos: int,
-    endPos: int,
-    chrName: str,
-    strand: str,
-    attr: dict[str, str] | None = None,
-) -> CDS:
-    """Simple factory method for creating CDS-type records."""
-    attr = {} if attr is None else attr
-    if recType == RecordType.CDS:
-        return CDS(startPos, endPos, chrName, strand, attr)
-    elif recType == RecordType.FIVE_PRIME_UTR:
-        return FP_UTR(startPos, endPos, chrName, strand, attr)
-    elif recType == RecordType.THREE_PRIME_UTR:
-        return TP_UTR(startPos, endPos, chrName, strand, attr)
-    else:
-        raise ValueError("Illegal CDS record type: {}".format(recType))
-
-
-class Chromosome:
-    """Class that encapsulates a chromosome GFF record."""
-
-    def __init__(self, start: int, end: int, name: str) -> None:
-        self.minpos = start
-        self.maxpos = end
-        self.name = name
-
-    def __len__(self) -> int:
-        return self.maxpos - self.minpos + 1
-
-    def __str__(self) -> str:
-        return f"{self.name}: {self.minpos}-{self.maxpos}"
-
-    def contains(self, pos: int) -> bool:
-        return self.minpos <= pos <= self.maxpos
-
-    def end(self) -> int:
-        return self.maxpos
-
-    def gffString(self) -> str:
-        # Example: Chr1    TAIR9   chromosome  1   30427671    .   .   .   ID=Chr1;Name=Chr1
-        nameStr = self.name.capitalize()
-        return (
-            f"{nameStr}\t{GFF_ID}\tchromosome\t{self.start()}\t{self.end()}\t.\t.\t."
-            f"\tID={nameStr};Name={nameStr}"
-        )
-
-    def start(self) -> int:
-        return self.minpos
-
-    def update(self, feature: BaseFeature) -> None:
-        """
-        Many species do not have 'chromosome' entries in their annotations,
-        so we must infer chromosome boundaries from observed features.
-        """
-        if feature.chromosome.lower() != self.name.lower():
-            raise ValueError(
-                "Cannot use feature from {} to update {}".format(feature.chromosome, self.name)
-            )
-        self.minpos = min(self.minpos, feature.minpos)
-        self.maxpos = max(self.maxpos, feature.maxpos)
-
-
-def featureCmp(a: BaseFeature, b: BaseFeature) -> int:
-    """
-    General comparison function for sorting any features that have 'minpos'
-    and 'maxpos' attributes.
-    """
-    if a.minpos == b.minpos:
-        return a.maxpos - b.maxpos
-    else:
-        return a.minpos - b.minpos
-
-
-def featureSortKey(feature: BaseFeature) -> tuple[int, int]:
-    """Sort features by genomic interval."""
-    return (feature.minpos, feature.maxpos)
-
-
-def geneSortKey(gene: Gene) -> tuple[int, int, str]:
-    """Sort genes by interval, then id for deterministic ties."""
-    return (gene.minpos, gene.maxpos, gene.id)
-
-
-def gtf_feature_sort_key(feature: BaseFeature) -> tuple[int, int]:
-    """Sort key for GTF emission using the genomic-ascending compatibility policy."""
-    return featureSortKey(feature)
-
-
-def featureOverlaps(a: BaseFeature | None, b: BaseFeature | None) -> bool:
-    """
-    General function for determining whether feature 'a' and feature 'b' overlap.
-    """
-    if not (a and b):
-        return False
-    return intervals_overlap(a, b)
-
-
-def featureContains(a: BaseFeature | None, b: BaseFeature | None) -> bool:
-    """
-    General function for determining whether feature 'a' contains
-    feature 'b'.  Note that both features must have 'minpos'
-    and 'maxpos' attributes.
-    """
-    if not (a and b):
-        return False
-    return interval_contains(a, b)
-
-
-def feature_search(
-    features: Sequence[BaseFeature],
-    query: BaseFeature,
-    lo: int = 0,
-    hi: int | None = None,
-    overlap_window: int = 8,
-) -> BaseFeature:
-    """
-    Bisect-based search through a sorted feature list.
-
-    Returns either the feature that contains ``query`` or the feature that
-    would immediately precede it.
-    """
-    if not features:
-        raise ValueError("Cannot search an empty feature list")
-
-    if hi is None:
-        hi = len(features) - 1
-
-    lo = max(0, lo)
-    hi = min(hi, len(features) - 1)
-    if lo > hi:
-        raise ValueError("Invalid search bounds")
-
-    index = InMemoryIntervalIndex(features)
-    return index.predecessor_or_containing(
-        query,
-        lo=lo,
-        hi=hi,
-        overlap_window=overlap_window,
-    )
-
-
-class BaseFeature:
-    def __init__(self, featureType, start, end, chromosome, strand, attr=None):
-        self.chromosome = chromosome
-        self.strand = strand
-        self.parent = None
-        self.minpos = min(start, end)
-        self.maxpos = max(start, end)
-        self.featureType = featureType
-        self.attributes = {} if attr is None else attr
-
-    def acceptor(self):
-        """
-        Returns the location where the acceptor dimer begins.
-
-        Contract: use canonical splice-dimer assumptions with 1-based
-        chromosome coordinates. On '+' this is exon-start minus 2 nt.
-        On '-' this is the exact exon-start.
-          + Example: AG|CGTATTC
-          - Example: GAATACG|CT (reverse-complement)
-        """
-        return self.start() - SPLICE_DIMER_OFFSET if self.strand == "+" else self.start()
-
-    def __lt__(self, other: object) -> bool:
-        if not isinstance(other, BaseFeature):
-            return NotImplemented
-        return (self.chromosome, self.minpos, self.maxpos) < (
-            other.chromosome,
-            other.minpos,
-            other.maxpos,
-        )
-
-    def contains(self, pos, strand):
-        return strand == self.strand and self.minpos <= pos <= self.maxpos
-
-    def detailString(self):
-        return (
-            f"Feature: {self.featureType}\nChromosome: {self.chromosome}\n"
-            f"Start: {self.start()}; End: {self.end()}; Strand: '{self.strand}'"
-        )
-
-    def donor(self):
-        """
-        Returns the location where the donor dimer begins.
-
-        Contract: use canonical splice-dimer assumptions with 1-based
-        chromosome coordinates. On '+' this is the exon end. On '-'
-        this is exon-end minus 2 nt.
-          + strand example: CGTATTC|GT
-          - strand example: AC|GAATACG
-        """
-        return self.end() if self.strand == "+" else self.end() - SPLICE_DIMER_OFFSET
-
-    def end(self):
-        return self.maxpos if self.strand == "+" else self.minpos
-
-    def __eq__(self, other):
-        return (
-            self.minpos == other.minpos
-            and self.maxpos == other.maxpos
-            and self.strand == other.strand
-            and self.chromosome == other.chromosome
-        )
-
-    def gffString(self, altAttributes=None):
-        """Returns a GFF-formatted representation of the feature."""
-        attrs = dict(self.attributes)
-        if altAttributes is not None:
-            attrs.update(altAttributes)
-
-        return "{}\t{}\t{}\t{}\t{}\t.\t{}\t.\t{}".format(
-            self.chromosome.capitalize(),
-            GFF_ID,
-            self.featureType,
-            self.minpos,
-            self.maxpos,
-            self.strand,
-            dict_to_gff(attrs),
-        )
-
-    def gtfString(self, transcript, genePtr, exonId):
-        """Returns a GTF-formatted representation of the feature."""
-        attrs = dict([(k.lower(), self.attributes[k]) for k in self.attributes])
-        attrs[GTF_GENE_ID] = genePtr.id
-        attrs[GTF_GENE_NAME] = genePtr.name
-        attrs[GTF_TRANSCRIPT] = transcript
-        attrs[GTF_EXON_ID] = exonId
-        try:
-            source = attrs[GTF_SOURCE]
-        except KeyError:
-            source = GFF_ID
-        return "{}\t{}\t{}\t{}\t{}\t.\t{}\t.\t{}".format(
-            self.chromosome.capitalize(),
-            source,
-            self.featureType,
-            self.minpos,
-            self.maxpos,
-            self.strand,
-            dict_to_gtf(attrs),
-        )
-
-    def __hash__(self):
-        return hash((self.minpos, self.maxpos, self.strand, self.chromosome))
-
-    def __len__(self):
-        return self.maxpos - self.minpos + 1
-
-    def setParent(self, id):
-        self.parent = id
-
-    def start(self):
-        return self.minpos if self.strand == "+" else self.maxpos
-
-    def __str__(self):
-        return f"{self.chromosome} {self.featureType}: {self.start()}-{self.end()} ({self.strand})"
-
-
-class Exon(BaseFeature):
-    def __init__(self, start, end, chromosome, strand, attr=None):
-        BaseFeature.__init__(self, RecordType.EXON, start, end, chromosome, strand, attr)
-        self.parents = []
-
-    def __str__(self):
-        if self.parents:
-            return (
-                f"{self.featureType} {self.start()}-{self.end()}({self.strand}) "
-                f"(isoforms: {','.join([x.id for x in self.parents])})"
-            )
-        else:
-            return f"{self.featureType} {self.start()}-{self.end()}({self.strand})"
-
-    def addParent(self, isoform):
-        if isoform not in self.parents:
-            self.parents.append(isoform)
-
-
-class Isoform(BaseFeature):
-    def __init__(self, id, start, end, chromosome, strand, attr=None):
-        BaseFeature.__init__(self, ISOFORM_TYPE, start, end, chromosome, strand, attr)
-        self.id = id
-        self.features = []
-        self.exons = []
-        self.exonMap = {}
-
-    def __eq__(self, other):
-        return self.featureType == other.featureType and self.id == other.id
-
-    def acceptorList(self):
-        """
-        Returns a list of acceptor positions for the isoform.
-        """
-        self.exons.sort(key=featureSortKey, reverse=(self.strand == "-"))
-        return [e.acceptor() for e in self.exons[1:]]
-
-    def add_exon(self, exon: Exon) -> bool:
-        """
-        Adds an exon to the isoform if it's unique.
-        Returns True if the exon was added; false otherwise.
-        """
-        if exon.strand != self.strand:
-            raise ValueError(
-                f"Exon strand '{exon.strand}' does not match isoform "
-                f"strand '{self.strand}' for {self.id}"
-            )
-        if exon.chromosome != self.chromosome:
-            raise ValueError(
-                f"Exon chromosome '{exon.chromosome}' does not match "
-                f"isoform chromosome '{self.chromosome}' for {self.id}"
-            )
-
-        exonTuple = (exon.minpos, exon.maxpos)
-        if exonTuple in self.exonMap:
-            return False
-
-        self.exons.append(exon)
-        self.exonMap[exonTuple] = exon
-        if self not in exon.parents:
-            exon.parents.append(self)
-        self.minpos = min(self.minpos, exon.minpos)
-        self.maxpos = max(self.maxpos, exon.maxpos)
-        return True
-
-    def add_feature(self, feature: BaseFeature) -> None:
-        if feature.strand != self.strand:
-            raise ValueError(
-                f"ERROR: feature strand '{feature.strand}' does not match "
-                f"form strand '{self.strand}'"
-            )
-
-        if feature.chromosome != self.chromosome:
-            raise ValueError(
-                f"ERROR: feature chromosome '{feature.chromosome}' does not "
-                f"match form chromosome '{self.chromosome}'"
-            )
-
-        feature.setParent(self.id)
-        self.minpos = min(self.minpos, feature.minpos)
-        self.maxpos = max(self.maxpos, feature.maxpos)
-        self.features.append(feature)
-
-    def addFeature(self, feature: BaseFeature) -> None:
-        self.add_feature(feature)
-
-    def detailString(self):
-        return (
-            f"Isoform {self.id}\nStart: {self.start()}; End: {self.end()}; "
-            f"Strand: {self.strand}\nExons: [{self.exonString()}]\n"
-        )
-
-    def donorList(self):
-        """
-        Returns a list of donor positions for the isoform.
-        """
-        self.exons.sort(key=featureSortKey, reverse=(self.strand == "-"))
-        return [e.donor() for e in self.exons[:-1]]
-
-    def exonString(self):
-        return ",".join([str(e) for e in self.exons])
-
-    def get_feature_list(self, featureType):
-        return [f for f in self.features if f.featureType == featureType]
-
-    def gffStrings(self) -> list[str]:
-        result: list[str] = []
-        # Attributes depend on where data originated
-        gffAttr = {PARENT_FIELD: self.id}
-        gtfAttr = {
-            PARENT_FIELD: self.id,
-            GTF_TRANSCRIPT: self.id,
-            GTF_TRANSNAME: self.id,
-            GTF_PROTEIN_ID: self.id,
-        }
-        for exon in self.exons:
-            if GTF_TRANSCRIPT in exon.attributes:
-                result.append(exon.gffString(altAttributes=gtfAttr))
-            else:
-                result.append(exon.gffString(altAttributes=gffAttr))
-        return result
-
-    def gtfStrings(self) -> list[str]:
-        result: list[str] = []
-        # Compatibility policy: GTF remains genomic-ascending on both strands.
-        exonList = sorted(self.exons, key=gtf_feature_sort_key)
-        for i in range(len(exonList)):
-            exon = exonList[i]
-            result.append(exon.gtfString(self.id, self.parent, i + 1))
-        return result
-
-    def sortedExons(self):
-        """
-        Sorts the exons in an isoform based on its strand and
-        returns the sorted list of exon objects.
-        """
-        self.exons.sort(key=featureSortKey, reverse=(self.strand == "-"))
-        return self.exons
-
-    def sortedIntrons(self):
-        """
-        Returns a list of intron (donor,acceptor) tuples sorted based on strand.
-        """
-        result = []
-        exons = self.sortedExons()
-        prev = exons[0]
-        for e in exons[1:]:
-            result.append((prev.donor(), e.acceptor()))
-            prev = e
-        return result
-
-    def __str__(self):
-        return (
-            f"{self.id} ({self.chromosome}): {self.start()}-{self.end()} "
-            f"(len={len(self)}, strand={self.strand}), {len(self.exons)} exons/cds, "
-            f"range {self.minpos} to {self.maxpos}"
-        )
-
-
-# Just as exons are part of an isoform, so CDS elements are part of an mRNA sequence:
-class CDS(Exon):
-    def __init__(self, start, end, chromosome, strand, attr=None):
-        BaseFeature.__init__(self, RecordType.CDS, start, end, chromosome, strand, attr)
-        self.parents = []
-
-    def __lt__(self, other: object) -> bool:
-        """Compare CDS records, including feature type for tied intervals."""
-        if not isinstance(other, BaseFeature):
-            return NotImplemented
-        return (self.chromosome, self.minpos, self.maxpos, self.featureType) < (
-            other.chromosome,
-            other.minpos,
-            other.maxpos,
-            other.featureType,
-        )
-
-    def __eq__(self, o):
-        """Compare CDS equality by type and genomic location."""
-        return (
-            self.featureType == o.featureType
-            and self.minpos == o.minpos
-            and self.maxpos == o.maxpos
-            and self.strand == o.strand
-            and self.chromosome == o.chromosome
-        )
-
-    def __str__(self):
-        return (
-            f"{self.featureType} {self.start()}-{self.end()} "
-            f"(isoforms: {','.join([x.id for x in self.parents])})"
-        )
-
-
-# We treat UTR records the same way as CDS records
-class FP_UTR(CDS):
-    def __init__(self, start, end, chromosome, strand, attr=None):
-        BaseFeature.__init__(self, RecordType.FIVE_PRIME_UTR, start, end, chromosome, strand, attr)
-        self.parents = []
-
-
-class TP_UTR(CDS):
-    def __init__(self, start, end, chromosome, strand, attr=None):
-        BaseFeature.__init__(self, RecordType.THREE_PRIME_UTR, start, end, chromosome, strand, attr)
-        self.parents = []
-
-
-class mRNA(Isoform):
-    """
-    An mRNA acts like an isoform in that it is associated with a parent gene
-    and contains a number of coding sequences (CDS).
-    """
-
-    def __init__(self, id, start, end, chromosome, strand, attr=None):
-        BaseFeature.__init__(self, RecordType.MRNA, start, end, chromosome, strand, attr)
-        self.id = id
-        self.exons = []
-        self.features = []
-        self.cds = []
-        self.cdsMap = {}
-        self.start_codon = None
-        self.end_codon = None
-
-    def acceptorList(self):
-        """Returns a list of acceptor positions for the mRNA."""
-        self.cds.sort(key=featureSortKey, reverse=(self.strand == "-"))
-        return [c.acceptor() for c in self.cds[1:]]
-
-    def add_cds(self, cds: CDS) -> bool:
-        """
-        Adds a CDS to the mRNA if it's unique.
-        Returns True if the CDS was added; false otherwise.
-        """
-        if cds.strand != self.strand:
-            raise ValueError(
-                f"ERROR: CDS strand '{cds.strand}' does not match gene strand '{self.strand}'"
-            )
-        if cds.chromosome != self.chromosome:
-            raise ValueError(
-                f"ERROR: CDS chromosome '{cds.chromosome}' does not match "
-                f"gene chromosome '{self.chromosome}'"
-            )
-
-        cdsTuple = (cds.minpos, cds.maxpos)
-        if cdsTuple in self.cdsMap:
-            return False
-        self.cdsMap[cdsTuple] = cds
-
-        if self not in cds.parents:
-            cds.parents.append(self)
-        self.cds.append(cds)
-        return True
-
-    def donorList(self):
-        """Returns a list of donor positions for the mRNA."""
-        self.cds.sort(key=featureSortKey, reverse=(self.strand == "-"))
-        return [c.donor() for c in self.cds[:-1]]
-
-    def endCodon(self):
-        """Returns the end codon for this splice form as a duple of (start,end)
-        positions, or None if there are none found.  Positions are relative to
-        the start of the chromosome (1-based)."""
-        if not self.end_codon:
-            self.findCodons()
-        return self.end_codon
-
-    def findCodons(self):
-        """Infers a transcript's start and end codon positions based on
-        the relative positions of UTR and CDS records."""
-        if self.end_codon and self.start_codon:
-            return
-        if not self.cds:
-            return
-        self.cds.sort(key=featureSortKey, reverse=(self.strand == "-"))
-        prev = self.cds[0]
-        for c in self.cds[1:]:
-            if (
-                not self.start_codon
-                and prev.featureType == RecordType.FIVE_PRIME_UTR
-                and c.featureType == RecordType.CDS
-            ):
-                self.start_codon = (
-                    (c.minpos, c.minpos + 2) if self.strand == "+" else (c.maxpos - 2, c.maxpos)
-                )
-            elif (
-                not self.end_codon
-                and prev.featureType == RecordType.CDS
-                and c.featureType == RecordType.THREE_PRIME_UTR
-            ):
-                self.end_codon = (
-                    (prev.maxpos - 2, prev.maxpos)
-                    if self.strand == "+"
-                    else (prev.minpos, prev.minpos + 2)
-                )
-            prev = c
-
-    def inferCodons(self):
-        """This method will infer start and end codons even when there are no
-        UTR records for a transcript.  It is best to use this only after all
-        data have been loaded for a gene."""
-        # No CDS records --> no way to infer codons
-        if not self.cds:
-            return
-
-        # First try UTR inference:
-        self.findCodons()
-
-        # If either codon is missing, assume the CDS endpoints
-        # represent start/stop codons.
-        if not self.start_codon:
-            c = self.cds[0]
-            self.start_codon = (
-                (c.minpos, c.minpos + 2) if self.strand == "+" else (c.maxpos - 2, c.maxpos)
-            )
-
-        if not self.end_codon:
-            c = self.cds[-1]
-            self.end_codon = (
-                (c.maxpos - 2, c.maxpos) if self.strand == "+" else (c.minpos, c.minpos + 2)
-            )
-
-    def getUTRs(self):
-        """Returns a list of all UTR records in the mRNA object."""
-        return [
-            c
-            for c in self.cds
-            if c.featureType in [RecordType.FIVE_PRIME_UTR, RecordType.THREE_PRIME_UTR]
-        ]
-
-    def gffStrings(self):
-        result = [self.gffString()]
-        gffAttr = {PARENT_FIELD: self.id}
-        gtfAttr = {
-            PARENT_FIELD: self.id,
-            GTF_TRANSCRIPT: self.id,
-            GTF_TRANSNAME: self.id,
-            GTF_PROTEIN_ID: self.id,
-        }
-        for c in self.cds:
-            if GTF_TRANSCRIPT in c.attributes:
-                result.append(c.gffString(altAttributes=gtfAttr))
-            else:
-                result.append(c.gffString(altAttributes=gffAttr))
-        return result
-
-    def gtfStartCodon(self) -> str | None:
-        if self.start_codon:
-            if self.parent is None:
-                raise RuntimeError("mRNA parent gene is required before writing start_codon")
-            return (
-                f"{self.chromosome}\t{GFF_ID}\tstart_codon\t{self.start_codon[0]}"
-                f"\t{self.start_codon[1]}\t.\t{self.strand}\t.\tgene_id "
-                f'"{self.parent.id}"; transcript_id "{self.id}"'
-            )
-        return None
-
-    def gtfStopCodon(self) -> str | None:
-        if self.end_codon:
-            if self.parent is None:
-                raise RuntimeError("mRNA parent gene is required before writing stop_codon")
-            return (
-                f"{self.chromosome}\t{GFF_ID}\tstop_codon\t{self.end_codon[0]}"
-                f"\t{self.end_codon[1]}\t.\t{self.strand}\t.\tgene_id "
-                f'"{self.parent.id}"; transcript_id "{self.id}"'
-            )
-        return None
-
-    def gtfStrings(self) -> list[str]:
-        """
-        Returns GTF strings for all elements of the mRNA transcript, including
-        start/stop codon locations.
-        """
-        result = []
-        codonString = self.gtfStartCodon() if self.strand == "+" else self.gtfStopCodon()
-        if codonString:
-            result.append(codonString)
-
-        # Compatibility policy: GTF remains genomic-ascending on both strands.
-        cdsList = sorted(self.cds, key=gtf_feature_sort_key)
-        for i in range(len(cdsList)):
-            c = cdsList[i]
-            result.append(c.gtfString(self.id, self.parent, i + 1))
-
-        codonString = self.gtfStopCodon() if self.strand == "+" else self.gtfStartCodon()
-        if codonString:
-            result.append(codonString)
-
-        return result
-
-    def sortedCDS(self):
-        """
-        Sorts the CDS in an mRNA based on its strand and returns the sorted list of CDS objects.
-        """
-        self.cds.sort(key=featureSortKey, reverse=(self.strand == "-"))
-        return self.cds
-
-    def sortedExons(self, *, minintron: int = 2) -> list[Exon]:
-        """
-        Infers an exon list from a CDS list and sorts the list based on strand.  Usually
-        this means a 5' UTR record abuts a CDS record or a CDS record abuts a 3' UTR record,
-        in which case an expanded exon represents both.
-        """
-        cdsList = self.sortedCDS()
-        result: list[Exon] = []
-        for i in range(len(cdsList)):
-            cds = cdsList[i]
-            if len(result) > 0 and abs(cds.start() - result[-1].end()) < minintron:
-                prev = result[-1]
-                result[-1] = Exon(prev.start(), cds.end(), self.chromosome, self.strand)
-            else:
-                result.append(Exon(cds.start(), cds.end(), self.chromosome, self.strand))
-        # Revise feature types to indicate CDS instead of exon
-        for e in result:
-            e.featureType = RecordType.CDS
-        return result
-
-    def startCodon(self):
-        """Returns the start codon for this splice form as a duple of (start,end)
-        positions, or None if there are none found.  Positions are relative to
-        the start of the chromosome (1-based)."""
-        if not self.start_codon:
-            self.findCodons()
-        return self.start_codon
-
-    def __str__(self):
-        return (
-            f"{self.id} ({self.chromosome}): {self.start()}-{self.end()} "
-            f"(len={len(self)}, strand={self.strand}), {len(self.cds)} exons/cds, "
-            f"range {self.minpos} to {self.maxpos}"
-        )
-
-
-class Gene(BaseFeature):
-    def __init__(self, id, note, start, end, chromosome, strand, name=None, attr=None):
-        BaseFeature.__init__(self, RecordType.GENE, start, end, chromosome, strand, attr)
-        self.id = id
-        self.name = name if name is not None else id
-        self.note = note
-        self.isoforms = {}
-        self.mrna = {}
-        self.exons = []
-        self.cds = []
-        self.exonMap = {}
-        self.cdsMap = {}
-
-        # Codons for all transcripts/mRNA, one entry per transcript
-        self.start_codons = {}
-        self.end_codons = {}
-
-        # All other features associated with genes in an annotation file, such as:
-        #    3'/5' UTRs, mRNA, miRNA, siRNA, tRNA, rRNA, ncRNA, snRNA, snoRNA
-        self.features = []
-
-    def acceptorList(self):
-        """
-        Returns a list of acceptors for this gene.
-        """
-        acceptorSet = set()
-        for transcript in self._iter_transcripts():
-            acceptorSet.update(transcript.acceptorList())
-        return sorted(list(acceptorSet), reverse=(self.strand == "-"))
-
-    def _iter_isoforms(self) -> Iterable[Isoform]:
-        return self.isoforms.values()
-
-    def _iter_mrna_records(self) -> Iterable[mRNA]:
-        return self.mrna.values()
-
-    def _iter_transcripts(self) -> Iterable[Isoform | mRNA]:
-        yield from self._iter_isoforms()
-        yield from self._iter_mrna_records()
-
-    def add_cds(self, new_mrna: mRNA, new_cds: CDS) -> bool:
-        """
-        Adds a CDS to the gene if it's unique.
-        Returns True if the CDS was added; false otherwise.
-        """
-        result = False
-        cdsTuple = (new_cds.featureType, new_cds.minpos, new_cds.maxpos)
-        try:
-            cds = self.cdsMap[cdsTuple]
-        except KeyError:
-            cds = new_cds
-            self.cds.append(cds)
-            self.cdsMap[cdsTuple] = cds
-            self.minpos = min(self.minpos, cds.minpos)
-            self.maxpos = max(self.maxpos, cds.maxpos)
-            result = True
-
-        mrna = self.add_mrna(new_mrna)
-        mrna.add_cds(cds)
-        self.start_codons[mrna.id] = mrna.startCodon()
-        self.end_codons[mrna.id] = mrna.endCodon()
-        return result
-
-    def add_exon(self, new_isoform: Isoform, new_exon: Exon) -> bool:
-        """
-        Adds an exon to the gene if it's unique.
-        Returns True if the exon was added; false otherwise.
-        """
-        if new_isoform is None:
-            raise ValueError("Illegal null isoform in exon {}".format(new_exon))
-        result = False
-        posTuple = (new_exon.minpos, new_exon.maxpos)
-        try:
-            exon = self.exonMap[posTuple]
-        except KeyError:
-            exon = new_exon
-            self.exons.append(exon)
-            self.exonMap[posTuple] = exon
-            self.minpos = min(self.minpos, exon.minpos)
-            self.maxpos = max(self.maxpos, exon.maxpos)
-            result = True
-
-        isoform = self.add_isoform(new_isoform)
-        isoform.add_exon(exon)
-        return result
-
-    def add_feature(self, feature: BaseFeature) -> None:
-        if feature.strand != self.strand:
-            raise ValueError(
-                f"ERROR: feature strand '{feature.strand}' does not match "
-                f"gene strand '{self.strand}'"
-            )
-
-        if feature.chromosome != self.chromosome:
-            raise ValueError(
-                f"ERROR: feature chromosome '{feature.chromosome}' does not "
-                f"match gene chromosome '{self.chromosome}'"
-            )
-
-        feature.setParent(self.id)
-        self.minpos = min(self.minpos, feature.minpos)
-        self.maxpos = max(self.maxpos, feature.maxpos)
-        self.features.append(feature)
-
-    def add_isoform(self, isoform: Isoform) -> Isoform:
-        isoform.setParent(self)
-        return self.isoforms.setdefault(isoform.id, isoform)
-
-    def add_mrna(self, mrna: mRNA) -> mRNA:
-        mrna.parent = self
-        return self.mrna.setdefault(mrna.id, mrna)
-
-    def detailString(self):
-        result = (
-            f"{self.id} ({self.chromosome}): {self.start()}-{self.end()} "
-            f"(len={len(self)}, strand={self.strand}), {len(self.exons) + len(self.cds)} "
-            f"exons/cds, range {self.minpos} to {self.maxpos}\n"
-        )
-        result += "\n  ".join([x.detailString() for x in self.isoforms.values()])
-        return result
-
-    def donorList(self):
-        """
-        Returns a list of donors for this gene.
-        """
-        donorSet = set()
-        for transcript in self._iter_transcripts():
-            donorSet.update(transcript.donorList())
-        return sorted(list(donorSet), reverse=(self.strand == "-"))
-
-    def endCodons(self):
-        """Returns a dictionary of splice forms and their associated end codon locations.
-        A codon location is given as a duple of (start,end) positions."""
-        return self.end_codons
-
-    def get_feature_list(self, featureType):
-        return [f for f in self.features if f.featureType == featureType]
-
-    def getIntrons(self):
-        """
-        Returns a list of duples containing start/end positions of introns in this gene.
-        """
-        result = {}
-        for transcript in self._iter_transcripts():
-            exons = transcript.sortedExons()
-            for i in range(1, len(exons)):
-                key = (exons[i - 1].end(), exons[i].start())
-                result[key] = 1
-
-        return result.keys()
-
-    def getIsoform(self, id):
-        return self.isoforms[id]
-
-    def getJunctions(self):
-        """
-        Returns a list of all known splice junctions for this gene
-        based on its isoform list.  List contains only unique
-        donor-acceptor duples.
-        """
-        result = {}
-        for iid in self.isoforms.keys():
-            iso = self.isoforms[iid]
-            exons = sorted(iso.exons, key=featureSortKey, reverse=(self.strand == "-"))
-            for i in range(1, len(exons)):
-                duple = (exons[i - 1].donor(), exons[i].acceptor())
-                result[duple] = 1
-        return result.keys()
-
-    def gffStrings(self):
-        """Returns a GFF string representation of the gene record plus
-        all elements within the gene."""
-        stringList = [self.gffString(altAttributes={ID_FIELD: self.id})]
-        isoSet = set(self.isoforms.keys())
-        mrnaSet = set(self.mrna.keys())
-        commonKeys = isoSet & mrnaSet
-        isoKeys = isoSet - mrnaSet
-        mrnaKeys = mrnaSet - isoSet
-        allKeys = sorted(isoSet | mrnaSet)
-        for k in allKeys:
-            if k in commonKeys:
-                allExons = self.isoforms[k].exons + self.mrna[k].cds
-                allExons.sort(key=featureSortKey, reverse=(self.strand == "-"))
-                stringList.append(self.mrna[k].gffString())
-                gffAttr = {PARENT_FIELD: k}
-                gtfAttr = {
-                    PARENT_FIELD: k,
-                    GTF_TRANSCRIPT: k,
-                    GTF_TRANSNAME: k,
-                    GTF_PROTEIN_ID: k,
-                }
-                # stringList += [e.gffString(altAttributes={PARENT_FIELD:k}) for e in allExons]
-                for e in allExons:
-                    if GTF_TRANSCRIPT in e.attributes:
-                        stringList.append(e.gffString(altAttributes=gtfAttr))
-                    else:
-                        stringList.append(e.gffString(altAttributes=gffAttr))
-
-            elif k in isoKeys:
-                stringList += self.isoforms[k].gffStrings()
-            elif k in mrnaKeys:
-                stringList += self.mrna[k].gffStrings()
-
-        return "\n".join(stringList)
-
-    def gtfStrings(self) -> str:
-        """Returns a GTF string representation of the gene record plus
-        all elements within the gene."""
-        stringList = []
-        isoSet = set(self.isoforms.keys())
-        mrnaSet = set(self.mrna.keys())
-        commonKeys = isoSet & mrnaSet
-        isoKeys = isoSet - mrnaSet
-        mrnaKeys = mrnaSet - isoSet
-        allKeys = sorted(isoSet | mrnaSet)
-        for k in allKeys:
-            if k in commonKeys:
-                allExons = self.isoforms[k].exons + self.mrna[k].cds
-                allExons.sort(key=gtf_feature_sort_key)
-
-                # Ensure that there are codons to write
-                self.mrna[k].inferCodons()
-
-                codonString = (
-                    self.mrna[k].gtfStartCodon()
-                    if self.strand == "+"
-                    else self.mrna[k].gtfStopCodon()
-                )
-                if codonString:
-                    stringList.append(codonString)
-
-                eCtr = 0
-                cCtr = 0
-                for i in range(len(allExons)):
-                    item = allExons[i]
-                    if item.featureType == RecordType.EXON:
-                        eCtr += 1
-                        stringList.append(item.gtfString(k, self, eCtr))
-                    elif item.featureType == RecordType.CDS:
-                        cCtr += 1
-                        stringList.append(item.gtfString(k, self, cCtr))
-
-                codonString = (
-                    self.mrna[k].gtfStopCodon()
-                    if self.strand == "+"
-                    else self.mrna[k].gtfStartCodon()
-                )
-                if codonString:
-                    stringList.append(codonString)
-
-            elif k in isoKeys:
-                stringList += self.isoforms[k].gtfStrings()
-            elif k in mrnaKeys:
-                stringList += self.mrna[k].gtfStrings()
-        return "\n".join(stringList)
-
-    def isSingleExon(self):
-        return len(self.exons) == 1
-
-    def sortedExons(self):
-        """Returns a list of all exons inferred by the gene model, sorted 5' to 3'."""
-        tmpset = set()
-        for isoform in self._iter_isoforms():
-            tmpset.update(isoform.sortedExons())
-
-        # Avoid returning duplicates:
-        stored = set([(e.minpos, e.maxpos) for e in tmpset])
-        for mrna_rec in self._iter_mrna_records():
-            tmpset.update([e for e in mrna_rec.sortedExons() if (e.minpos, e.maxpos) not in stored])
-
-        result = list(tmpset)
-        result.sort(key=featureSortKey, reverse=(self.strand == "-"))
-        return result
-
-    def startCodons(self):
-        """Returns a dictionary of splice forms and their associated start codon locations.
-        A codon location is given as a duple of (start,end) positions."""
-        return self.start_codons
-
-    def __str__(self):
-        return (
-            f"{self.id} ({self.chromosome}): {self.start()}-{self.end()} "
-            f"(len={len(self)}, strand={self.strand}), {len(self.cds) + len(self.exons)} "
-            f"exons/cds, range {self.minpos} to {self.maxpos}"
-        )
-
-
-class PseudoGene(Gene):
-    def __init__(self, id, note, start, end, chromosome, strand, name=None, attr=None):
-        BaseFeature.__init__(self, RecordType.PSEUDOGENE, start, end, chromosome, strand, attr)
-        self.id = id
-        self.name = name
-        self.note = note
-        self.features = []
-        self.exons = []
-        self.cds = []
-        self.mrna = {}
-        self.isoforms = {}
-        self.exonMap = {}
-        self.cdsMap = {}
-
-        self.start_codons = {}
-        self.end_codons = {}
-
-    def detailString(self):
-        return self.__str__()
-
-
+IntervalQuery = _models.IntervalQuery
+ChromosomeGeneIndex = _models.ChromosomeGeneIndex
+Chromosome = _models.Chromosome
+BaseFeature = _models.BaseFeature
+TranscriptRegion = _models.TranscriptRegion
+Exon = _models.Exon
+Isoform = _models.Isoform
+CDS = _models.CDS
+FpUtr = _models.FpUtr
+TpUtr = _models.TpUtr
+Mrna = _models.Mrna
+Gene = _models.Gene
+PseudoGene = _models.PseudoGene
+
+gene_type_filter = _models.gene_type_filter
+default_gene_filter = _models.default_gene_filter
+dict_to_gff = _models.dict_to_gff
+dict_to_gtf = _models.dict_to_gtf
+cds_factory = _models.cds_factory
+feature_cmp = _models.feature_cmp
+feature_sort_key = _models.feature_sort_key
+gene_sort_key = _models.gene_sort_key
+gtf_feature_sort_key = _models.gtf_feature_sort_key
+feature_overlaps = _models.feature_overlaps
+feature_contains = _models.feature_contains
+feature_search = _models.feature_search
+
+
+@dataclass(slots=True)
 class GeneModel:
-    def __init__(
-        self,
-        gff_path: GffRecordSource | None,
-        *,
-        require_notes: bool = False,
-        chromosomes: Sequence[str] | str | None = None,
-        verbose: bool = False,
-        ignore_errors: bool = False,
-    ) -> None:
-        """Instantiates a GeneModel object.  If a path is provided, this will
-        load gene models from the given file."""
-        # 2-dimensional model indexed by chromosome then gene
-        self.allGenes: dict[str, Gene] = {}
-        self.allChr: dict[str, Chromosome] = {}
-        self.foundTypes: dict[RecordType, bool] = {}
-        self.model: dict[str, dict[str, Gene]] = {}
-        self.mRNAforms: dict[str, dict[str, mRNA]] = {}
-        self.sorted: dict[str, dict[str, list[Gene]]] = {}
+    gff_path: GffRecordSource | None
+    require_notes: bool = False
+    chromosomes: Sequence[str] | str | None = None
+    verbose: bool = False
+    ignore_errors: bool = False
+    # 2-dimensional model indexed by chromosome then gene
+    all_genes: dict[str, Gene] = field(init=False, default_factory=dict)
+    all_chr: dict[str, Chromosome] = field(init=False, default_factory=dict)
+    found_types: dict[RecordType, bool] = field(init=False, default_factory=dict)
+    model: dict[str, dict[str, Gene]] = field(init=False, default_factory=dict)
+    mrna_forms: dict[str, dict[str, Mrna]] = field(init=False, default_factory=dict)
+    mrna_gene: dict[str, dict[str, Gene]] = field(init=False, default_factory=dict)
+    chromosome_index: dict[str, ChromosomeGeneIndex] = field(init=False, default_factory=dict)
 
-        if gff_path:  # Load gene models from a file
-            if isinstance(gff_path, str) and not os.path.exists(gff_path):
-                raise ValueError("Gene model file not found: {}".format(gff_path))
+    def __post_init__(self) -> None:
+        """Instantiates a GeneModel object and optionally loads a GFF source."""
+        if not self.gff_path:
+            return
+        if isinstance(self.gff_path, str) and not os.path.exists(self.gff_path):
+            raise ValueError(f"Gene model file not found: {self.gff_path}")
 
-            self.load_gene_model(
-                gff_path,
-                require_notes=require_notes,
-                chromosomes=chromosomes,
-                verbose=verbose,
-                ignore_errors=ignore_errors,
-            )
+        self.load_gene_model(
+            self.gff_path,
+            require_notes=self.require_notes,
+            chromosomes=self.chromosomes,
+            verbose=self.verbose,
+            ignore_errors=self.ignore_errors,
+        )
 
-            if not self.model:
-                raise ValueError("No gene models found in {}".format(gff_path))
-            self.make_sorted_model()
+        if not self.model:
+            raise ValueError(f"No gene models found in {self.gff_path}")
+        self.make_sorted_model()
 
-    def __contains__(self, gene: object) -> bool:
+    def __contains__(self, gene: str | Gene) -> bool:
         """Returns true if a gene is in the model; false otherwise."""
-        return str(gene) in self.allGenes
+        return str(gene) in self.all_genes
 
     def add_chromosome(self, start: int, end: int, name: str) -> None:
         """Adds a chromosome to a gene model or updates the end points
         if the record already exists."""
         key = name.lower()
         try:
-            rec = self.allChr[key]
+            rec = self.all_chr[key]
             rec.minpos = min(rec.minpos, start)
             rec.maxpos = max(rec.maxpos, end)
         except KeyError:
-            self.allChr[key] = Chromosome(start, end, name)
+            self.all_chr[key] = Chromosome(start, end, name)
             self.model.setdefault(key, {})
 
     def add_gene(self, gene: Gene) -> None:
         """Adds a gene to a gene model.  Raises a ValueError if the
         gene has already been added."""
-        if gene.id in self.model[gene.chromosome] or str(gene) in self.allGenes:
-            raise ValueError("Gene {} already stored in gene model".format(gene.id))
+        if gene.id in self.model[gene.chromosome] or str(gene) in self.all_genes:
+            raise ValueError(f"Gene {gene.id} already stored in gene model")
 
         self.model[gene.chromosome][gene.id] = gene
-        self.allGenes[str(gene)] = gene
-
-    def binary_search_genes(
-        self,
-        geneList: list[GeneLikeT],
-        loc: int,
-        lo: int,
-        hi: int,
-        pfx: str = "",
-    ) -> tuple[GeneLikeT | None, GeneLikeT | None]:
-        """Quasi-binary search through a gene list.  Performs binary search to a point,
-        then performs linear search within a refined gene range.  Real binary search may
-        not be possible since gene models may overlap or contain one within another."""
-        if (hi - lo) <= GENE_SEARCH_RANGE:
-            loBound = max(0, lo - GENE_SEARCH_MARGIN)
-            hiBound = min(hi + GENE_SEARCH_MARGIN, len(geneList))
-            for gene in geneList[loBound:hiBound]:
-                if gene.contains(loc, gene.strand):
-                    return (gene, gene)
-            return (None, None)
-        else:
-            midpt = (hi + lo) // 2
-            midGene = geneList[midpt]
-            if midGene.contains(loc, midGene.strand):
-                return (midGene, midGene)
-            elif loc > midGene.maxpos:
-                return self.binary_search_genes(geneList, loc, midpt + 1, hi, pfx + " ")
-            elif loc < midGene.minpos:
-                return self.binary_search_genes(geneList, loc, lo, midpt - 1, pfx + " ")
-        return (None, None)
+        self.all_genes[str(gene)] = gene
 
     def clean_name(self, s: str) -> str:
         """
@@ -1237,57 +152,57 @@ class GeneModel:
         return revised.replace(" ", "-")
 
     def get_all_acceptors(
-        self, geneFilter: GeneFilter = defaultGeneFilter
+        self, gene_filter: GeneFilter = default_gene_filter
     ) -> dict[str, dict[str, set[int]]]:
         """
         Returns a dictionary of all known acceptor sites in the gene model,
         indexed by chromosome and strand.
         """
         result = {}
-        for chrom in self.model.keys():
-            result[chrom] = self.get_known_acceptors(chrom, geneFilter)
+        for chrom in self.model:
+            result[chrom] = self.get_known_acceptors(chrom, gene_filter)
         return result
 
     def get_all_donors(
-        self, geneFilter: GeneFilter = defaultGeneFilter
+        self, gene_filter: GeneFilter = default_gene_filter
     ) -> dict[str, dict[str, set[int]]]:
         """
         Returns a dictionary of all known donor sites in the gene model,
         indexed by chromosome and strand.
         """
         result = {}
-        for chrom in self.model.keys():
-            result[chrom] = self.get_known_donors(chrom, geneFilter)
+        for chrom in self.model:
+            result[chrom] = self.get_known_donors(chrom, gene_filter)
         return result
 
-    def get_all_gene_ids(self, geneFilter: GeneFilter = defaultGeneFilter) -> list[str]:
+    def get_all_gene_ids(self, gene_filter: GeneFilter = default_gene_filter) -> list[str]:
         """Returns a list of ids for all genes stored."""
-        return [g.id for g in self.allGenes.values() if geneFilter(g)]
+        return [g.id for g in self.all_genes.values() if gene_filter(g)]
 
     def get_all_genes(
         self,
-        geneFilter: GeneFilter = defaultGeneFilter,
+        gene_filter: GeneFilter = default_gene_filter,
         *,
         verbose: bool = False,
     ) -> list[Gene]:
         """Returns a list of all genes stored."""
         indicator = ProgressIndicator(10000, verbose=verbose)
         result = []
-        for g in self.allGenes.values():
+        for g in self.all_genes.values():
             indicator.update()
-            if geneFilter(g):
+            if gene_filter(g):
                 result.append(g)
         indicator.finish()
         return result
 
     def get_annotation(
-        self, key: str, annotDict: dict[str, str], default: AttrT | None = None
+        self, key: str, annot_dict: dict[str, str], default: AttrT | None = None
     ) -> str | AttrT | None:
         """
         Convenience method for retrieving a value from an annotation dictionary
         """
         try:
-            return annotDict[key]
+            return annot_dict[key]
         except KeyError:
             return default
 
@@ -1296,8 +211,8 @@ class GeneModel:
         Parses a ';'-separated annotation string containing key-value pairs
         and returns them as a dictionary.
         """
-        valStr = s.replace(" ", "")
-        parts = valStr.split(";")
+        val_str = s.replace(" ", "")
+        parts = val_str.split(";")
         result = {}
         for p in parts:
             if "=" not in p:
@@ -1308,10 +223,10 @@ class GeneModel:
             result[key] = value
         return result
 
-    def get_chromosome(self, chrName: str) -> Chromosome | None:
+    def get_chromosome(self, chr_name: str) -> Chromosome | None:
         """Returns a simple record with basic chromosome information."""
         try:
-            return self.allChr[chrName]
+            return self.all_chr[chr_name]
         except KeyError:
             return None
 
@@ -1319,24 +234,24 @@ class GeneModel:
         """Returns a list of all chromosomes represented in the model."""
         return self.model.keys()
 
-    def get_feature_list(self, featureType: str | RecordType) -> list[BaseFeature]:
+    def get_feature_list(self, feature_type: str | RecordType) -> list[BaseFeature]:
         """
         Returns a list of all features of the given type found in all genes.
         """
         result = []
-        for gene in self.allGenes.values():
-            fList = gene.get_feature_list(featureType)
-            if fList:
-                result += fList
+        for gene in self.all_genes.values():
+            feature_list = gene.get_feature_list(feature_type)
+            if feature_list:
+                result += feature_list
         return result
 
-    def get_gene(self, chrom: str, geneId: str) -> Gene | None:
+    def get_gene(self, chrom: str, gene_id: str) -> Gene | None:
         """
         Returns a gene from within a chromosome.  The gene will contain
         information on all exons within it.
         """
         try:
-            return self.model[chrom.lower()][geneId]
+            return self.model[chrom.lower()][gene_id]
         except KeyError:
             return None
 
@@ -1344,7 +259,7 @@ class GeneModel:
         """
         Returns a gene with the given id if it exists.
         """
-        for k in self.model.keys():
+        for k in self.model:
             try:
                 return self.model[k][id.upper()]
             except KeyError:
@@ -1352,47 +267,38 @@ class GeneModel:
         return None
 
     def get_gene_from_locations(
-        self, chrom: str, startPos: int, endPos: int, strand: str
+        self, chrom: str, start_pos: int, end_pos: int, strand: str
     ) -> Gene | None:
         """
         Finds the gene within the given chromosome that contains the given start
-        and end positions.  Uses quasi-binary search through the sorted list of genes.
+        and end positions.
+
+        Uses the in-memory interval index built by ``make_sorted_model``.
         """
-        # Only get genes on the correct strand:
-        try:
-            geneList = self.sorted[chrom.lower()][strand]
-        except KeyError:
-            raise KeyError(f"Key {chrom.lower()} not found in {','.join(self.sorted.keys())}")
-
-        (logene, higene) = self.binary_search_genes(geneList, startPos, 0, len(geneList) - 1)
-
-        if not (logene or higene):
-            return None
-        elif logene and (logene.contains(startPos, strand) or logene.contains(endPos, strand)):
-            return logene
-        elif higene and (higene.contains(startPos, strand) or higene.contains(endPos, strand)):
-            return higene
-
-        return None
+        chrom_key = chrom.lower()
+        chrom_index = self.chromosome_index.get(chrom_key)
+        if chrom_index is None:
+            raise KeyError(f"Key {chrom_key} not found in {','.join(self.model.keys())}")
+        return chrom_index.find_gene(start_pos, end_pos, strand)
 
     def get_gene_records(
         self,
         chrom: str,
-        geneFilter: GeneFilter = defaultGeneFilter,
+        gene_filter: GeneFilter = default_gene_filter,
         *,
         verbose: bool = False,
     ) -> list[Gene]:
         """
         Returns a list of all gene instances represented within a given chromosome.
-        The gene list may be filtered by changing the geneFilter function.
+        The gene list may be filtered by changing the gene_filter function.
         """
         try:
-            # return [g for g in self.model[chrom.lower()].values() if geneFilter(g)]
+            # return [g for g in self.model[chrom.lower()].values() if gene_filter(g)]
             indicator = ProgressIndicator(10000, verbose=verbose)
             result = []
             for g in self.model[chrom.lower()].values():
                 indicator.update()
-                if geneFilter(g):
+                if gene_filter(g):
                     result.append(g)
             indicator.finish()
             return result
@@ -1426,36 +332,36 @@ class GeneModel:
         return result
 
     def get_known_acceptors(
-        self, chrom: str, geneFilter: GeneFilter = defaultGeneFilter
+        self, chrom: str, gene_filter: GeneFilter = default_gene_filter
     ) -> dict[str, set[int]]:
         """
         Returns a dictionary of all known acceptor sites for the chromosome,
         indexed by strand.
         """
         result: dict[str, set[int]] = {"-": set(), "+": set()}
-        for g in self.get_gene_records(chrom, geneFilter):
-            result[g.strand].update(g.acceptorList())
+        for g in self.get_gene_records(chrom, gene_filter):
+            result[g.strand].update(g.acceptor_list())
         return result
 
     def get_known_donors(
-        self, chrom: str, geneFilter: GeneFilter = defaultGeneFilter
+        self, chrom: str, gene_filter: GeneFilter = default_gene_filter
     ) -> dict[str, set[int]]:
         """
         Returns a dictionary of all known donor sites for the chromosome,
         indexed by strand.
         """
         result: dict[str, set[int]] = {"-": set(), "+": set()}
-        for g in self.get_gene_records(chrom, geneFilter):
-            result[g.strand].update(g.donorList())
+        for g in self.get_gene_records(chrom, gene_filter):
+            result[g.strand].update(g.donor_list())
         return result
 
     def get_parent(
         self,
         s: str,
         chrom: str,
-        searchGenes: bool = True,
-        searchmRNA: bool = True,
-    ) -> Gene | mRNA | None:
+        search_genes: bool = True,
+        search_mrna: bool = True,
+    ) -> Gene | Mrna | None:
         """
         Parent identifiers are not stored in a consistent manner.  We may have
         'AT1G01160', 'AT1G01160.1' or '12345.AT1G01160' or possibly something else.
@@ -1464,12 +370,12 @@ class GeneModel:
         parent_key = s.upper()
         chrom_key = chrom.lower()
 
-        if searchmRNA:
-            chrom_forms = self.mRNAforms.get(chrom_key)
+        if search_mrna:
+            chrom_forms = self.mrna_forms.get(chrom_key)
             if chrom_forms is not None and parent_key in chrom_forms:
                 return chrom_forms[parent_key]
 
-        if searchGenes:
+        if search_genes:
             chrom_genes = self.model.get(chrom_key)
             if chrom_genes is not None and parent_key in chrom_genes:
                 return chrom_genes[parent_key]
@@ -1477,18 +383,22 @@ class GeneModel:
 
     def get_record_types(self) -> list[RecordType]:
         """Returns a list of all record types found in the input file."""
-        return [k for k in self.foundTypes if self.foundTypes[k]]
+        return [k for k in self.found_types if self.found_types[k]]
+
+    def get_mrna_parent(self, chrom: str, mrna_id: str) -> Gene | None:
+        """Return owning gene for a transcript identifier on ``chrom``."""
+        return self.mrna_gene.get(chrom.lower(), {}).get(mrna_id.upper())
 
     def isoform_dict(
         self,
-        geneFilter: GeneFilter = defaultGeneFilter,
+        gene_filter: GeneFilter = default_gene_filter,
         *,
         verbose: bool = False,
     ) -> dict[str, set[str]]:
         """Returns a dictionary that maps gene names to their corresponding
         isoform identifiers.  Each gene is associated with a set of isoform ids."""
         result: dict[str, set[str]] = {}
-        for g in self.get_all_genes(geneFilter=geneFilter, verbose=verbose):
+        for g in self.get_all_genes(gene_filter=gene_filter, verbose=verbose):
             result[g.id] = set(list(g.mrna.keys()) + list(g.isoforms.keys()))
         return result
 
@@ -1513,6 +423,8 @@ class GeneModel:
           'verbose'      - provide verbose feedback (default=False)
           'ignore_errors' - ignore error conditions (default=False)
         """
+        from SpliceGrapher.formats.parsers.gene_model_gff import load_gene_model_records
+
         load_gene_model_records(
             self,
             gff_records,
@@ -1523,34 +435,24 @@ class GeneModel:
         )
 
     def make_sorted_model(self) -> None:
-        self.sorted = {}
-        for chrom in self.model.keys():
-            self.sorted[chrom] = {}
-            # Get a list of gene objects sorted by position
-            geneList = sorted(
-                self.model[chrom].values(),
-                key=geneSortKey,
-            )
-            # Note: we accept unknown ('.') strands, but it's
-            # up to calling routines to ask for them specifically
-            self.sorted[chrom] = {"-": [], "+": [], ".": []}
-            for g in geneList:
-                self.sorted[chrom][g.strand].append(g)
+        self.chromosome_index = {
+            chrom: ChromosomeGeneIndex.build(self.model[chrom].values()) for chrom in self.model
+        }
 
     def write_gff(
         self,
         gff_path: str | TextIO,
         *,
-        geneFilter: GeneFilter = defaultGeneFilter,
-        geneSet: set[str] | list[str] | tuple[str, ...] | None = None,
+        gene_filter: GeneFilter = default_gene_filter,
+        gene_set: set[str] | list[str] | tuple[str, ...] | None = None,
         verbose: bool = False,
     ) -> None:
         """Writes a complete gene model out to a GFF file."""
         write_gene_model_gff(
             self,
             gff_path,
-            gene_filter=geneFilter,
-            gene_set=geneSet,
+            gene_filter=gene_filter,
+            gene_set=gene_set,
             verbose=verbose,
         )
 
@@ -1558,13 +460,13 @@ class GeneModel:
         self,
         gtf_path: str | TextIO,
         *,
-        geneFilter: GeneFilter = defaultGeneFilter,
+        gene_filter: GeneFilter = default_gene_filter,
         verbose: bool = False,
     ) -> None:
         """Writes a complete gene model out to a GTF file."""
         write_gene_model_gtf(
             self,
             gtf_path,
-            gene_filter=geneFilter,
+            gene_filter=gene_filter,
             verbose=verbose,
         )

--- a/SpliceGrapher/formats/models.py
+++ b/SpliceGrapher/formats/models.py
@@ -1,0 +1,1260 @@
+"""
+Stores gene annotation information from a GFF3 annotation
+file and provides methods for searching on the data.
+"""
+
+from __future__ import annotations
+
+# TRYING A NEW WAY TO IDENTIFY GENES:
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import InitVar, dataclass, field
+from typing import TypeVar
+
+from SpliceGrapher.core.enums import AttrKey, RecordType, Strand
+from SpliceGrapher.core.interval_helpers import (
+    InMemoryIntervalIndex,
+    interval_contains,
+    intervals_overlap,
+)
+
+KNOWN_RECTYPES = [
+    RecordType.CDS,
+    RecordType.CHROMOSOME,
+    RecordType.EXON,
+    RecordType.FIVE_PRIME_UTR,
+    RecordType.GENE,
+    RecordType.INTRON,
+    RecordType.MRNA,
+    RecordType.MRNA_TE_GENE,
+    RecordType.NONUNIQUE,
+    RecordType.PROTEIN,
+    RecordType.CDS_PREDICTED,
+    RecordType.PREDICTED_GENE,
+    RecordType.PSEUDOGENE,
+    RecordType.PSEUDOGENIC_EXON,
+    RecordType.PSEUDOGENIC_TRANSCRIPT,
+    RecordType.THREE_PRIME_UTR,
+    RecordType.TRANS_ELE_GENE,
+]
+IGNORE_RECTYPES = {
+    RecordType.PROTEIN,
+    RecordType.INTRON,
+    RecordType.MRNA_TE_GENE,
+    RecordType.TRANS_ELE_GENE,
+    RecordType.NONUNIQUE,
+}
+CDS_TYPES = {RecordType.FIVE_PRIME_UTR, RecordType.THREE_PRIME_UTR, RecordType.CDS}
+
+# Special GTF types for conversions
+GTF_GENE_ID = "gene_id"
+GTF_GENE_NAME = "gene_name"
+GTF_TRANSCRIPT = "transcript_id"
+GTF_TRANSNAME = "transcript_name"
+GTF_SOURCE = "gene_biotype"
+GTF_EXON_ID = "exon_number"
+GTF_PROTEIN_ID = "protein_id"
+
+# Record type map allows mapping unusual names to known types:
+RECTYPE_MAP = {k: k for k in KNOWN_RECTYPES}
+RECTYPE_MAP[RecordType.PREDICTED_GENE] = RecordType.GENE
+RECTYPE_MAP[RecordType.CDS_PREDICTED] = RecordType.CDS
+
+# Virtual types (don't appear in GFF):
+ISOFORM_TYPE = "isoform"
+
+# Annotation fields:
+ID_FIELD = AttrKey.ID
+NAME_FIELD = AttrKey.NAME
+NOTE_FIELD = AttrKey.NOTE
+PARENT_FIELD = AttrKey.PARENT
+
+# There seems to be no consensus about how these tags are used in UCSC, ENSEMBL
+# and other forms of gene models, so we must try each kind:
+POSSIBLE_GENE_FIELDS = [PARENT_FIELD, GTF_GENE_ID, GTF_GENE_NAME]
+POSSIBLE_FORM_FIELDS = [PARENT_FIELD, GTF_TRANSCRIPT]
+
+# ID for GFF output:
+GFF_ID = "SpliceGrapher"
+MAX_BAD_LINES = 3
+
+# Some files contain '.' for an unassigned strand
+VALID_STRANDS = {strand.value for strand in Strand}
+
+FORM_DELIMITERS = [".", "-", "_", ","]
+
+# GeneModel splice-site helpers assume canonical GT/AG-style 2nt dimer boundaries.
+# This remains a compatibility contract for existing callers and fixtures.
+SPLICE_DIMER_OFFSET = 2
+
+# GTF serialization contract: emit records in genomic coordinate order for both
+# strands (ascending minpos, then maxpos) to preserve historical output shape.
+GTF_ORDER_POLICY = "genomic_ascending"
+
+GeneFilter = Callable[["Gene"], bool]
+GffRecordSource = str | list[str] | set[str] | tuple[str, ...]
+AttrValue = str
+AttrMap = Mapping[str | AttrKey, AttrValue]
+ExtraAttrMap = Mapping[str, AttrValue] | Mapping[AttrKey, AttrValue]
+AttrT = TypeVar("AttrT")
+
+
+@dataclass(slots=True)
+class IntervalQuery:
+    """Simple interval wrapper for index overlap queries."""
+
+    minpos: int
+    maxpos: int
+
+
+@dataclass(slots=True)
+class ChromosomeGeneIndex:
+    """Per-chromosome interval/search indexes keyed by strand."""
+
+    by_strand: dict[str, list[Gene]]
+    interval_by_strand: dict[str, InMemoryIntervalIndex[Gene]]
+
+    @classmethod
+    def build(cls, genes: Iterable[Gene]) -> ChromosomeGeneIndex:
+        by_strand: dict[str, list[Gene]] = {"-": [], "+": [], ".": []}
+        for gene in sorted(genes, key=gene_sort_key):
+            by_strand.setdefault(gene.strand, []).append(gene)
+
+        interval_by_strand = {
+            strand: InMemoryIntervalIndex(strand_genes)
+            for strand, strand_genes in by_strand.items()
+            if strand_genes
+        }
+        return cls(by_strand=by_strand, interval_by_strand=interval_by_strand)
+
+    def find_gene(self, start_pos: int, end_pos: int, strand: str) -> Gene | None:
+        strand_index = self.interval_by_strand.get(strand)
+        if strand_index is None:
+            return None
+        query = IntervalQuery(min(start_pos, end_pos), max(start_pos, end_pos))
+        for gene in strand_index.overlaps(query):
+            if gene.contains(start_pos, strand) or gene.contains(end_pos, strand):
+                return gene
+        return None
+
+    def genes(self, strand: str | None = None) -> list[Gene]:
+        if strand is None:
+            return [gene for strand_genes in self.by_strand.values() for gene in strand_genes]
+        return list(self.by_strand.get(strand, []))
+
+
+def gene_type_filter(g: Gene) -> bool:
+    """Convenience filter for getting only 'gene' records."""
+    return g.feature_type == RecordType.GENE
+
+
+def default_gene_filter(g: Gene) -> bool:
+    """Default function for filtering genes from a list."""
+    return True
+
+
+def dict_to_gff(d: Mapping[str, str]) -> str:
+    """Returns a string representation of a dictionary based on the GFF3 annotation format."""
+    return ";".join([f"{k}={v}" for k, v in sorted(d.items()) if k != "parent"])
+
+
+def dict_to_gtf(d: Mapping[str, str]) -> str:
+    """Returns a string representation of a dictionary based on the GTF annotation format."""
+    return "; ".join([f'{k} "{v}"' for k, v in sorted(d.items()) if k != "parent"])
+
+
+def cds_factory(
+    rec_type: RecordType,
+    start_pos: int,
+    end_pos: int,
+    chr_name: str,
+    strand: str,
+    attr: AttrMap | None = None,
+) -> TranscriptRegion:
+    """Simple factory method for creating CDS-type records."""
+    attr = {} if attr is None else {str(key): str(value) for key, value in attr.items()}
+    if rec_type == RecordType.CDS:
+        return CDS(start_pos, end_pos, chr_name, strand, attr)
+    elif rec_type == RecordType.FIVE_PRIME_UTR:
+        return FpUtr(start_pos, end_pos, chr_name, strand, attr)
+    elif rec_type == RecordType.THREE_PRIME_UTR:
+        return TpUtr(start_pos, end_pos, chr_name, strand, attr)
+    else:
+        raise ValueError(f"Illegal CDS record type: {rec_type}")
+
+
+@dataclass(slots=True)
+class Chromosome:
+    """Class that encapsulates a chromosome GFF record."""
+
+    minpos: int
+    maxpos: int
+    name: str
+
+    def __len__(self) -> int:
+        return self.maxpos - self.minpos + 1
+
+    def __str__(self) -> str:
+        return f"{self.name}: {self.minpos}-{self.maxpos}"
+
+    def contains(self, pos: int) -> bool:
+        return self.minpos <= pos <= self.maxpos
+
+    def end(self) -> int:
+        return self.maxpos
+
+    def gff_string(self) -> str:
+        # Example: Chr1    TAIR9   chromosome  1   30427671    .   .   .   ID=Chr1;Name=Chr1
+        name_str = self.name.capitalize()
+        return (
+            f"{name_str}\t{GFF_ID}\tchromosome\t{self.start()}\t{self.end()}\t.\t.\t."
+            f"\tID={name_str};Name={name_str}"
+        )
+
+    def start(self) -> int:
+        return self.minpos
+
+    def update(self, feature: BaseFeature) -> None:
+        """
+        Many species do not have 'chromosome' entries in their annotations,
+        so we must infer chromosome boundaries from observed features.
+        """
+        if feature.chromosome.lower() != self.name.lower():
+            raise ValueError(f"Cannot use feature from {feature.chromosome} to update {self.name}")
+        self.minpos = min(self.minpos, feature.minpos)
+        self.maxpos = max(self.maxpos, feature.maxpos)
+
+
+def feature_cmp(a: BaseFeature, b: BaseFeature) -> int:
+    """
+    General comparison function for sorting any features that have 'minpos'
+    and 'maxpos' attributes.
+    """
+    if a.minpos == b.minpos:
+        return a.maxpos - b.maxpos
+    else:
+        return a.minpos - b.minpos
+
+
+def feature_sort_key(feature: BaseFeature) -> tuple[int, int]:
+    """Sort features by genomic interval."""
+    return (feature.minpos, feature.maxpos)
+
+
+def gene_sort_key(gene: Gene) -> tuple[int, int, str]:
+    """Sort genes by interval, then id for deterministic ties."""
+    return (gene.minpos, gene.maxpos, gene.id)
+
+
+def gtf_feature_sort_key(feature: BaseFeature) -> tuple[int, int]:
+    """Sort key for GTF emission using the genomic-ascending compatibility policy."""
+    return feature_sort_key(feature)
+
+
+def feature_overlaps(a: BaseFeature | None, b: BaseFeature | None) -> bool:
+    """
+    General function for determining whether feature 'a' and feature 'b' overlap.
+    """
+    if not (a and b):
+        return False
+    return intervals_overlap(a, b)
+
+
+def feature_contains(a: BaseFeature | None, b: BaseFeature | None) -> bool:
+    """
+    General function for determining whether feature 'a' contains
+    feature 'b'.  Note that both features must have 'minpos'
+    and 'maxpos' attributes.
+    """
+    if not (a and b):
+        return False
+    return interval_contains(a, b)
+
+
+def feature_search(
+    features: Sequence[BaseFeature],
+    query: BaseFeature,
+    lo: int = 0,
+    hi: int | None = None,
+    overlap_window: int = 8,
+) -> BaseFeature:
+    """
+    Bisect-based search through a sorted feature list.
+
+    Returns either the feature that contains ``query`` or the feature that
+    would immediately precede it.
+    """
+    if not features:
+        raise ValueError("Cannot search an empty feature list")
+
+    if hi is None:
+        hi = len(features) - 1
+
+    lo = max(0, lo)
+    hi = min(hi, len(features) - 1)
+    if lo > hi:
+        raise ValueError("Invalid search bounds")
+
+    index = InMemoryIntervalIndex(features)
+    return index.predecessor_or_containing(
+        query,
+        lo=lo,
+        hi=hi,
+        overlap_window=overlap_window,
+    )
+
+
+def _resolve_gene_ptr(
+    explicit_gene: Gene | None,
+    parent: str | Gene | None,
+    *,
+    context: str,
+) -> Gene:
+    """Resolve parent gene for GTF serialization without requiring object back-links."""
+    if explicit_gene is not None:
+        return explicit_gene
+    if isinstance(parent, Gene):
+        return parent
+    raise RuntimeError(context)
+
+
+@dataclass(slots=True, eq=False)
+class BaseFeature:
+    feature_type: str | RecordType
+    start_pos: InitVar[int]
+    end_pos: InitVar[int]
+    chromosome: str
+    strand: str
+    attr: InitVar[AttrMap | None] = None
+    parent: str | Gene | None = field(init=False, default=None)
+    minpos: int = field(init=False)
+    maxpos: int = field(init=False)
+    attributes: dict[str, str] = field(init=False, default_factory=dict)
+
+    def __post_init__(
+        self,
+        start_pos: int,
+        end_pos: int,
+        attr: AttrMap | None,
+    ) -> None:
+        self.minpos = min(start_pos, end_pos)
+        self.maxpos = max(start_pos, end_pos)
+        self.attributes = (
+            {} if attr is None else {str(key): str(value) for key, value in attr.items()}
+        )
+
+    def acceptor(self) -> int:
+        """
+        Returns the location where the acceptor dimer begins.
+
+        Contract: use canonical splice-dimer assumptions with 1-based
+        chromosome coordinates. On '+' this is exon-start minus 2 nt.
+        On '-' this is the exact exon-start.
+          + Example: AG|CGTATTC
+          - Example: GAATACG|CT (reverse-complement)
+        """
+        return self.start() - SPLICE_DIMER_OFFSET if self.strand == "+" else self.start()
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, BaseFeature):
+            return NotImplemented
+        return (self.chromosome, self.minpos, self.maxpos) < (
+            other.chromosome,
+            other.minpos,
+            other.maxpos,
+        )
+
+    def contains(self, pos: int, strand: str) -> bool:
+        return strand == self.strand and self.minpos <= pos <= self.maxpos
+
+    def detail_string(self) -> str:
+        return (
+            f"Feature: {self.feature_type}\nChromosome: {self.chromosome}\n"
+            f"Start: {self.start()}; End: {self.end()}; Strand: '{self.strand}'"
+        )
+
+    def donor(self) -> int:
+        """
+        Returns the location where the donor dimer begins.
+
+        Contract: use canonical splice-dimer assumptions with 1-based
+        chromosome coordinates. On '+' this is the exon end. On '-'
+        this is exon-end minus 2 nt.
+          + strand example: CGTATTC|GT
+          - strand example: AC|GAATACG
+        """
+        return self.end() if self.strand == "+" else self.end() - SPLICE_DIMER_OFFSET
+
+    def end(self) -> int:
+        return self.maxpos if self.strand == "+" else self.minpos
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, BaseFeature):
+            return NotImplemented
+        return (
+            self.minpos == other.minpos
+            and self.maxpos == other.maxpos
+            and self.strand == other.strand
+            and self.chromosome == other.chromosome
+        )
+
+    def gff_string(self, alt_attributes: ExtraAttrMap | None = None) -> str:
+        """Returns a GFF-formatted representation of the feature."""
+        attrs = dict(self.attributes)
+        if alt_attributes is not None:
+            attrs.update({str(k): str(v) for k, v in alt_attributes.items()})
+
+        return (
+            f"{self.chromosome.capitalize()}\t{GFF_ID}\t{self.feature_type}\t"
+            f"{self.minpos}\t{self.maxpos}\t.\t{self.strand}\t.\t{dict_to_gff(attrs)}"
+        )
+
+    def gtf_string(self, transcript: str, gene_ptr: Gene, exon_id: int) -> str:
+        """Returns a GTF-formatted representation of the feature."""
+        attrs = {str(k).lower(): str(v) for k, v in self.attributes.items()}
+        attrs[GTF_GENE_ID] = gene_ptr.id
+        attrs[GTF_GENE_NAME] = gene_ptr.name
+        attrs[GTF_TRANSCRIPT] = transcript
+        attrs[GTF_EXON_ID] = str(exon_id)
+        try:
+            source = attrs[GTF_SOURCE]
+        except KeyError:
+            source = GFF_ID
+        return (
+            f"{self.chromosome.capitalize()}\t{source}\t{self.feature_type}\t"
+            f"{self.minpos}\t{self.maxpos}\t.\t{self.strand}\t.\t{dict_to_gtf(attrs)}"
+        )
+
+    def __hash__(self) -> int:
+        return hash((self.minpos, self.maxpos, self.strand, self.chromosome))
+
+    def __len__(self) -> int:
+        return self.maxpos - self.minpos + 1
+
+    def set_parent(self, id: str | Gene) -> None:
+        self.parent = id
+
+    def start(self) -> int:
+        return self.minpos if self.strand == "+" else self.maxpos
+
+    def __str__(self) -> str:
+        return f"{self.chromosome} {self.feature_type}: {self.start()}-{self.end()} ({self.strand})"
+
+
+class TranscriptRegion(BaseFeature):
+    def __init__(
+        self,
+        feature_type: str | RecordType,
+        start: int,
+        end: int,
+        chromosome: str,
+        strand: str,
+        attr: AttrMap | None = None,
+    ) -> None:
+        super().__init__(feature_type, start, end, chromosome, strand, attr)
+
+    def add_parent(self, isoform: Isoform | Mrna) -> None:
+        # Compatibility no-op: transcript regions no longer track child->parent object links.
+        _ = isoform
+
+    def __str__(self) -> str:
+        return f"{self.feature_type} {self.start()}-{self.end()}({self.strand})"
+
+
+class Exon(TranscriptRegion):
+    def __init__(
+        self,
+        start: int,
+        end: int,
+        chromosome: str,
+        strand: str,
+        attr: AttrMap | None = None,
+    ) -> None:
+        super().__init__(RecordType.EXON, start, end, chromosome, strand, attr)
+
+
+class Isoform(BaseFeature):
+    def __init__(
+        self,
+        id: str,
+        start: int,
+        end: int,
+        chromosome: str,
+        strand: str,
+        attr: AttrMap | None = None,
+    ) -> None:
+        BaseFeature.__init__(self, ISOFORM_TYPE, start, end, chromosome, strand, attr)
+        self.id: str = id
+        self.features: list[BaseFeature] = []
+        self.exons: list[Exon] = []
+        self.exon_map: dict[tuple[int, int], Exon] = {}
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Isoform):
+            return NotImplemented
+        return self.feature_type == other.feature_type and self.id == other.id
+
+    def acceptor_list(self) -> list[int]:
+        """
+        Returns a list of acceptor positions for the isoform.
+        """
+        ordered_exons = sorted(self.exons, key=feature_sort_key, reverse=(self.strand == "-"))
+        return [e.acceptor() for e in ordered_exons[1:]]
+
+    def add_exon(self, exon: Exon) -> bool:
+        """
+        Adds an exon to the isoform if it's unique.
+        Returns True if the exon was added; false otherwise.
+        """
+        if exon.strand != self.strand:
+            raise ValueError(
+                f"Exon strand '{exon.strand}' does not match isoform "
+                f"strand '{self.strand}' for {self.id}"
+            )
+        if exon.chromosome != self.chromosome:
+            raise ValueError(
+                f"Exon chromosome '{exon.chromosome}' does not match "
+                f"isoform chromosome '{self.chromosome}' for {self.id}"
+            )
+
+        exon_tuple = (exon.minpos, exon.maxpos)
+        if exon_tuple in self.exon_map:
+            return False
+
+        self.exons.append(exon)
+        self.exon_map[exon_tuple] = exon
+        self.minpos = min(self.minpos, exon.minpos)
+        self.maxpos = max(self.maxpos, exon.maxpos)
+        return True
+
+    def add_feature(self, feature: BaseFeature) -> None:
+        if feature.strand != self.strand:
+            raise ValueError(
+                f"ERROR: feature strand '{feature.strand}' does not match "
+                f"form strand '{self.strand}'"
+            )
+
+        if feature.chromosome != self.chromosome:
+            raise ValueError(
+                f"ERROR: feature chromosome '{feature.chromosome}' does not "
+                f"match form chromosome '{self.chromosome}'"
+            )
+
+        feature.set_parent(self.id)
+        self.minpos = min(self.minpos, feature.minpos)
+        self.maxpos = max(self.maxpos, feature.maxpos)
+        self.features.append(feature)
+
+    def detail_string(self) -> str:
+        return (
+            f"Isoform {self.id}\nStart: {self.start()}; End: {self.end()}; "
+            f"Strand: {self.strand}\nExons: [{self.exon_string()}]\n"
+        )
+
+    def donor_list(self) -> list[int]:
+        """
+        Returns a list of donor positions for the isoform.
+        """
+        ordered_exons = sorted(self.exons, key=feature_sort_key, reverse=(self.strand == "-"))
+        return [e.donor() for e in ordered_exons[:-1]]
+
+    def exon_string(self) -> str:
+        return ",".join([str(e) for e in self.exons])
+
+    def get_feature_list(self, feature_type: str | RecordType) -> list[BaseFeature]:
+        return [f for f in self.features if f.feature_type == feature_type]
+
+    def gff_strings(self) -> list[str]:
+        result: list[str] = []
+        # Attributes depend on where data originated
+        gff_attr = {PARENT_FIELD: self.id}
+        gtf_attr = {
+            PARENT_FIELD: self.id,
+            GTF_TRANSCRIPT: self.id,
+            GTF_TRANSNAME: self.id,
+            GTF_PROTEIN_ID: self.id,
+        }
+        for exon in self.exons:
+            if GTF_TRANSCRIPT in exon.attributes:
+                result.append(exon.gff_string(alt_attributes=gtf_attr))
+            else:
+                result.append(exon.gff_string(alt_attributes=gff_attr))
+        return result
+
+    def gtf_strings(self, gene_ptr: Gene | None = None) -> list[str]:
+        result: list[str] = []
+        parent_gene = _resolve_gene_ptr(
+            gene_ptr,
+            self.parent,
+            context="Isoform parent gene is required before writing GTF",
+        )
+        # Compatibility policy: GTF remains genomic-ascending on both strands.
+        exon_list = sorted(self.exons, key=gtf_feature_sort_key)
+        for i in range(len(exon_list)):
+            exon = exon_list[i]
+            result.append(exon.gtf_string(self.id, parent_gene, i + 1))
+        return result
+
+    def sorted_exons(self) -> list[Exon]:
+        """
+        Sorts the exons in an isoform based on its strand and
+        returns the sorted list of exon objects.
+        """
+        return sorted(self.exons, key=feature_sort_key, reverse=(self.strand == "-"))
+
+    def sorted_introns(self) -> list[tuple[int, int]]:
+        """
+        Returns a list of intron (donor,acceptor) tuples sorted based on strand.
+        """
+        result = []
+        exons = self.sorted_exons()
+        prev = exons[0]
+        for e in exons[1:]:
+            result.append((prev.donor(), e.acceptor()))
+            prev = e
+        return result
+
+    def __str__(self) -> str:
+        return (
+            f"{self.id} ({self.chromosome}): {self.start()}-{self.end()} "
+            f"(len={len(self)}, strand={self.strand}), {len(self.exons)} exons/cds, "
+            f"range {self.minpos} to {self.maxpos}"
+        )
+
+
+# Just as exons are part of an isoform, CDS/UTR regions are part of an Mrna sequence:
+class CDS(TranscriptRegion):
+    def __init__(
+        self,
+        start: int,
+        end: int,
+        chromosome: str,
+        strand: str,
+        attr: AttrMap | None = None,
+    ) -> None:
+        super().__init__(RecordType.CDS, start, end, chromosome, strand, attr)
+
+    def __lt__(self, other: object) -> bool:
+        """Compare CDS records, including feature type for tied intervals."""
+        if not isinstance(other, BaseFeature):
+            return NotImplemented
+        return (self.chromosome, self.minpos, self.maxpos, self.feature_type) < (
+            other.chromosome,
+            other.minpos,
+            other.maxpos,
+            other.feature_type,
+        )
+
+    def __eq__(self, o: object) -> bool:
+        """Compare CDS equality by type and genomic location."""
+        if not isinstance(o, BaseFeature):
+            return NotImplemented
+        return (
+            self.feature_type == o.feature_type
+            and self.minpos == o.minpos
+            and self.maxpos == o.maxpos
+            and self.strand == o.strand
+            and self.chromosome == o.chromosome
+        )
+
+    def __str__(self) -> str:
+        return f"{self.feature_type} {self.start()}-{self.end()}({self.strand})"
+
+
+# We treat UTR records the same way as CDS records
+class FpUtr(TranscriptRegion):
+    def __init__(
+        self,
+        start: int,
+        end: int,
+        chromosome: str,
+        strand: str,
+        attr: AttrMap | None = None,
+    ) -> None:
+        super().__init__(RecordType.FIVE_PRIME_UTR, start, end, chromosome, strand, attr)
+
+
+class TpUtr(TranscriptRegion):
+    def __init__(
+        self,
+        start: int,
+        end: int,
+        chromosome: str,
+        strand: str,
+        attr: AttrMap | None = None,
+    ) -> None:
+        super().__init__(RecordType.THREE_PRIME_UTR, start, end, chromosome, strand, attr)
+
+
+class Mrna(Isoform):
+    """
+    An Mrna acts like an isoform in that it is associated with a parent gene
+    and contains a number of coding sequences (CDS).
+    """
+
+    def __init__(
+        self,
+        id: str,
+        start: int,
+        end: int,
+        chromosome: str,
+        strand: str,
+        attr: AttrMap | None = None,
+    ) -> None:
+        BaseFeature.__init__(self, RecordType.MRNA, start, end, chromosome, strand, attr)
+        self.id: str = id
+        self.exons: list[Exon] = []
+        self.features: list[BaseFeature] = []
+        self.cds: list[TranscriptRegion] = []
+        self.cds_map: dict[tuple[int, int], TranscriptRegion] = {}
+        self.start_codon_pos: tuple[int, int] | None = None
+        self.end_codon_pos: tuple[int, int] | None = None
+
+    def acceptor_list(self) -> list[int]:
+        """Returns a list of acceptor positions for the Mrna."""
+        ordered_cds = sorted(self.cds, key=feature_sort_key, reverse=(self.strand == "-"))
+        return [c.acceptor() for c in ordered_cds[1:]]
+
+    def add_cds(self, cds: TranscriptRegion) -> bool:
+        """
+        Adds a CDS to the Mrna if it's unique.
+        Returns True if the CDS was added; false otherwise.
+        """
+        if cds.strand != self.strand:
+            raise ValueError(
+                f"ERROR: CDS strand '{cds.strand}' does not match gene strand '{self.strand}'"
+            )
+        if cds.chromosome != self.chromosome:
+            raise ValueError(
+                f"ERROR: CDS chromosome '{cds.chromosome}' does not match "
+                f"gene chromosome '{self.chromosome}'"
+            )
+
+        cds_tuple = (cds.minpos, cds.maxpos)
+        if cds_tuple in self.cds_map:
+            return False
+        self.cds_map[cds_tuple] = cds
+
+        self.cds.append(cds)
+        return True
+
+    def donor_list(self) -> list[int]:
+        """Returns a list of donor positions for the Mrna."""
+        ordered_cds = sorted(self.cds, key=feature_sort_key, reverse=(self.strand == "-"))
+        return [c.donor() for c in ordered_cds[:-1]]
+
+    def end_codon(self) -> tuple[int, int] | None:
+        """Returns the end codon for this splice form as a duple of (start,end)
+        positions, or None if there are none found.  Positions are relative to
+        the start of the chromosome (1-based)."""
+        if not self.end_codon_pos:
+            self.find_codons()
+        return self.end_codon_pos
+
+    def find_codons(self) -> None:
+        """Infers a transcript's start and end codon positions based on
+        the relative positions of UTR and CDS records."""
+        if self.end_codon_pos and self.start_codon_pos:
+            return
+        if not self.cds:
+            return
+        ordered_cds = sorted(self.cds, key=feature_sort_key, reverse=(self.strand == "-"))
+        prev = ordered_cds[0]
+        for c in ordered_cds[1:]:
+            if (
+                not self.start_codon_pos
+                and prev.feature_type == RecordType.FIVE_PRIME_UTR
+                and c.feature_type == RecordType.CDS
+            ):
+                self.start_codon_pos = (
+                    (c.minpos, c.minpos + 2) if self.strand == "+" else (c.maxpos - 2, c.maxpos)
+                )
+            elif (
+                not self.end_codon_pos
+                and prev.feature_type == RecordType.CDS
+                and c.feature_type == RecordType.THREE_PRIME_UTR
+            ):
+                self.end_codon_pos = (
+                    (prev.maxpos - 2, prev.maxpos)
+                    if self.strand == "+"
+                    else (prev.minpos, prev.minpos + 2)
+                )
+            prev = c
+
+    def infer_codons(self) -> None:
+        """This method will infer start and end codons even when there are no
+        UTR records for a transcript.  It is best to use this only after all
+        data have been loaded for a gene."""
+        # No CDS records --> no way to infer codons
+        if not self.cds:
+            return
+
+        # First try UTR inference:
+        self.find_codons()
+
+        # If either codon is missing, assume the CDS endpoints
+        # represent start/stop codons.
+        ordered_cds = sorted(self.cds, key=feature_sort_key, reverse=(self.strand == "-"))
+        if not self.start_codon_pos:
+            c = ordered_cds[0]
+            self.start_codon_pos = (
+                (c.minpos, c.minpos + 2) if self.strand == "+" else (c.maxpos - 2, c.maxpos)
+            )
+
+        if not self.end_codon_pos:
+            c = ordered_cds[-1]
+            self.end_codon_pos = (
+                (c.maxpos - 2, c.maxpos) if self.strand == "+" else (c.minpos, c.minpos + 2)
+            )
+
+    def get_utrs(self) -> list[TranscriptRegion]:
+        """Returns a list of all UTR records in the Mrna object."""
+        return [
+            c
+            for c in self.cds
+            if c.feature_type in [RecordType.FIVE_PRIME_UTR, RecordType.THREE_PRIME_UTR]
+        ]
+
+    def gff_strings(self) -> list[str]:
+        result = [self.gff_string()]
+        gff_attr = {PARENT_FIELD: self.id}
+        gtf_attr = {
+            PARENT_FIELD: self.id,
+            GTF_TRANSCRIPT: self.id,
+            GTF_TRANSNAME: self.id,
+            GTF_PROTEIN_ID: self.id,
+        }
+        for c in self.cds:
+            if GTF_TRANSCRIPT in c.attributes:
+                result.append(c.gff_string(alt_attributes=gtf_attr))
+            else:
+                result.append(c.gff_string(alt_attributes=gff_attr))
+        return result
+
+    def gtf_start_codon(self, gene_ptr: Gene | None = None) -> str | None:
+        if self.start_codon_pos:
+            parent_gene = _resolve_gene_ptr(
+                gene_ptr,
+                self.parent,
+                context="Mrna parent gene is required before writing start_codon",
+            )
+            return (
+                f"{self.chromosome}\t{GFF_ID}\tstart_codon\t{self.start_codon_pos[0]}"
+                f"\t{self.start_codon_pos[1]}\t.\t{self.strand}\t.\tgene_id "
+                f'"{parent_gene.id}"; transcript_id "{self.id}"'
+            )
+        return None
+
+    def gtf_stop_codon(self, gene_ptr: Gene | None = None) -> str | None:
+        if self.end_codon_pos:
+            parent_gene = _resolve_gene_ptr(
+                gene_ptr,
+                self.parent,
+                context="Mrna parent gene is required before writing stop_codon",
+            )
+            return (
+                f"{self.chromosome}\t{GFF_ID}\tstop_codon\t{self.end_codon_pos[0]}"
+                f"\t{self.end_codon_pos[1]}\t.\t{self.strand}\t.\tgene_id "
+                f'"{parent_gene.id}"; transcript_id "{self.id}"'
+            )
+        return None
+
+    def gtf_strings(self, gene_ptr: Gene | None = None) -> list[str]:
+        """
+        Returns GTF strings for all elements of the Mrna transcript, including
+        start/stop codon locations.
+        """
+        result = []
+        parent_gene = _resolve_gene_ptr(
+            gene_ptr,
+            self.parent,
+            context="Mrna parent gene is required before writing GTF",
+        )
+        codon_string = (
+            self.gtf_start_codon(parent_gene)
+            if self.strand == "+"
+            else self.gtf_stop_codon(parent_gene)
+        )
+        if codon_string:
+            result.append(codon_string)
+
+        # Compatibility policy: GTF remains genomic-ascending on both strands.
+        cds_list = sorted(self.cds, key=gtf_feature_sort_key)
+        for i in range(len(cds_list)):
+            c = cds_list[i]
+            result.append(c.gtf_string(self.id, parent_gene, i + 1))
+
+        codon_string = (
+            self.gtf_stop_codon(parent_gene)
+            if self.strand == "+"
+            else self.gtf_start_codon(parent_gene)
+        )
+        if codon_string:
+            result.append(codon_string)
+
+        return result
+
+    def sorted_cds(self) -> list[TranscriptRegion]:
+        """
+        Sorts the CDS in an Mrna based on its strand and returns the sorted list of CDS objects.
+        """
+        return sorted(self.cds, key=feature_sort_key, reverse=(self.strand == "-"))
+
+    def sorted_exons(self, *, minintron: int = 2) -> list[Exon]:
+        """
+        Infers an exon list from a CDS list and sorts the list based on strand.  Usually
+        this means a 5' UTR record abuts a CDS record or a CDS record abuts a 3' UTR record,
+        in which case an expanded exon represents both.
+        """
+        cds_list = self.sorted_cds()
+        result: list[Exon] = []
+        for i in range(len(cds_list)):
+            cds = cds_list[i]
+            if len(result) > 0 and abs(cds.start() - result[-1].end()) < minintron:
+                prev = result[-1]
+                result[-1] = Exon(prev.start(), cds.end(), self.chromosome, self.strand)
+            else:
+                result.append(Exon(cds.start(), cds.end(), self.chromosome, self.strand))
+        # Revise feature types to indicate CDS instead of exon
+        for e in result:
+            e.feature_type = RecordType.CDS
+        return result
+
+    def start_codon(self) -> tuple[int, int] | None:
+        """Returns the start codon for this splice form as a duple of (start,end)
+        positions, or None if there are none found.  Positions are relative to
+        the start of the chromosome (1-based)."""
+        if not self.start_codon_pos:
+            self.find_codons()
+        return self.start_codon_pos
+
+    def __str__(self) -> str:
+        return (
+            f"{self.id} ({self.chromosome}): {self.start()}-{self.end()} "
+            f"(len={len(self)}, strand={self.strand}), {len(self.cds)} exons/cds, "
+            f"range {self.minpos} to {self.maxpos}"
+        )
+
+
+class Gene(BaseFeature):
+    def __init__(
+        self,
+        id: str,
+        note: str | None,
+        start: int,
+        end: int,
+        chromosome: str,
+        strand: str,
+        name: str | None = None,
+        attr: AttrMap | None = None,
+    ) -> None:
+        BaseFeature.__init__(self, RecordType.GENE, start, end, chromosome, strand, attr)
+        self.id: str = id
+        self.name: str = name if name is not None else id
+        self.note: str | None = note
+        self.isoforms: dict[str, Isoform] = {}
+        self.mrna: dict[str, Mrna] = {}
+        self.exons: list[Exon] = []
+        self.cds: list[TranscriptRegion] = []
+        self.exon_map: dict[tuple[int, int], Exon] = {}
+        self.cds_map: dict[tuple[str | RecordType, int, int], TranscriptRegion] = {}
+
+        # Codons for all transcripts/Mrna, one entry per transcript
+        self.start_codon_map: dict[str, tuple[int, int] | None] = {}
+        self.end_codon_map: dict[str, tuple[int, int] | None] = {}
+
+        # All other features associated with genes in an annotation file, such as:
+        #    3'/5' UTRs, Mrna, miRNA, siRNA, tRNA, rRNA, ncRNA, snRNA, snoRNA
+        self.features: list[BaseFeature] = []
+
+    def acceptor_list(self) -> list[int]:
+        """
+        Returns a list of acceptors for this gene.
+        """
+        acceptor_set = set()
+        for transcript in self._iter_transcripts():
+            acceptor_set.update(transcript.acceptor_list())
+        return sorted(acceptor_set, reverse=(self.strand == "-"))
+
+    def _iter_isoforms(self) -> Iterable[Isoform]:
+        return self.isoforms.values()
+
+    def _iter_mrna_records(self) -> Iterable[Mrna]:
+        return self.mrna.values()
+
+    def _iter_transcripts(self) -> Iterable[Isoform | Mrna]:
+        yield from self._iter_isoforms()
+        yield from self._iter_mrna_records()
+
+    def add_cds(self, new_mrna: Mrna, new_cds: TranscriptRegion) -> bool:
+        """
+        Adds a CDS to the gene if it's unique.
+        Returns True if the CDS was added; false otherwise.
+        """
+        result = False
+        cds_tuple = (new_cds.feature_type, new_cds.minpos, new_cds.maxpos)
+        try:
+            cds = self.cds_map[cds_tuple]
+        except KeyError:
+            cds = new_cds
+            self.cds.append(cds)
+            self.cds_map[cds_tuple] = cds
+            self.minpos = min(self.minpos, cds.minpos)
+            self.maxpos = max(self.maxpos, cds.maxpos)
+            result = True
+
+        mrna = self.add_mrna(new_mrna)
+        mrna.add_cds(cds)
+        self.start_codon_map[mrna.id] = mrna.start_codon()
+        self.end_codon_map[mrna.id] = mrna.end_codon()
+        return result
+
+    def add_exon(self, new_isoform: Isoform, new_exon: Exon) -> bool:
+        """
+        Adds an exon to the gene if it's unique.
+        Returns True if the exon was added; false otherwise.
+        """
+        if new_isoform is None:
+            raise ValueError(f"Illegal null isoform in exon {new_exon}")
+        result = False
+        pos_tuple = (new_exon.minpos, new_exon.maxpos)
+        try:
+            exon = self.exon_map[pos_tuple]
+        except KeyError:
+            exon = new_exon
+            self.exons.append(exon)
+            self.exon_map[pos_tuple] = exon
+            self.minpos = min(self.minpos, exon.minpos)
+            self.maxpos = max(self.maxpos, exon.maxpos)
+            result = True
+
+        isoform = self.add_isoform(new_isoform)
+        isoform.add_exon(exon)
+        return result
+
+    def add_feature(self, feature: BaseFeature) -> None:
+        if feature.strand != self.strand:
+            raise ValueError(
+                f"ERROR: feature strand '{feature.strand}' does not match "
+                f"gene strand '{self.strand}'"
+            )
+
+        if feature.chromosome != self.chromosome:
+            raise ValueError(
+                f"ERROR: feature chromosome '{feature.chromosome}' does not "
+                f"match gene chromosome '{self.chromosome}'"
+            )
+
+        feature.set_parent(self.id)
+        self.minpos = min(self.minpos, feature.minpos)
+        self.maxpos = max(self.maxpos, feature.maxpos)
+        self.features.append(feature)
+
+    def add_isoform(self, isoform: Isoform) -> Isoform:
+        isoform.set_parent(self.id)
+        return self.isoforms.setdefault(isoform.id, isoform)
+
+    def add_mrna(self, mrna: Mrna) -> Mrna:
+        mrna.set_parent(self.id)
+        return self.mrna.setdefault(mrna.id, mrna)
+
+    def detail_string(self) -> str:
+        result = (
+            f"{self.id} ({self.chromosome}): {self.start()}-{self.end()} "
+            f"(len={len(self)}, strand={self.strand}), {len(self.exons) + len(self.cds)} "
+            f"exons/cds, range {self.minpos} to {self.maxpos}\n"
+        )
+        result += "\n  ".join([x.detail_string() for x in self.isoforms.values()])
+        return result
+
+    def donor_list(self) -> list[int]:
+        """
+        Returns a list of donors for this gene.
+        """
+        donor_set = set()
+        for transcript in self._iter_transcripts():
+            donor_set.update(transcript.donor_list())
+        return sorted(donor_set, reverse=(self.strand == "-"))
+
+    def end_codons(self) -> dict[str, tuple[int, int] | None]:
+        """Returns a dictionary of splice forms and their associated end codon locations.
+        A codon location is given as a duple of (start,end) positions."""
+        return self.end_codon_map
+
+    def get_feature_list(self, feature_type: str | RecordType) -> list[BaseFeature]:
+        return [f for f in self.features if f.feature_type == feature_type]
+
+    def get_introns(self) -> set[tuple[int, int]]:
+        """
+        Returns a list of duples containing start/end positions of introns in this gene.
+        """
+        result: set[tuple[int, int]] = set()
+        for transcript in self._iter_transcripts():
+            exons = transcript.sorted_exons()
+            for i in range(1, len(exons)):
+                result.add((exons[i - 1].end(), exons[i].start()))
+        return result
+
+    def get_isoform(self, id: str) -> Isoform:
+        return self.isoforms[id]
+
+    def get_junctions(self) -> set[tuple[int, int]]:
+        """
+        Returns a list of all known splice junctions for this gene
+        based on its isoform list.  List contains only unique
+        donor-acceptor duples.
+        """
+        result: set[tuple[int, int]] = set()
+        for iid in self.isoforms:
+            iso = self.isoforms[iid]
+            exons = sorted(iso.exons, key=feature_sort_key, reverse=(self.strand == "-"))
+            for i in range(1, len(exons)):
+                result.add((exons[i - 1].donor(), exons[i].acceptor()))
+        return result
+
+    def gff_strings(self) -> str:
+        """Returns a GFF string representation of the gene record plus
+        all elements within the gene."""
+        string_list = [self.gff_string(alt_attributes={ID_FIELD: self.id})]
+        iso_set = set(self.isoforms.keys())
+        mrna_set = set(self.mrna.keys())
+        common_keys = iso_set & mrna_set
+        iso_keys = iso_set - mrna_set
+        mrna_keys = mrna_set - iso_set
+        all_keys = sorted(iso_set | mrna_set)
+        for k in all_keys:
+            if k in common_keys:
+                all_exons = self.isoforms[k].exons + self.mrna[k].cds
+                all_exons.sort(key=feature_sort_key, reverse=(self.strand == "-"))
+                string_list.append(self.mrna[k].gff_string())
+                gff_attr = {PARENT_FIELD: k}
+                gtf_attr = {
+                    PARENT_FIELD: k,
+                    GTF_TRANSCRIPT: k,
+                    GTF_TRANSNAME: k,
+                    GTF_PROTEIN_ID: k,
+                }
+                # string_list += [e.gff_string(alt_attributes={PARENT_FIELD:k}) for e in all_exons]
+                for e in all_exons:
+                    if GTF_TRANSCRIPT in e.attributes:
+                        string_list.append(e.gff_string(alt_attributes=gtf_attr))
+                    else:
+                        string_list.append(e.gff_string(alt_attributes=gff_attr))
+
+            elif k in iso_keys:
+                string_list += self.isoforms[k].gff_strings()
+            elif k in mrna_keys:
+                string_list += self.mrna[k].gff_strings()
+
+        return "\n".join(string_list)
+
+    def gtf_strings(self) -> str:
+        """Returns a GTF string representation of the gene record plus
+        all elements within the gene."""
+        string_list = []
+        iso_set = set(self.isoforms.keys())
+        mrna_set = set(self.mrna.keys())
+        common_keys = iso_set & mrna_set
+        iso_keys = iso_set - mrna_set
+        mrna_keys = mrna_set - iso_set
+        all_keys = sorted(iso_set | mrna_set)
+        for k in all_keys:
+            if k in common_keys:
+                all_exons = self.isoforms[k].exons + self.mrna[k].cds
+                all_exons.sort(key=gtf_feature_sort_key)
+
+                # Ensure that there are codons to write
+                self.mrna[k].infer_codons()
+
+                codon_string = (
+                    self.mrna[k].gtf_start_codon(self)
+                    if self.strand == "+"
+                    else self.mrna[k].gtf_stop_codon(self)
+                )
+                if codon_string:
+                    string_list.append(codon_string)
+
+                exon_counter = 0
+                cds_counter = 0
+                for i in range(len(all_exons)):
+                    item = all_exons[i]
+                    if item.feature_type == RecordType.EXON:
+                        exon_counter += 1
+                        string_list.append(item.gtf_string(k, self, exon_counter))
+                    elif item.feature_type == RecordType.CDS:
+                        cds_counter += 1
+                        string_list.append(item.gtf_string(k, self, cds_counter))
+
+                codon_string = (
+                    self.mrna[k].gtf_stop_codon(self)
+                    if self.strand == "+"
+                    else self.mrna[k].gtf_start_codon(self)
+                )
+                if codon_string:
+                    string_list.append(codon_string)
+
+            elif k in iso_keys:
+                string_list += self.isoforms[k].gtf_strings(self)
+            elif k in mrna_keys:
+                string_list += self.mrna[k].gtf_strings(self)
+        return "\n".join(string_list)
+
+    def is_single_exon(self) -> bool:
+        return len(self.exons) == 1
+
+    def sorted_exons(self) -> list[Exon]:
+        """Returns a list of all exons inferred by the gene model, sorted 5' to 3'."""
+        tmp_set = set()
+        for isoform in self._iter_isoforms():
+            tmp_set.update(isoform.sorted_exons())
+
+        # Avoid returning duplicates:
+        stored = {(e.minpos, e.maxpos) for e in tmp_set}
+        for mrna_rec in self._iter_mrna_records():
+            tmp_set.update(e for e in mrna_rec.sorted_exons() if (e.minpos, e.maxpos) not in stored)
+
+        result = list(tmp_set)
+        result.sort(key=feature_sort_key, reverse=(self.strand == "-"))
+        return result
+
+    def start_codons(self) -> dict[str, tuple[int, int] | None]:
+        """Returns a dictionary of splice forms and their associated start codon locations.
+        A codon location is given as a duple of (start,end) positions."""
+        return self.start_codon_map
+
+    def __str__(self) -> str:
+        return (
+            f"{self.id} ({self.chromosome}): {self.start()}-{self.end()} "
+            f"(len={len(self)}, strand={self.strand}), {len(self.cds) + len(self.exons)} "
+            f"exons/cds, range {self.minpos} to {self.maxpos}"
+        )
+
+
+class PseudoGene(Gene):
+    def __init__(
+        self,
+        id: str,
+        note: str | None,
+        start: int,
+        end: int,
+        chromosome: str,
+        strand: str,
+        name: str | None = None,
+        attr: AttrMap | None = None,
+    ) -> None:
+        BaseFeature.__init__(self, RecordType.PSEUDOGENE, start, end, chromosome, strand, attr)
+        self.id = id
+        self.name = name if name is not None else id
+        self.note = note
+        self.features = []
+        self.exons = []
+        self.cds = []
+        self.mrna = {}
+        self.isoforms = {}
+        self.exon_map = {}
+        self.cds_map = {}
+
+        self.start_codon_map = {}
+        self.end_codon_map = {}
+
+    def detail_string(self) -> str:
+        return self.__str__()

--- a/SpliceGrapher/formats/parsers/gene_model_gff.py
+++ b/SpliceGrapher/formats/parsers/gene_model_gff.py
@@ -2,18 +2,76 @@
 
 from __future__ import annotations
 
-import sys
-from collections.abc import Iterable, Sequence
-from typing import TYPE_CHECKING
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import TypeAlias
 
+import structlog
+
+# Safe import boundary: GeneModel loads this parser lazily at call time.
+import SpliceGrapher.formats.gene_model as gm
 from SpliceGrapher.core.enum_coercion import coerce_enum
 from SpliceGrapher.core.enums import RecordType, Strand
 from SpliceGrapher.shared.file_utils import ez_open
 from SpliceGrapher.shared.format_utils import comma_format
 from SpliceGrapher.shared.progress import ProgressIndicator
 
-if TYPE_CHECKING:
-    from SpliceGrapher.formats.gene_model import GeneModel, GffRecordSource
+RecordHandler: TypeAlias = Callable[["ParseContext", "ParsedRecord"], None]
+LOGGER = structlog.get_logger(__name__)
+
+
+@dataclass(slots=True)
+class ParseStats:
+    gene_count: int = 0
+    exon_count: int = 0
+    iso_count: int = 0
+    mrna_count: int = 0
+    cds_count: int = 0
+    orphan_mrna_count: int = 0
+    bad_lines: int = 0
+
+
+@dataclass(slots=True)
+class ParsedRecord:
+    line_no: int
+    raw_line: str
+    annots: dict[str, str]
+    chrom: str
+    rec_type: RecordType
+    start_pos: int
+    end_pos: int
+    strand: str
+
+
+@dataclass(slots=True)
+class ParseContext:
+    model: gm.GeneModel
+    require_notes: bool
+    verbose: bool
+    ignore_errors: bool
+    chromosomes: set[str] | None = None
+    stats: ParseStats = field(default_factory=ParseStats)
+    gene_alias: dict[str, str] = field(default_factory=dict)
+    parent_cache: dict[tuple[str, str, bool, bool], gm.Gene | gm.Mrna] = field(default_factory=dict)
+    parent_candidates: dict[str, tuple[str, ...]] = field(default_factory=dict)
+
+    def fail(self, message: str) -> None:
+        if self.ignore_errors:
+            return
+        raise RuntimeError(message)
+
+    def write_verbose(self, message: str) -> None:
+        if self.verbose:
+            LOGGER.info("gene_model_gff_verbose", message=message)
+
+    def report_bad_line(self, line_no: int) -> None:
+        self.stats.bad_lines += 1
+        self.write_verbose(
+            f"line {line_no}: invalid GFF format (not enough columns); file may be corrupt"
+        )
+        if self.stats.bad_lines >= gm.MAX_BAD_LINES:
+            LOGGER.error("gene_model_gff_invalid_input", line=line_no)
+            raise ValueError("Invalid GFF input file")
 
 
 def _subnames(full_string: str, delimiter: str) -> list[str]:
@@ -21,56 +79,521 @@ def _subnames(full_string: str, delimiter: str) -> list[str]:
     return [delimiter.join(parts[:i]) for i in range(len(parts) - 1, 0, -1)]
 
 
+def _annotation_value(annots: Mapping[str, str], key: object) -> str | None:
+    return annots.get(str(key))
+
+
+def _normalize_chromosomes(chromosomes: Sequence[str] | str | None) -> set[str] | None:
+    if chromosomes is None:
+        return None
+    if isinstance(chromosomes, str):
+        return {chromosomes.lower()} if chromosomes else None
+    return {str(chrom).lower() for chrom in chromosomes}
+
+
+def _candidate_parent_ids(ctx: ParseContext, parent_string: str) -> tuple[str, ...]:
+    cached = ctx.parent_candidates.get(parent_string)
+    if cached is not None:
+        return cached
+
+    candidates: list[str] = []
+    seen: set[str] = set()
+
+    def add_candidate(candidate: str) -> None:
+        if candidate and candidate not in seen:
+            seen.add(candidate)
+            candidates.append(candidate)
+
+    add_candidate(parent_string)
+    delimiters = [delimiter for delimiter in gm.FORM_DELIMITERS if delimiter in parent_string]
+    for delimiter in delimiters:
+        for candidate in _subnames(parent_string, delimiter):
+            add_candidate(candidate)
+    for item in parent_string.split(","):
+        add_candidate(item)
+        for piece in item.split("."):
+            add_candidate(piece)
+
+    result = tuple(candidates)
+    ctx.parent_candidates[parent_string] = result
+    return result
+
+
+def _iter_record_lines(gff_records: gm.GffRecordSource, *, verbose: bool) -> Iterable[str]:
+    if isinstance(gff_records, str):
+        if verbose:
+            LOGGER.info("gene_model_gff_loading_file", source=gff_records)
+        return ez_open(gff_records)
+    if isinstance(gff_records, (list, set, tuple)):
+        if verbose:
+            LOGGER.info(
+                "gene_model_gff_loading_records",
+                record_count=len(gff_records),
+            )
+        return gff_records
+    raise ValueError(
+        "Unrecognized GFF record source "
+        f"({type(gff_records).__name__}); must be file path or a list/set of strings."
+    )
+
+
 def _resolve_parent(
-    model: "GeneModel",
+    ctx: ParseContext,
     parent_id: str,
     chrom: str,
     *,
     search_genes: bool = True,
     search_mrna: bool = True,
-):
-    import SpliceGrapher.formats.gene_model as gm
-
+) -> gm.Gene | gm.Mrna | None:
     parent_string = parent_id.upper()
     chrom_key = chrom.lower()
+    cache_key = (chrom_key, parent_string, search_genes, search_mrna)
+    cached = ctx.parent_cache.get(cache_key)
+    if cached is not None:
+        return cached
 
-    # First try exact lookup on model-owned IDs.
-    exact = model.get_parent(
+    exact = ctx.model.get_parent(
         parent_string,
         chrom_key,
-        searchGenes=search_genes,
-        searchmRNA=search_mrna,
+        search_genes=search_genes,
+        search_mrna=search_mrna,
     )
     if exact is not None:
+        ctx.parent_cache[cache_key] = exact
         return exact
 
-    delimiters = [c for c in gm.FORM_DELIMITERS if c in parent_string]
-    candidates = [parent_string]
-    for delimiter in delimiters:
-        candidates.extend(_subnames(parent_string, delimiter))
+    candidates = _candidate_parent_ids(ctx, parent_string)
 
-    if search_mrna and chrom_key in model.mRNAforms:
-        comma_sep = parent_string.split(",")
-        additional = list(comma_sep)
-        for item in comma_sep:
-            additional.extend(item.split("."))
-        candidates.extend(additional)
+    if search_mrna and chrom_key in ctx.model.mrna_forms:
         for candidate in candidates:
-            transcript = model.mRNAforms[chrom_key].get(candidate)
+            transcript = ctx.model.mrna_forms[chrom_key].get(candidate)
             if transcript is not None:
+                ctx.parent_cache[cache_key] = transcript
                 return transcript
 
-    if search_genes and chrom_key in model.model:
+    if search_genes and chrom_key in ctx.model.model:
         for candidate in candidates:
-            gene = model.model[chrom_key].get(candidate)
+            gene = ctx.model.model[chrom_key].get(candidate)
             if gene is not None:
+                ctx.parent_cache[cache_key] = gene
                 return gene
     return None
 
 
+def _resolve_strand(
+    ctx: ParseContext,
+    *,
+    observed: str,
+    expected: str,
+    mismatch_message: str,
+) -> str:
+    if observed in gm.VALID_STRANDS and observed != expected:
+        ctx.fail(mismatch_message)
+        return observed
+    return expected
+
+
+def _parse_record_line(ctx: ParseContext, line: str, line_no: int) -> ParsedRecord | None:
+    stripped = line.rstrip()
+    if not stripped or stripped[0] == "#":
+        return None
+
+    parts = stripped.split("\t")
+    if len(parts) < 7:
+        ctx.report_bad_line(line_no)
+        return None
+
+    annots = ctx.model.get_annotation_dict(parts[-1])
+    chrom = parts[0].lower()
+    if ctx.chromosomes and chrom not in ctx.chromosomes:
+        return None
+
+    try:
+        rec_type = coerce_enum(parts[2].lower(), RecordType, field="record_type")
+    except ValueError as exc:
+        raise ValueError(f"line {line_no}: unknown record type '{parts[2]}'") from exc
+    rec_type = gm.RECTYPE_MAP.get(rec_type, rec_type)
+
+    start_pos = int(parts[3])
+    end_pos = int(parts[4])
+    try:
+        strand = coerce_enum(parts[6], Strand, field="strand").value
+    except ValueError as exc:
+        raise ValueError(f"line {line_no}: unknown strand '{parts[6]}'") from exc
+
+    ctx.model.found_types[rec_type] = (
+        rec_type in gm.KNOWN_RECTYPES and rec_type not in gm.IGNORE_RECTYPES
+    )
+    if not ctx.model.found_types[rec_type]:
+        return None
+
+    return ParsedRecord(
+        line_no=line_no,
+        raw_line=line,
+        annots=annots,
+        chrom=chrom,
+        rec_type=rec_type,
+        start_pos=start_pos,
+        end_pos=end_pos,
+        strand=strand,
+    )
+
+
+def _handle_gene_record(ctx: ParseContext, record: ParsedRecord) -> None:
+    gid = _annotation_value(record.annots, gm.ID_FIELD)
+    if gid is None:
+        raise ValueError(
+            f"line {record.line_no}: {record.rec_type} record has no ID field:\n{record.raw_line}\n"
+        )
+    gid = gid.upper()
+
+    name = ctx.model.get_annotation(gm.NAME_FIELD, record.annots, None)
+    if name:
+        name = ctx.model.clean_name(name)
+
+    note = ctx.model.get_annotation(gm.NOTE_FIELD, record.annots)
+    if not note and ctx.require_notes:
+        return
+
+    if record.strand not in gm.VALID_STRANDS:
+        ctx.fail(f"line {record.line_no}: {record.rec_type} record with unknown strand")
+
+    if record.chrom not in ctx.model.model:
+        ctx.model.model[record.chrom] = {}
+        ctx.model.add_chromosome(1, record.end_pos, record.chrom)
+
+    if record.rec_type == RecordType.PSEUDOGENE:
+        gene_obj: gm.Gene = gm.PseudoGene(
+            gid,
+            note,
+            record.start_pos,
+            record.end_pos,
+            record.chrom,
+            record.strand,
+            name,
+            record.annots,
+        )
+    else:
+        gene_obj = gm.Gene(
+            gid,
+            note,
+            record.start_pos,
+            record.end_pos,
+            record.chrom,
+            record.strand,
+            name,
+            record.annots,
+        )
+
+    other = ctx.model.all_genes.get(str(gene_obj))
+    if other is not None:
+        ctx.fail(
+            f"line {record.line_no}: gene {gene_obj.id} associated with multiple loci: "
+            f"{other.minpos}-{other.maxpos} and {record.start_pos}-{record.end_pos}"
+        )
+
+    ctx.model.all_chr[record.chrom].update(gene_obj)
+    ctx.model.add_gene(gene_obj)
+    ctx.gene_alias[gene_obj.name.upper()] = gene_obj.id.upper()
+    ctx.stats.gene_count += 1
+
+
+def _resolve_exon_parent(ctx: ParseContext, record: ParsedRecord) -> gm.Gene | None:
+    parent_record: gm.Gene | gm.Mrna | None = None
+    tried: set[str] = set()
+    for key in gm.POSSIBLE_GENE_FIELDS:
+        parent_name = _annotation_value(record.annots, key)
+        if parent_name is None or parent_name in tried:
+            continue
+        parent_record = _resolve_parent(ctx, parent_name, record.chrom)
+        if parent_record is not None:
+            break
+        tried.add(parent_name)
+
+    if parent_record is None:
+        return None
+    if isinstance(parent_record, gm.Mrna):
+        parent_gene = ctx.model.get_mrna_parent(record.chrom, parent_record.id)
+        if parent_gene is None and isinstance(parent_record.parent, gm.Gene):
+            parent_gene = parent_record.parent
+        if parent_gene is None:
+            ctx.fail(f"line {record.line_no}: Mrna parent is missing gene for exon record")
+            return None
+        return parent_gene
+    if not isinstance(parent_record, gm.Gene):
+        ctx.fail(f"line {record.line_no}: exon parent {parent_record} is not a gene")
+        return None
+    return parent_record
+
+
+def _resolve_isoform(
+    ctx: ParseContext,
+    record: ParsedRecord,
+    gene_obj: gm.Gene,
+) -> tuple[gm.Isoform | None, bool]:
+    isoform = None
+    iso_name = ""
+    tried: set[str] = set()
+    for key in gm.POSSIBLE_FORM_FIELDS:
+        name = _annotation_value(record.annots, key)
+        if name is None or name in tried:
+            continue
+        iso_name = name
+        if iso_name in gene_obj.isoforms:
+            isoform = gene_obj.isoforms[iso_name]
+            break
+        tried.add(iso_name)
+
+    if not (isoform or iso_name):
+        return (None, False)
+    if isoform is not None:
+        return (isoform, False)
+
+    strand = _resolve_strand(
+        ctx,
+        observed=record.strand,
+        expected=gene_obj.strand,
+        mismatch_message=(
+            f"line {record.line_no}: exon strand ({record.strand}) != gene "
+            f"strand ({gene_obj.strand}) for {gene_obj.id}"
+        ),
+    )
+    iso_attr = {
+        str(gm.PARENT_FIELD): gene_obj.id,
+        str(gm.NAME_FIELD): iso_name,
+        str(gm.ID_FIELD): iso_name,
+    }
+    return (
+        gm.Isoform(
+            iso_name,
+            record.start_pos,
+            record.end_pos,
+            record.chrom,
+            strand,
+            attr=iso_attr,
+        ),
+        True,
+    )
+
+
+def _handle_exon_record(ctx: ParseContext, record: ParsedRecord) -> None:
+    if record.chrom not in ctx.model.model:
+        return
+
+    gene_obj = _resolve_exon_parent(ctx, record)
+    if gene_obj is None:
+        return
+
+    isoform, created_isoform = _resolve_isoform(ctx, record, gene_obj)
+    if isoform is None:
+        return
+
+    strand = _resolve_strand(
+        ctx,
+        observed=record.strand,
+        expected=gene_obj.strand,
+        mismatch_message=(
+            f"line {record.line_no}: exon strand ({record.strand}) != gene "
+            f"strand ({gene_obj.strand}) for {gene_obj.id}"
+        ),
+    )
+    exon = gm.Exon(record.start_pos, record.end_pos, record.chrom, strand, record.annots)
+    if gene_obj.add_exon(isoform, exon):
+        ctx.stats.exon_count += 1
+    if created_isoform:
+        ctx.stats.iso_count += 1
+
+
+def _resolve_mrna_gene(ctx: ParseContext, record: ParsedRecord, parent_id: str) -> gm.Gene | None:
+    parent_id_upper = parent_id.upper()
+    parent_candidate = _resolve_parent(ctx, parent_id_upper, record.chrom)
+    if isinstance(parent_candidate, gm.Gene):
+        return parent_candidate
+
+    alias = ctx.gene_alias.get(parent_id_upper)
+    if alias is None:
+        return None
+    alias_candidate = _resolve_parent(ctx, alias, record.chrom)
+    if isinstance(alias_candidate, gm.Gene):
+        return alias_candidate
+    return None
+
+
+def _handle_mrna_record(ctx: ParseContext, record: ParsedRecord) -> None:
+    if record.chrom not in ctx.model.model:
+        ctx.fail(
+            f"line {record.line_no}: Mrna with missing chromosome dictionary {record.chrom} "
+            f"(known: {','.join(ctx.model.model.keys())})"
+        )
+        return
+
+    transcript_id = _annotation_value(record.annots, gm.ID_FIELD)
+    if transcript_id is None:
+        ctx.fail(f"line {record.line_no}: Mrna with missing ID")
+        return
+    transcript_id = transcript_id.upper()
+
+    parent_id = ctx.model.get_annotation(gm.PARENT_FIELD, record.annots)
+    if parent_id is None:
+        return
+
+    mrna_gene = _resolve_mrna_gene(ctx, record, parent_id)
+    if mrna_gene is None:
+        ctx.stats.orphan_mrna_count += 1
+        parent_id_upper = parent_id.upper()
+        alias = ctx.gene_alias.get(parent_id_upper, parent_id_upper)
+        if ctx.verbose:
+            if alias == parent_id_upper:
+                ctx.write_verbose(
+                    f"line {record.line_no}: no gene {parent_id_upper} found for {record.rec_type}"
+                )
+            else:
+                ctx.write_verbose(
+                    f"line {record.line_no}: no gene '{parent_id_upper}' or '{alias}' "
+                    f"found for {record.rec_type}"
+                )
+        ctx.fail(f"line {record.line_no}: no gene parent found for transcript {parent_id_upper}")
+        return
+
+    strand = _resolve_strand(
+        ctx,
+        observed=record.strand,
+        expected=mrna_gene.strand,
+        mismatch_message=(
+            f"line {record.line_no}: Mrna strand ({record.strand}) does not "
+            f"match gene strand ({mrna_gene.strand})"
+        ),
+    )
+    mrna_attr = {
+        str(gm.PARENT_FIELD): mrna_gene.id,
+        str(gm.NAME_FIELD): transcript_id,
+        str(gm.ID_FIELD): transcript_id,
+    }
+    mrna = gm.Mrna(
+        transcript_id,
+        record.start_pos,
+        record.end_pos,
+        record.chrom,
+        strand,
+        attr=mrna_attr,
+    )
+    mrna_gene.add_mrna(mrna)
+    ctx.model.mrna_forms.setdefault(record.chrom, {})[transcript_id] = mrna
+    ctx.model.mrna_gene.setdefault(record.chrom, {})[transcript_id] = mrna_gene
+    ctx.stats.mrna_count += 1
+
+
+def _handle_transcript_region_record(ctx: ParseContext, record: ParsedRecord) -> None:
+    if record.chrom not in ctx.model.model:
+        ctx.fail(
+            f"line {record.line_no}: {record.rec_type} has unrecognized chromosome: "
+            f"{record.chrom} (known: {','.join(ctx.model.model.keys())})"
+        )
+        return
+    if record.chrom not in ctx.model.mrna_forms:
+        ctx.fail(
+            f"line {record.line_no}: {record.rec_type} has unrecognized chromosome: "
+            f"{record.chrom} (known: {','.join(ctx.model.mrna_forms.keys())})"
+        )
+        return
+
+    parent_id = _annotation_value(record.annots, gm.PARENT_FIELD)
+    if parent_id is None:
+        return
+    mrna_record = _resolve_parent(ctx, parent_id, record.chrom, search_genes=False)
+    if mrna_record is None:
+        ctx.write_verbose(f"line {record.line_no}: no Mrna {parent_id} found for {record.rec_type}")
+        return
+    if not isinstance(mrna_record, gm.Mrna):
+        ctx.fail(f"line {record.line_no}: parent {parent_id} is not an Mrna record")
+        return
+    parent_gene = ctx.model.get_mrna_parent(record.chrom, mrna_record.id)
+    if parent_gene is None and isinstance(mrna_record.parent, gm.Gene):
+        parent_gene = mrna_record.parent
+    if parent_gene is None:
+        ctx.fail(
+            f"line {record.line_no}: Mrna {mrna_record.id} is missing a parent gene for CDS record"
+        )
+        return
+
+    strand = _resolve_strand(
+        ctx,
+        observed=record.strand,
+        expected=mrna_record.strand,
+        mismatch_message=(
+            f"line {record.line_no}: CDS strand ({record.strand}) does not "
+            f"match Mrna strand ({mrna_record.strand})"
+        ),
+    )
+    cds = gm.cds_factory(
+        record.rec_type,
+        record.start_pos,
+        record.end_pos,
+        record.chrom,
+        strand,
+        record.annots,
+    )
+    if parent_gene.add_cds(mrna_record, cds):
+        ctx.stats.cds_count += 1
+
+
+def _extract_parent_gene_id(parent_id: str) -> str | None:
+    if not parent_id:
+        return None
+    primary_parent = parent_id.split(",", 1)[0].strip()
+    if not primary_parent:
+        return None
+    return primary_parent.split(".", 1)[0]
+
+
+def _handle_misc_feature_record(ctx: ParseContext, record: ParsedRecord) -> None:
+    if record.chrom not in ctx.model.model:
+        return
+    parent_value = _annotation_value(record.annots, gm.PARENT_FIELD)
+    if parent_value is None:
+        return
+    parent_gene_id = _extract_parent_gene_id(parent_value)
+    if not parent_gene_id:
+        return
+    feature_gene = ctx.model.model[record.chrom].get(parent_gene_id)
+    if feature_gene is None:
+        return
+    try:
+        feature_gene.add_feature(
+            gm.BaseFeature(
+                record.rec_type,
+                record.start_pos,
+                record.end_pos,
+                record.chrom,
+                record.strand,
+                record.annots,
+            )
+        )
+    except ValueError as err:
+        ctx.fail(f"line {record.line_no}: {err}")
+
+
+def _handle_chromosome_record(ctx: ParseContext, record: ParsedRecord) -> None:
+    ctx.model.add_chromosome(record.start_pos, record.end_pos, record.chrom)
+
+
+RECORD_HANDLERS: dict[RecordType, RecordHandler] = {
+    RecordType.GENE: _handle_gene_record,
+    RecordType.PSEUDOGENE: _handle_gene_record,
+    RecordType.EXON: _handle_exon_record,
+    RecordType.PSEUDOGENIC_EXON: _handle_exon_record,
+    RecordType.MRNA: _handle_mrna_record,
+    RecordType.PSEUDOGENIC_TRANSCRIPT: _handle_mrna_record,
+    RecordType.CDS: _handle_transcript_region_record,
+    RecordType.FIVE_PRIME_UTR: _handle_transcript_region_record,
+    RecordType.THREE_PRIME_UTR: _handle_transcript_region_record,
+    RecordType.CHROMOSOME: _handle_chromosome_record,
+}
+
+
 def load_gene_model_records(
-    model: "GeneModel",
-    gff_records: "GffRecordSource",
+    model: gm.GeneModel,
+    gff_records: gm.GffRecordSource,
     *,
     require_notes: bool = False,
     chromosomes: Sequence[str] | str | None = None,
@@ -78,384 +601,59 @@ def load_gene_model_records(
     ignore_errors: bool = False,
 ) -> None:
     """Load gene model records from GFF-like input into ``model``."""
-    import SpliceGrapher.formats.gene_model as gm
-
-    chromosomes_list: list[str] | None = None
-
-    # Convenience method for handling exceptions that could be ignored:
-    def conditionalException(message: str) -> None:
-        if not ignore_errors:
-            raise RuntimeError(message)
-
-    if isinstance(gff_records, str):
-        if verbose:
-            sys.stderr.write(f"Loading and validating gene models in {gff_records}\n")
-        instream: Iterable[str] = ez_open(gff_records)
-    elif isinstance(gff_records, (list, set, tuple)):
-        if verbose:
-            sys.stderr.write(f"Loading and validating gene models in {len(gff_records)} records\n")
-        instream = gff_records
-    else:
-        raise ValueError(
-            "Unrecognized GFF record source "
-            f"({type(gff_records).__name__}); must be file path or a list/set of strings."
+    chrom_filter = _normalize_chromosomes(chromosomes)
+    if verbose and chrom_filter is not None:
+        LOGGER.info(
+            "gene_model_gff_chromosome_filter",
+            chromosomes=sorted(chrom_filter),
         )
-
-    if chromosomes is not None:
-        if isinstance(chromosomes, str):
-            chromosomes_list = [chromosomes.lower()] if chromosomes else None
-        else:
-            chromosomes_list = [str(s).lower() for s in chromosomes]
-        if verbose and chromosomes_list is not None:
-            sys.stderr.write(f"GeneModel loading chromosomes {','.join(chromosomes_list)}\n")
 
     model.model = {}
-    model.mRNAforms = {}
-    model.allGenes = {}
-    model.foundTypes = {}
-    model.allChr = {}
-    lineCtr = 0
+    model.mrna_forms = {}
+    model.mrna_gene = {}
+    model.all_genes = {}
+    model.found_types = {}
+    model.all_chr = {}
+    model.chromosome_index = {}
+    ctx = ParseContext(
+        model=model,
+        require_notes=require_notes,
+        verbose=verbose,
+        ignore_errors=ignore_errors,
+        chromosomes=chrom_filter,
+    )
 
-    geneAlias: dict[str, str] = {}
-    geneCount = 0
-    exonCount = 0
-    isoCount = 0
-    mrnaCount = 0
-    cdsCount = 0
-    badLines = 0
     indicator = ProgressIndicator(1000000, verbose=verbose)
-
-    for line in instream:
-        lineCtr += 1
+    for line_no, line in enumerate(_iter_record_lines(gff_records, verbose=verbose), start=1):
         indicator.update()
-        s = line.rstrip()
-        if not s or s[0] == "#":
+        record = _parse_record_line(ctx, line, line_no)
+        if record is None:
             continue
-
-        parts = s.split("\t")
-        if len(parts) < 7:
-            badLines += 1
-            if verbose:
-                sys.stderr.write(
-                    f"line {lineCtr}: invalid GFF format "
-                    "(not enough columns); file may be corrupt\n"
-                )
-            if badLines >= gm.MAX_BAD_LINES:
-                sys.stderr.write("\nInput GFF file appears to be invalid; aborting.\n")
-                raise ValueError("Invalid GFF input file")
-            continue
-
-        annots = model.get_annotation_dict(parts[-1])
-        chrName = parts[0].lower()
-        if chromosomes_list and chrName not in chromosomes_list:
-            continue
-
-        try:
-            recType = coerce_enum(parts[2].lower(), RecordType, field="record_type")
-        except ValueError as exc:
-            raise ValueError(f"line {lineCtr}: unknown record type '{parts[2]}'") from exc
-        recType = gm.RECTYPE_MAP.get(recType, recType)
-
-        startPos = int(parts[3])
-        endPos = int(parts[4])
-        try:
-            strand = coerce_enum(parts[6], Strand, field="strand")
-        except ValueError as exc:
-            raise ValueError(f"line {lineCtr}: unknown strand '{parts[6]}'") from exc
-
-        model.foundTypes[recType] = (
-            recType in gm.KNOWN_RECTYPES and recType not in gm.IGNORE_RECTYPES
-        )
-        if not model.foundTypes[recType]:
-            continue
-
-        if recType in [RecordType.GENE, RecordType.PSEUDOGENE]:
-            try:
-                gid = annots[gm.ID_FIELD].upper()
-            except KeyError:
-                raise ValueError(f"line {lineCtr}: {recType} record has no ID field:\n{line}\n")
-
-            name = model.get_annotation(gm.NAME_FIELD, annots, None)
-            if name:
-                name = model.clean_name(name)
-
-            note = model.get_annotation(gm.NOTE_FIELD, annots)
-            if not note and require_notes:
-                continue
-
-            if strand not in gm.VALID_STRANDS:
-                conditionalException(f"line {lineCtr}: {recType} record with unknown strand")
-
-            if chrName not in model.model:
-                model.model[chrName] = {}
-                model.add_chromosome(1, endPos, chrName)
-
-            if recType == RecordType.PSEUDOGENE:
-                gene_obj: gm.Gene = gm.PseudoGene(
-                    gid, note, startPos, endPos, chrName, strand, name, annots
-                )
-            else:
-                gene_obj = gm.Gene(gid, note, startPos, endPos, chrName, strand, name, annots)
-
-            try:
-                other = model.allGenes[str(gene_obj)]
-                conditionalException(
-                    f"line {lineCtr}: gene {gene_obj.id} associated with multiple loci: "
-                    f"{other.minpos}-{other.maxpos} and {startPos}-{endPos}"
-                )
-            except KeyError:
-                pass
-
-            model.allChr[chrName].update(gene_obj)
-            model.add_gene(gene_obj)
-            geneAlias[gene_obj.name.upper()] = gene_obj.id.upper()
-            geneAlias[gene_obj.id.upper()] = gene_obj.name.upper()
-            geneCount += 1
-
-        elif recType in [RecordType.EXON, RecordType.PSEUDOGENIC_EXON]:
-            if chrName not in model.model:
-                continue
-
-            parent_record: gm.Gene | gm.mRNA | None = None
-            tried = set()
-            for key in gm.POSSIBLE_GENE_FIELDS:
-                if (key not in annots) or (annots[key] in tried):
-                    continue
-                isoName = annots[key]
-                parent_record = _resolve_parent(model, isoName, chrName)
-                if parent_record:
-                    break
-                tried.add(isoName)
-            if not parent_record:
-                continue
-
-            if parent_record.featureType == RecordType.MRNA:
-                gene_obj = parent_record.parent
-                if gene_obj is None:
-                    conditionalException(
-                        f"line {lineCtr}: mRNA parent is missing gene for exon record"
-                    )
-                    continue
-            else:
-                if not isinstance(parent_record, gm.Gene):
-                    conditionalException(
-                        f"line {lineCtr}: exon parent {parent_record} is not a gene"
-                    )
-                    continue
-                gene_obj = parent_record
-
-            isoform = None
-            isoName = ""
-            tried = set()
-            for key in gm.POSSIBLE_FORM_FIELDS:
-                if key not in annots:
-                    continue
-                if annots[key] in tried:
-                    continue
-                isoName = annots[key]
-                if isoName in gene_obj.isoforms:
-                    isoform = gene_obj.isoforms[isoName]
-                    break
-                tried.add(isoName)
-
-            if not (isoform or isoName):
-                continue
-
-            if strand in gm.VALID_STRANDS and strand != gene_obj.strand:
-                conditionalException(
-                    f"line {lineCtr}: exon strand ({strand}) != gene "
-                    f"strand ({gene_obj.strand}) for {gene_obj.id}"
-                )
-            else:
-                strand = gene_obj.strand
-
-            if not isoform:
-                isoAttr = {
-                    gm.PARENT_FIELD: gene_obj.id,
-                    gm.NAME_FIELD: isoName,
-                    gm.ID_FIELD: isoName,
-                }
-                isoform = gm.Isoform(isoName, startPos, endPos, chrName, strand, attr=isoAttr)
-                isoCount += 1
-
-            exon = gm.Exon(startPos, endPos, chrName, strand, annots)
-            exonCount = exonCount + 1 if gene_obj.add_exon(isoform, exon) else exonCount
-
-        elif recType in [RecordType.MRNA, RecordType.PSEUDOGENIC_TRANSCRIPT]:
-            if chrName not in model.model:
-                conditionalException(
-                    f"line {lineCtr}: mRNA with missing chromosome dictionary {chrName} "
-                    f"(known: {','.join(model.model.keys())})"
-                )
-
-            if gm.ID_FIELD not in annots:
-                conditionalException(f"line {lineCtr}: mRNA with missing ID")
-
-            transcript_id = annots[gm.ID_FIELD].upper()
-            parent_id = model.get_annotation(gm.PARENT_FIELD, annots)
-            if parent_id is None:
-                continue
-
-            parent_id_upper = parent_id.upper()
-            mrna_gene: gm.Gene | None = None
-            parent_candidate = _resolve_parent(model, parent_id_upper, chrName)
-            if isinstance(parent_candidate, gm.Gene):
-                mrna_gene = parent_candidate
-            if not mrna_gene:
-                alias = parent_id_upper
-                try:
-                    alias = geneAlias[parent_id_upper]
-                    alias_candidate = _resolve_parent(model, alias, chrName)
-                    if isinstance(alias_candidate, gm.Gene):
-                        mrna_gene = alias_candidate
-                except KeyError:
-                    if verbose:
-                        if alias == parent_id_upper:
-                            sys.stderr.write(
-                                f"line {lineCtr}: no gene {parent_id_upper} found for {recType}\n"
-                            )
-                        else:
-                            sys.stderr.write(
-                                f"line {lineCtr}: no gene '{parent_id_upper}' or "
-                                f"'{alias}' found for {recType}\n"
-                            )
-                    continue
-
-            if mrna_gene is None:
-                conditionalException(
-                    f"line {lineCtr}: no gene parent found for transcript {parent_id_upper}"
-                )
-                continue
-
-            if strand in gm.VALID_STRANDS and strand != mrna_gene.strand:
-                conditionalException(
-                    f"line {lineCtr}: mRNA strand ({strand}) does not "
-                    f"match gene strand ({mrna_gene.strand})"
-                )
-            else:
-                strand = mrna_gene.strand
-
-            mrnaAttr = {
-                gm.PARENT_FIELD: mrna_gene.id,
-                gm.NAME_FIELD: transcript_id,
-                gm.ID_FIELD: transcript_id,
-            }
-            mrna = gm.mRNA(transcript_id, startPos, endPos, chrName, strand, attr=mrnaAttr)
-            mrna_gene.add_mrna(mrna)
-            model.mRNAforms[chrName] = model.mRNAforms.setdefault(chrName, {})
-            model.mRNAforms[chrName][transcript_id] = mrna
-            mrnaCount += 1
-
-        elif recType in gm.CDS_TYPES:
-            if chrName not in model.model:
-                conditionalException(
-                    f"line {lineCtr}: {recType} has unrecognized chromosome: {chrName} "
-                    f"(known: {','.join(model.model.keys())})"
-                )
-            if chrName not in model.mRNAforms:
-                conditionalException(
-                    f"line {lineCtr}: {recType} has unrecognized chromosome: {chrName} "
-                    f"(known: {','.join(model.mRNAforms.keys())})"
-                )
-
-            mrna_record = _resolve_parent(
-                model,
-                annots[gm.PARENT_FIELD],
-                chrName,
-                search_genes=False,
-            )
-            if not mrna_record:
-                if verbose:
-                    sys.stderr.write(
-                        f"line {lineCtr}: no mRNA {annots[gm.PARENT_FIELD]} found for {recType}\n"
-                    )
-                continue
-            if mrna_record.featureType != RecordType.MRNA:
-                conditionalException(
-                    f"line {lineCtr}: parent {annots[gm.PARENT_FIELD]} is not an mRNA record"
-                )
-                continue
-            gene_obj = mrna_record.parent
-            if gene_obj is None:
-                conditionalException(
-                    f"line {lineCtr}: mRNA {mrna_record.id} is missing a parent gene for CDS record"
-                )
-                continue
-
-            if strand in gm.VALID_STRANDS and strand != mrna_record.strand:
-                conditionalException(
-                    f"line {lineCtr}: CDS strand ({strand}) does not "
-                    f"match mRNA strand ({mrna_record.strand})"
-                )
-            else:
-                strand = mrna_record.strand
-
-            cds = gm.cdsFactory(recType, startPos, endPos, chrName, strand, annots)
-            if gene_obj.add_cds(mrna_record, cds):
-                cdsCount += 1
-
-        elif recType == RecordType.CHROMOSOME:
-            model.add_chromosome(startPos, endPos, chrName)
-
-        elif recType in [RecordType.FIVE_PRIME_UTR, RecordType.THREE_PRIME_UTR]:
-            if chrName not in model.model:
-                continue
-            if gm.PARENT_FIELD not in annots:
-                continue
-
-            parent_id = annots[gm.PARENT_FIELD]
-            parent_record = _resolve_parent(model, parent_id, chrName)
-            if parent_record:
-                if strand in gm.VALID_STRANDS and strand != parent_record.strand:
-                    conditionalException(
-                        f"line {lineCtr}: {recType} strand ({strand}) does not match "
-                        f"parent strand ({parent_record.strand})"
-                    )
-                else:
-                    strand = parent_record.strand
-                parent_record.add_feature(
-                    gm.BaseFeature(recType, startPos, endPos, chrName, strand, annots)
-                )
-            else:
-                if verbose:
-                    sys.stderr.write(f"line {lineCtr}: no parent {parent_id} found for {recType}\n")
-                continue
-
-        elif recType not in gm.IGNORE_RECTYPES:
-            if chrName not in model.model:
-                continue
-            if gm.PARENT_FIELD not in annots:
-                continue
-
-            parent_gene_id = annots[gm.PARENT_FIELD].split(".")[0]
-            if parent_gene_id not in model.model[chrName]:
-                continue
-
-            feature_gene = model.model[chrName][parent_gene_id]
-            try:
-                feature_gene.add_feature(
-                    gm.BaseFeature(recType, startPos, endPos, chrName, strand, annots)
-                )
-            except ValueError as err:
-                conditionalException(f"line {lineCtr}: {err}")
+        handler = RECORD_HANDLERS.get(record.rec_type, _handle_misc_feature_record)
+        handler(ctx, record)
 
     indicator.finish()
     if verbose:
-        if geneCount > 0:
-            sys.stderr.write(
-                "Loaded {} genes with {} isoforms, {} exons (avg. {:.1f}/gene), "
-                "{} mRNA, {} CDS (avg. {:.1f}/gene)\n".format(
-                    comma_format(geneCount),
-                    comma_format(isoCount),
-                    comma_format(exonCount),
-                    float(exonCount) / geneCount,
-                    comma_format(mrnaCount),
-                    comma_format(cdsCount),
-                    float(cdsCount / geneCount),
-                )
+        if ctx.stats.gene_count > 0:
+            LOGGER.info(
+                "gene_model_gff_load_summary",
+                gene_count=ctx.stats.gene_count,
+                isoform_count=ctx.stats.iso_count,
+                exon_count=ctx.stats.exon_count,
+                exon_per_gene=round(float(ctx.stats.exon_count) / ctx.stats.gene_count, 1),
+                mrna_count=ctx.stats.mrna_count,
+                orphan_mrna_count=ctx.stats.orphan_mrna_count,
+                cds_count=ctx.stats.cds_count,
+                cds_per_gene=round(float(ctx.stats.cds_count / ctx.stats.gene_count), 1),
+                gene_count_fmt=comma_format(ctx.stats.gene_count),
+                isoform_count_fmt=comma_format(ctx.stats.iso_count),
+                exon_count_fmt=comma_format(ctx.stats.exon_count),
+                mrna_count_fmt=comma_format(ctx.stats.mrna_count),
+                orphan_mrna_count_fmt=comma_format(ctx.stats.orphan_mrna_count),
+                cds_count_fmt=comma_format(ctx.stats.cds_count),
             )
         else:
-            sys.stderr.write("** Warning: no genes loaded!\n")
+            LOGGER.warning("gene_model_gff_no_genes_loaded")
 
 
 __all__ = ["load_gene_model_records"]

--- a/SpliceGrapher/formats/polars_gff_benchmark.py
+++ b/SpliceGrapher/formats/polars_gff_benchmark.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import hashlib
 import json
 import tracemalloc
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from time import perf_counter
-from typing import Callable, TypedDict
+from typing import TypedDict
 
 from SpliceGrapher.formats.gene_model import GeneModel
 from SpliceGrapher.formats.polars_gff import (
@@ -219,9 +220,9 @@ def _exon_records_from_gene_model(path: Path) -> list[tuple[str, str, int, int, 
     model = GeneModel(str(path), verbose=False)
     result: list[tuple[str, str, int, int, str]] = []
 
-    for gene in model.allGenes.values():
-        for exon in gene.exons:
-            for isoform in exon.parents:
+    for gene in model.all_genes.values():
+        for isoform in gene.isoforms.values():
+            for exon in isoform.exons:
                 result.append((exon.chromosome, exon.strand, exon.minpos, exon.maxpos, isoform.id))
 
     return result
@@ -737,13 +738,13 @@ def evaluation_to_markdown(evaluation: SingleCycleEvaluation) -> str:
 
 
 __all__ = [
-    "BenchmarkMetrics",
     "DEFAULT_DATASET_SIZES",
-    "GoNoGoDecision",
     "MEMORY_REGRESSION_THRESHOLD",
     "MIN_WINNING_DATASETS",
     "REQUIRED_REAL_DATASETS",
     "RUNTIME_SPEEDUP_THRESHOLD",
+    "BenchmarkMetrics",
+    "GoNoGoDecision",
     "SingleCycleEvaluation",
     "benchmark_end_to_end_gff_path",
     "benchmark_gff_path",

--- a/SpliceGrapher/formats/writers/gene_model.py
+++ b/SpliceGrapher/formats/writers/gene_model.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Collection
+from collections.abc import Callable, Collection, Iterator
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, TextIO
 
 from SpliceGrapher.shared.progress import ProgressIndicator
@@ -13,16 +14,25 @@ if TYPE_CHECKING:
 GeneFilter = Callable[["Gene"], bool]
 
 
-def _default_gene_filter(gene: "Gene") -> bool:
+def _default_gene_filter(gene: Gene) -> bool:
     return True
 
 
-def _gene_sort_key(gene: "Gene") -> tuple[int, int, str]:
+def _gene_sort_key(gene: Gene) -> tuple[int, int, str]:
     return (gene.minpos, gene.maxpos, gene.id)
 
 
+@contextmanager
+def _open_output(path: str | TextIO) -> Iterator[TextIO]:
+    if isinstance(path, str):
+        with open(path, "w") as stream:
+            yield stream
+        return
+    yield path
+
+
 def write_gff(
-    model: "GeneModel",
+    model: GeneModel,
     gff_path: str | TextIO,
     *,
     gene_filter: GeneFilter = _default_gene_filter,
@@ -30,46 +40,46 @@ def write_gff(
     verbose: bool = False,
 ) -> None:
     """Write full gene model to GFF output."""
-    outStream = open(gff_path, "w") if isinstance(gff_path, str) else gff_path
-    chromList = sorted(model.allChr.keys())
-    indicator = ProgressIndicator(10000, verbose=verbose)
-    for c in chromList:
-        chrom = model.get_chromosome(c)
-        if chrom is None:
-            continue
-        outStream.write(f"{chrom.gffString()}\n")
-        genes = model.get_gene_records(c, gene_filter)
-        if gene_set:
-            genes = [g for g in genes if g.id in gene_set or g.name in gene_set]
-        genes.sort(key=_gene_sort_key)
-        for g in genes:
-            indicator.update()
-            strings = g.gffStrings()
-            if strings:
-                outStream.write(f"{strings}\n")
-    indicator.finish()
+    with _open_output(gff_path) as out_stream:
+        chrom_list = sorted(model.all_chr)
+        indicator = ProgressIndicator(10000, verbose=verbose)
+        for chrom_name in chrom_list:
+            chrom = model.get_chromosome(chrom_name)
+            if chrom is None:
+                continue
+            out_stream.write(f"{chrom.gff_string()}\n")
+            genes = model.get_gene_records(chrom_name, gene_filter)
+            if gene_set:
+                genes = [g for g in genes if g.id in gene_set or g.name in gene_set]
+            genes.sort(key=_gene_sort_key)
+            for gene in genes:
+                indicator.update()
+                strings = gene.gff_strings()
+                if strings:
+                    out_stream.write(f"{strings}\n")
+        indicator.finish()
 
 
 def write_gtf(
-    model: "GeneModel",
+    model: GeneModel,
     gtf_path: str | TextIO,
     *,
     gene_filter: GeneFilter = _default_gene_filter,
     verbose: bool = False,
 ) -> None:
     """Write full gene model to GTF output."""
-    outStream = open(gtf_path, "w") if isinstance(gtf_path, str) else gtf_path
-    chromList = sorted(model.allChr.keys())
-    indicator = ProgressIndicator(10000, verbose=verbose)
-    for c in chromList:
-        genes = model.get_gene_records(c, gene_filter)
-        genes.sort(key=_gene_sort_key)
-        for g in genes:
-            indicator.update()
-            strings = g.gtfStrings()
-            if strings:
-                outStream.write(f"{strings}\n")
-    indicator.finish()
+    with _open_output(gtf_path) as out_stream:
+        chrom_list = sorted(model.all_chr)
+        indicator = ProgressIndicator(10000, verbose=verbose)
+        for chrom_name in chrom_list:
+            genes = model.get_gene_records(chrom_name, gene_filter)
+            genes.sort(key=_gene_sort_key)
+            for gene in genes:
+                indicator.update()
+                strings = gene.gtf_strings()
+                if strings:
+                    out_stream.write(f"{strings}\n")
+        indicator.finish()
 
 
 __all__ = ["write_gff", "write_gtf"]

--- a/SpliceGrapher/shared/progress.py
+++ b/SpliceGrapher/shared/progress.py
@@ -4,14 +4,19 @@ from __future__ import annotations
 
 import random
 import sys
+from collections.abc import Iterator, Sequence
+from typing import Generic, TypeVar
 
 from tqdm.auto import tqdm
 
+T = TypeVar("T")
 
-def _is_tty(stream) -> bool:
+
+def _is_tty(stream: object) -> bool:
     """Return True when a stream is interactive."""
     try:
-        return bool(stream.isatty())
+        isatty = getattr(stream, "isatty", None)
+        return bool(isatty and isatty())
     except Exception:
         return False
 
@@ -19,7 +24,12 @@ def _is_tty(stream) -> bool:
 class ProgressIndicator:
     """Compatibility wrapper around a tqdm progress bar."""
 
-    def __init__(self, increment, description="", verbose=True):
+    def __init__(
+        self,
+        increment: int,
+        description: str = "",
+        verbose: bool = True,
+    ) -> None:
         self.limit = max(1, int(increment))
         self.descr = description
         self.verbose = verbose
@@ -36,15 +46,15 @@ class ProgressIndicator:
             file=sys.stderr,
         )
 
-    def count(self):
+    def count(self) -> int:
         """Returns the current count."""
         return self.ctr
 
-    def finish(self):
+    def finish(self) -> None:
         """Finishes progress output."""
         self._bar.close()
 
-    def reset(self):
+    def reset(self) -> None:
         """Resets the indicator to be used again."""
         self.finish()
         self.ctr = 0
@@ -59,7 +69,7 @@ class ProgressIndicator:
             file=sys.stderr,
         )
 
-    def update(self):
+    def update(self) -> None:
         """Updates the indicator."""
         self.ctr += 1
         if not self.verbose:
@@ -67,24 +77,24 @@ class ProgressIndicator:
         self._bar.update(1)
 
 
-class RandomListIterator:
+class RandomListIterator(Generic[T], Iterator[T]):
     """
     Returns items at random, with replacement, from a list of values.
     For lists with more than ~1000 elements, this is about 30% more
     efficient than using random.sample() repeatedly.
     """
 
-    def __init__(self, values, **args):
+    def __init__(self, values: Sequence[T], *, seed: int | None = None) -> None:
         self.values = values
         self.rand = random.Random()
         self.limit = len(self.values) - 1
-        if "seed" in args:
-            self.rand.seed(args["seed"])
+        if seed is not None:
+            self.rand.seed(seed)
 
-    def __iter__(self):
+    def __iter__(self) -> RandomListIterator[T]:
         return self
 
-    def __next__(self):
+    def __next__(self) -> T:
         """Iterator implementation that returns a random value, with
         replacement, from a list."""
         i = self.rand.randint(0, self.limit)

--- a/tests/test_gene_model.py
+++ b/tests/test_gene_model.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import inspect
-from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
@@ -9,16 +8,6 @@ import pytest
 from SpliceGrapher.core.enums import RecordType, Strand
 from SpliceGrapher.formats import gene_model as gm
 from SpliceGrapher.formats.gene_model import Exon, Gene, GeneModel, feature_search
-
-
-@dataclass
-class _DummyGene:
-    minpos: int
-    maxpos: int
-    strand: str = "+"
-
-    def contains(self, loc: int, strand: str) -> bool:
-        return strand == self.strand and self.minpos <= loc <= self.maxpos
 
 
 def test_feature_search_supports_recursive_midpoint_indexing() -> None:
@@ -33,18 +22,18 @@ def test_feature_search_supports_recursive_midpoint_indexing() -> None:
 
 
 def test_mrna_sorted_exons_uses_explicit_minintron_keyword() -> None:
-    transcript = gm.mRNA("tx1", 1, 20, "chr1", "+")
+    transcript = gm.Mrna("tx1", 1, 20, "chr1", "+")
     transcript.add_cds(gm.CDS(1, 5, "chr1", "+"))
     transcript.add_cds(gm.CDS(7, 10, "chr1", "+"))
 
-    merged = transcript.sortedExons(minintron=3)
-    unmerged = transcript.sortedExons(minintron=2)
+    merged = transcript.sorted_exons(minintron=3)
+    unmerged = transcript.sorted_exons(minintron=2)
 
     assert len(merged) == 1
     assert len(unmerged) == 2
 
     with pytest.raises(TypeError):
-        transcript.sortedExons(min_intron=3)  # type: ignore[call-arg]
+        transcript.sorted_exons(min_intron=3)  # type: ignore[call-arg]
 
 
 def test_feature_search_snake_case_api_returns_expected_match() -> None:
@@ -63,9 +52,9 @@ def test_feature_overlap_and_contains_match_interval_helper_semantics() -> None:
     right = Exon(20, 30, "chr1", "+")
     nested = Exon(12, 18, "chr1", "+")
 
-    assert gm.featureOverlaps(left, right)
-    assert gm.featureContains(left, nested)
-    assert not gm.featureContains(left, right)
+    assert gm.feature_overlaps(left, right)
+    assert gm.feature_contains(left, nested)
+    assert not gm.feature_contains(left, right)
 
 
 def test_feature_search_returns_preceding_feature_when_not_contained() -> None:
@@ -79,14 +68,14 @@ def test_feature_search_returns_preceding_feature_when_not_contained() -> None:
     assert feature_search(features, query) is features[1]
 
 
-def test_binary_search_genes_handles_large_gene_lists() -> None:
+def test_get_gene_from_locations_uses_interval_index() -> None:
     model = GeneModel(None)
-    genes = [_DummyGene(i * 10, (i * 10) + 9) for i in range(30)]
+    model.add_chromosome(1, 1000, "chr1")
+    gene = Gene("GENE_A", None, 150, 190, "chr1", "+", name="GENE_A")
+    model.add_gene(gene)
+    model.make_sorted_model()
 
-    low_gene, high_gene = model.binary_search_genes(genes, 155, 0, len(genes) - 1)
-
-    assert low_gene is genes[15]
-    assert high_gene is genes[15]
+    assert model.get_gene_from_locations("chr1", 155, 160, "+") is gene
 
 
 def test_write_gff_writes_chromosome_records(tmp_path: Path) -> None:
@@ -140,7 +129,7 @@ def test_gene_model_alias_mapping_uses_recordtype_domain() -> None:
 
 
 def test_gene_model_valid_strands_uses_enum_domain() -> None:
-    assert gm.VALID_STRANDS == set(Strand)
+    assert set(Strand) == gm.VALID_STRANDS
 
 
 def test_gene_model_gtf_policy_and_splice_offset_contract_constants() -> None:
@@ -161,29 +150,29 @@ def test_exon_splice_site_offset_contract_is_explicit_for_both_strands() -> None
 def test_isoform_gtf_strings_remain_genomic_ascending_on_minus_strand() -> None:
     gene = Gene("GENE1", None, 1, 200, "chr1", "-", name="GENE1")
     isoform = gm.Isoform("TX1", 1, 200, "chr1", "-")
-    isoform.setParent(gene)
+    isoform.set_parent(gene)
     isoform.add_exon(Exon(80, 90, "chr1", "-"))
     isoform.add_exon(Exon(20, 30, "chr1", "-"))
 
-    starts = [int(line.split("\t")[3]) for line in isoform.gtfStrings()]
+    starts = [int(line.split("\t")[3]) for line in isoform.gtf_strings()]
     assert starts == [20, 80]
 
 
 def test_mrna_gtf_strings_remain_genomic_ascending_on_minus_strand() -> None:
     gene = Gene("GENE1", None, 1, 200, "chr1", "-", name="GENE1")
-    transcript = gm.mRNA("TX1", 1, 200, "chr1", "-")
+    transcript = gm.Mrna("TX1", 1, 200, "chr1", "-")
     transcript.parent = gene
     transcript.add_cds(gm.CDS(80, 90, "chr1", "-"))
     transcript.add_cds(gm.CDS(20, 30, "chr1", "-"))
 
-    cds_starts = [int(line.split("\t")[3]) for line in transcript.gtfStrings()]
+    cds_starts = [int(line.split("\t")[3]) for line in transcript.gtf_strings()]
     assert cds_starts == [20, 80]
 
 
 def test_gene_gtf_strings_common_path_remains_genomic_ascending_on_minus_strand() -> None:
     gene = Gene("GENE1", None, 1, 200, "chr1", "-", name="GENE1")
     isoform = gm.Isoform("TX1", 1, 200, "chr1", "-")
-    transcript = gm.mRNA("TX1", 1, 200, "chr1", "-")
+    transcript = gm.Mrna("TX1", 1, 200, "chr1", "-")
     gene.add_isoform(isoform)
     gene.add_mrna(transcript)
 
@@ -194,7 +183,7 @@ def test_gene_gtf_strings_common_path_remains_genomic_ascending_on_minus_strand(
 
     feature_starts = [
         int(line.split("\t")[3])
-        for line in gene.gtfStrings().splitlines()
+        for line in gene.gtf_strings().splitlines()
         if line.split("\t")[2] in {RecordType.EXON.value, RecordType.CDS.value}
     ]
     assert feature_starts == sorted(feature_starts)
@@ -207,6 +196,17 @@ def test_exon_default_attributes_are_not_shared() -> None:
     exon_one.attributes["tag"] = "one"
 
     assert "tag" not in exon_two.attributes
+
+
+def test_transcript_regions_do_not_store_parent_backlinks() -> None:
+    gene = Gene("GENE1", None, 1, 100, "chr1", "+")
+    isoform = gm.Isoform("TX1", 1, 100, "chr1", "+")
+    exon = Exon(10, 20, "chr1", "+")
+
+    gene.add_isoform(isoform)
+    isoform.add_exon(exon)
+
+    assert not hasattr(exon, "parents")
 
 
 def test_gene_default_attributes_are_not_shared() -> None:
@@ -233,6 +233,8 @@ def test_basefeature_hash_matches_equality_contract() -> None:
 
 
 def test_load_gene_model_delegates_to_parser_boundary(monkeypatch: pytest.MonkeyPatch) -> None:
+    from SpliceGrapher.formats.parsers import gene_model_gff as parser_boundary
+
     model = GeneModel(None)
     records = ["chr1\tsrc\tgene\t1\t10\t.\t+\t.\tID=GENE1;Name=GENE1"]
     calls: dict[str, object] = {}
@@ -244,7 +246,7 @@ def test_load_gene_model_delegates_to_parser_boundary(monkeypatch: pytest.Monkey
         calls["records"] = gff_records_arg
         calls["kwargs"] = kwargs
 
-    monkeypatch.setattr(gm, "load_gene_model_records", _fake_loader)
+    monkeypatch.setattr(parser_boundary, "load_gene_model_records", _fake_loader)
 
     model.load_gene_model(records, verbose=True)
 
@@ -256,6 +258,20 @@ def test_load_gene_model_delegates_to_parser_boundary(monkeypatch: pytest.Monkey
         "verbose": True,
         "ignore_errors": False,
     }
+
+
+def test_load_gene_model_populates_mrna_parent_lookup() -> None:
+    model = GeneModel(None)
+    records = [
+        "chr1\tsrc\tgene\t1\t100\t.\t+\t.\tID=GENE1;Name=GENE1",
+        "chr1\tsrc\tmRNA\t1\t100\t.\t+\t.\tID=TX1;Parent=GENE1",
+    ]
+
+    model.load_gene_model(records)
+
+    parent = model.get_mrna_parent("chr1", "tx1")
+    assert parent is not None
+    assert parent.id == "GENE1"
 
 
 def test_write_gff_delegates_to_writer_boundary(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -285,7 +301,7 @@ def test_write_gff_delegates_to_writer_boundary(monkeypatch: pytest.MonkeyPatch)
 
     assert calls["model"] is model
     assert calls["path"] is out_stream
-    assert calls["gene_filter"] is gm.defaultGeneFilter
+    assert calls["gene_filter"] is gm.default_gene_filter
     assert calls["gene_set"] is None
     assert calls["verbose"] is True
 
@@ -315,7 +331,7 @@ def test_write_gtf_delegates_to_writer_boundary(monkeypatch: pytest.MonkeyPatch)
 
     assert calls["model"] is model
     assert calls["path"] is out_stream
-    assert calls["gene_filter"] is gm.defaultGeneFilter
+    assert calls["gene_filter"] is gm.default_gene_filter
     assert calls["verbose"] is True
 
 
@@ -383,7 +399,7 @@ def test_get_all_genes_keyword_is_supported() -> None:
     model.add_chromosome(1, 100, "chr1")
     model.add_gene(Gene("GENE1", None, 10, 20, "chr1", "+", name="GENE1"))
 
-    genes = model.get_all_genes(geneFilter=gm.defaultGeneFilter)
+    genes = model.get_all_genes(gene_filter=gm.default_gene_filter)
 
     assert [g.id for g in genes] == ["GENE1"]
 
@@ -394,4 +410,4 @@ def test_get_parent_keywords_are_supported() -> None:
     gene = Gene("GENE1", None, 10, 20, "chr1", "+", name="GENE1")
     model.add_gene(gene)
 
-    assert model.get_parent("GENE1", "chr1", searchGenes=True, searchmRNA=False) is gene
+    assert model.get_parent("GENE1", "chr1", search_genes=True, search_mrna=False) is gene


### PR DESCRIPTION
## Summary
- split the monolithic GeneModel runtime module by introducing `SpliceGrapher/formats/models.py` for feature/domain entities and helper constants
- convert `SpliceGrapher/formats/gene_model.py` into a `GeneModel` orchestration facade that re-exports model symbols for compatibility
- harden the parser boundary in `SpliceGrapher/formats/parsers/gene_model_gff.py` with typed parse context, dispatch handlers, parent lookup caching, structured logging, and one-way transcript ownership
- remove transcript-region child->parent back-link storage (`exon.parents` / `cds.parents`) and switch parser parent resolution to explicit `GeneModel.mrna_gene` mapping
- update related annotation/writer/progress utilities and benchmark/test call sites to preserve behavior under the new boundary

## Migration Impact (iDiffIR / TAPIS)
- Import compatibility is preserved through `SpliceGrapher.formats.gene_model` re-exports.
- Legacy runtime behavior for GFF/GTF parsing/writing remains parity-focused in this tranche.
- One internal behavior shift: transcript regions no longer expose `parents` back-links; ownership should be resolved through gene/transcript containers.

## Issue Tracking
- Closes #158
- Follow-ups: #159, #160

## Test Plan
- `uv run ruff check . --fix`
- `uv run ruff format .`
- `PYTHONDONTWRITEBYTECODE=1 uv run pytest -q -p no:cacheprovider`
- `uv run mypy SpliceGrapher/formats/models.py SpliceGrapher/formats/gene_model.py SpliceGrapher/formats/parsers/gene_model_gff.py SpliceGrapher/formats/writers/gene_model.py SpliceGrapher/formats/annotation_io.py SpliceGrapher/formats/polars_gff_benchmark.py SpliceGrapher/shared/progress.py tests/test_gene_model.py`
