### PR TITLE
refactor: hard cut SpliceGraph to networkx core

### DIFF
--- a/SpliceGrapher/SpliceGraph.py
+++ b/SpliceGrapher/SpliceGraph.py
@@ -1,139 +1,59 @@
-"""
-Module that encapsulates a splice graph.
-"""
+"""NetworkX-backed splice graph core and parser."""
 
 from __future__ import annotations
 
 import sys
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable
+from dataclasses import dataclass, field
 from typing import TextIO
 
+import networkx as nx
 import structlog
 
 from SpliceGrapher.core.enum_coercion import coerce_enum
 from SpliceGrapher.core.enums import (
     ALT_SPLICE_EVENT_CODE_BY_NAME,
-    ALT_SPLICE_EVENT_NAME_BY_CODE,
     AlternativeSplicingEvent,
     AlternativeSplicingEventName,
     AttrKey,
-    EdgeType,
     NodeDisposition,
     RecordType,
     Strand,
 )
-from SpliceGrapher.core.interval_helpers import (
-    InMemoryIntervalIndex,
-    interval_contains,
-    intervals_overlap,
-)
-from SpliceGrapher.shared.collection_utils import as_list
 from SpliceGrapher.shared.file_utils import ez_open
-from SpliceGrapher.shared.format_utils import list_string
-from SpliceGrapher.shared.process_utils import idFactory
 from SpliceGrapher.shared.progress import ProgressIndicator
 
 LOGGER = structlog.get_logger(__name__)
 
-# Attributes used in standard GFF3 files:
 SOURCE_NAME = "SpliceGraph"
 DEPRECATED_GENE_REC = RecordType.CLUSTER.value
 GENE_REC = RecordType.GRAPH.value
 PARENT_REC = RecordType.PARENT.value
 CHILD_REC = RecordType.CHILD.value
-VALID_GENES = [DEPRECATED_GENE_REC, GENE_REC]
-VALID_RECTYPES = [DEPRECATED_GENE_REC, GENE_REC, PARENT_REC, CHILD_REC]
+VALID_GENES = frozenset({DEPRECATED_GENE_REC, GENE_REC})
+VALID_RECTYPES = frozenset({DEPRECATED_GENE_REC, GENE_REC, PARENT_REC, CHILD_REC})
 
-# Graph node attributes for splice graph GFF files
 PARENT_ATTR = AttrKey.PARENT.value
 ID_ATTR = AttrKey.ID.value
-KNOWN_ATTRS = [PARENT_ATTR, ID_ATTR]
-
-# Specific node attribute and values for AS forms:
+KNOWN_ATTRS = frozenset({PARENT_ATTR, ID_ATTR})
 AS_KEY = AttrKey.ALT_FORM.value
-
-# Attributes for unresolved nodes:
-PUTATIVE_PARENTS = "putative_parents"
-PUTATIVE_CHILDREN = "putative_children"
-
-# Attributes for predicting protein sequences:
 START_CODON_KEY = AttrKey.START_CODON.value
 END_CODON_KEY = AttrKey.END_CODON.value
-
-# Alternative splicing event names and abbreviations are defined canonically in core.enums.
-IR_NAME = AlternativeSplicingEventName.IR.value
-ALT5_NAME = AlternativeSplicingEventName.ALT5.value
-ALT3_NAME = AlternativeSplicingEventName.ALT3.value
-ALTB3_NAME = AlternativeSplicingEventName.ALTB3.value
-ALTB5_NAME = AlternativeSplicingEventName.ALTB5.value
-ES_NAME = AlternativeSplicingEventName.ES.value
-ALTI_NAME = AlternativeSplicingEventName.ALTI.value
-ALTT_NAME = AlternativeSplicingEventName.ALTT.value
-AS_NAMES = [event_name.value for event_name in AlternativeSplicingEventName]
-
-IR_ABBREV = AlternativeSplicingEvent.IR.value
-ALT5_ABBREV = AlternativeSplicingEvent.ALT5.value
-ALT3_ABBREV = AlternativeSplicingEvent.ALT3.value
-ALTB3_ABBREV = AlternativeSplicingEvent.ALTB3.value
-ALTB5_ABBREV = AlternativeSplicingEvent.ALTB5.value
-ES_ABBREV = AlternativeSplicingEvent.ES.value
-ALTI_ABBREV = AlternativeSplicingEvent.ALTI.value
-ALTT_ABBREV = AlternativeSplicingEvent.ALTT.value
-AS_ABBREVS = [event.value for event in AlternativeSplicingEvent]
-AS_ABBREV_SET = {event.value for event in AlternativeSplicingEvent}
-
-EVENT_NAME = {
-    event.value: ALT_SPLICE_EVENT_NAME_BY_CODE[event].value for event in AlternativeSplicingEvent
-}
-EVENT_ABBREV = {
-    event_name.value: event.value for event_name, event in ALT_SPLICE_EVENT_CODE_BY_NAME.items()
-}
-
-ALT_35_NAMES = [ALT3_NAME, ALT5_NAME, ALTB3_NAME, ALTB5_NAME]
-ALT_35_ABBREVS = [ALT3_ABBREV, ALT5_ABBREV, ALTB3_ABBREV, ALTB5_ABBREV]
-NON_35_NAMES = set(AS_NAMES) - set(ALT_35_NAMES)
-NON_35_EVENTS = set(AlternativeSplicingEvent) - {
-    AlternativeSplicingEvent.ALT3,
-    AlternativeSplicingEvent.ALT5,
-    AlternativeSplicingEvent.ALTB3,
-    AlternativeSplicingEvent.ALTB5,
-}
-NON_35_ABBREVS = {event.value for event in NON_35_EVENTS}
-
-# Dispositions for nodes in a graph:
+ISO_KEY = AttrKey.ISOFORMS.value
 DISPOSITION_KEY = AttrKey.DISPOSITION.value
 KNOWN_NODE = NodeDisposition.KNOWN.value
 PREDICTED_NODE = NodeDisposition.PREDICTED.value
 UNRESOLVED_NODE = NodeDisposition.UNRESOLVED.value
-
-# Edge types for adding edges to new nodes
-PARENT_EDGE = EdgeType.PARENT.value
-CHILD_EDGE = EdgeType.CHILD.value
-ALL_EDGE_TYPES = [PARENT_EDGE, CHILD_EDGE]
-
-# Identifies predicted nodes
-PNODE_PREFIX = "pred_"
-
-# Attributes used for displaying splice graphs:
+PUTATIVE_PARENTS = "putative_parents"
+PUTATIVE_CHILDREN = "putative_children"
 ACCEPTORS_KEY = "acceptors"
 DONORS_KEY = "donors"
-INFORMATION_KEY = "as_info"
-
-# Keys for retained intron evidence cross-referencing
-IR_TP_EVIDENCE = "ir_tp_evidence"
-IR_FP_EVIDENCE = "ir_fp_evidence"
-
-# Specific node attribute for isoform names
-ISO_KEY = AttrKey.ISOFORMS.value
-
-# Specific graph attribute for expanded gene models
 ALT_MODEL_KEY = AttrKey.EXPANDED.value
+VALID_STRANDS = frozenset({strand.value for strand in Strand})
 
-VALID_STRANDS = [Strand.PLUS.value, Strand.MINUS.value]
+NodeAttributeValue = str | set[int]
 
 
-# ========================================================================
-# Function definitions
 def _coerce_alt_splicing_event(
     form: str | AlternativeSplicingEvent | AlternativeSplicingEventName,
 ) -> AlternativeSplicingEvent:
@@ -155,629 +75,36 @@ def _coerce_alt_splicing_event(
             raise ValueError(f"Unknown alternative splicing form: {form}") from exc
 
 
-def acceptor(node: SpliceGraphNode) -> int:
-    """Returns the strand-adjusted position at the start of the acceptor dimer."""
-    return node.minpos - 2 if node.strand == "+" else node.maxpos
-
-
-def containsEdge(node: SpliceGraphNode, edge: Edge) -> bool:
-    """Returns true if the Node contains the given Edge; false otherwise.  Note
-    that the edge must be completely contained within the node (<,>)."""
-    return interval_contains(node, edge, strict=True)
-
-
-def containsNode(edge: Edge, node: SpliceGraphNode) -> bool:
-    """Returns true if the Edge contains the given Node; false otherwise.  Note
-    that the node must be completely contained within the edge (<,>)."""
-    return interval_contains(edge, node, strict=True)
-
-
-def childEdges(n: SpliceGraphNode) -> set[Edge]:
-    """Returns a set of child edges for a node."""
-    return {Edge(n, c) for c in n.children}
-
-
-def donor(node: SpliceGraphNode) -> int:
-    """Returns the strand-adjusted position at the start of the donor dimer."""
-    return node.maxpos if node.strand == "+" else node.minpos - 2
-
-
-def edgeSet(G: SpliceGraph) -> set[Edge]:
-    """Returns a complete set of edges found in splice graph G.
-    This includes duplicate edges between distinct nodes as found
-    in alternate 3'/5' events."""
-    result: set[Edge] = set()
-    for n in G.nodeDict.values():
-        result.update(childEdges(n))
-    return result
-
-
-def intronSet(G: SpliceGraph) -> set[tuple[int, int]]:
-    """Returns the set of distinct edges found in a splice graph.
-    This does not include any duplicate edges."""
-    return {(edge.minpos, edge.maxpos) for edge in edgeSet(G)}
-
-
-def overlap(a: SpliceGraphNode, b: SpliceGraphNode) -> bool:
-    """Returns true if the two nodes overlap and are distinct; false otherwise."""
-    return a.id != b.id and intervals_overlap(a, b, inclusive=False)
-
-
-def overlapsAll(A: SpliceGraphNode, nodeList: Iterable[SpliceGraphNode]) -> bool:
-    """Returns true if node A overlaps all nodes in the given node list; false otherwise."""
-    for n in nodeList:
-        if not overlap(A, n):
-            return False
-    return True
-
-
-def parentEdges(n: SpliceGraphNode) -> set[Edge]:
-    """Returns a set of parent edges for a node."""
-    return {Edge(p, n) for p in n.parents}
-
-
-# ------------------------------------------------------------------------
-# AS annotation functions:
-def altSiteEventList(
-    nodes: Iterable[SpliceGraphNode],
-    siteType: str | AlternativeSplicingEvent | AlternativeSplicingEventName,
-    verbose: bool = False,
-) -> list[set[SpliceGraphNode]]:
-    """Returns a list of alt. 3' or alt. 5' events.  Each element consists
-    of a set of nodes involved in the same event.  Note: assumes the graph's
-    nodes have already been annotated (see detectAltAcceptor and detectAltDonor)."""
-    site_event = _coerce_alt_splicing_event(siteType)
-    if site_event not in {AlternativeSplicingEvent.ALT3, AlternativeSplicingEvent.ALT5}:
-        raise ValueError(f"altNodeList called using non-alternative site type: {siteType}")
-
-    def set_string(s: set[SpliceGraphNode]) -> str:
-        return ",".join(n.id for n in s)
-
-    def neighbor_nodes(n: SpliceGraphNode) -> set[SpliceGraphNode]:
-        return set(n.parents) if site_event == AlternativeSplicingEvent.ALT3 else set(n.children)
-
-    # Find nodes annotated with the given event
-    eventNodes = [n for n in nodes if site_event in n.altFormSet]
-    if not eventNodes:
-        return []
-    if verbose:
-        modifier = "parents" if site_event == AlternativeSplicingEvent.ALT3 else "children"
-        LOGGER.debug(
-            "alt_site_event_list_found_nodes",
-            count=len(eventNodes),
-            site_type=site_event.value,
-        )
-        for n in eventNodes:
-            LOGGER.debug("alt_site_event_list_node", node=str(n))
-
-    # Sorting nodes ensures that overlapping nodes will
-    # not be stored in distinct sets to be merged later
-    eventNodes.sort(key=lambda node: (node.minpos, node.maxpos, node.id))
-    eventList: list[set[SpliceGraphNode]] = []
-    overlap_index = InMemoryIntervalIndex(eventNodes)
-    stored: set[SpliceGraphNode] = set()
-    for n in eventNodes:
-        eset = {n}
-        # Grab neighboring nodes (share an edge)
-        adj_n = neighbor_nodes(n)
-        if verbose:
-            LOGGER.debug(
-                "alt_site_event_list_neighbors",
-                node_id=n.id,
-                modifier=modifier,
-                neighbors=set_string(adj_n),
-            )
-
-        # Find other nodes with the same annotation that overlap the current one
-        for m in overlap_index.overlaps(n, inclusive=False):
-            if m == n or not overlap(m, n):
-                continue
-            if verbose:
-                LOGGER.debug(
-                    "alt_site_event_list_overlap_candidate",
-                    node_id=n.id,
-                    candidate_id=m.id,
-                )
-            # Grab other node's neighbors
-            adj_m = neighbor_nodes(m)
-
-            # If either node overlaps all of the other's parents (alt3)
-            # or children (alt5), they are not part of the same event:
-            neighborsContained = overlapsAll(m, adj_n) or overlapsAll(n, adj_m)
-
-            # Otherwise, the nodes are part of the same event
-            if not neighborsContained:
-                eset.add(m)
-            elif verbose:
-                LOGGER.debug(
-                    "alt_site_event_list_neighbor_containment_excluded",
-                    node=str(n),
-                    candidate=str(m),
-                    modifier=modifier,
-                )
-
-        # If the nodes overlapping the current node also overlap
-        # distinct other nodes, merge the events into one set
-        if verbose:
-            LOGGER.debug(
-                "alt_site_event_list_event_set",
-                node_id=n.id,
-                event_set=set_string(eset),
-            )
-        for e in eventList:
-            if e & eset:
-                if verbose:
-                    LOGGER.debug(
-                        "alt_site_event_list_merge_sets",
-                        event_set=set_string(eset),
-                        existing_set=set_string(e),
-                    )
-                e.update(eset)
-                stored.update(eset)
-                if verbose:
-                    LOGGER.debug(
-                        "alt_site_event_list_merged_set",
-                        merged_set=set_string(e),
-                    )
-                break
-            elif verbose:
-                LOGGER.debug(
-                    "alt_site_event_list_no_intersection",
-                    event_set=set_string(eset),
-                    existing_set=set_string(e),
-                )
-
-        if n not in stored:
-            if verbose:
-                LOGGER.debug(
-                    "alt_site_event_list_store_new_set",
-                    event_set=set_string(eset),
-                )
-            eventList.append(eset)
-
-    if verbose:
-        LOGGER.debug(
-            "alt_site_event_list_final",
-            result=";".join([set_string(e) for e in eventList]),
-        )
-    return eventList
-
-
-def detectAltAcceptor(
-    n: SpliceGraphNode,
-    nodes: list[SpliceGraphNode],
-    edges: set[Edge],
-) -> None:
-    """Looks for evidence that identifies the given node as an alternate acceptor."""
-    # Inference rules:
-    #  - Establish set of all nodes that overlap the given one and are not graph roots
-    #  - Get the set of nodes flanking edges that the node contains (retained introns)
-    #  - Get the set of all nodes that overlap parents of the given one (other retained introns)
-    #  - Subtract those overlapping parents from the first set
-    #  - For those that remain, if any have acceptor sites different from
-    #    this one, mark it as an alternate acceptor
-    if not n.parents:
-        return
-    allOverlaps = {o for o in nodes if o.parents and overlap(o, n)}
-    containedEdges = {e for e in edges if containsEdge(n, e)}
-    flankingNodes = {e.child for e in containedEdges if overlapsAll(n, e.child.parents)}
-    parentOverlaps = {o for o in nodes if overlapsAll(o, n.parents)}
-    overlapSet = allOverlaps - parentOverlaps - flankingNodes
-
-    for o in overlapSet:
-        if o.acceptorEnd() != n.acceptorEnd():
-            n.addAltForm(AlternativeSplicingEvent.ALT3)
-            return
-
-
-def detectAltBoth(
-    nodes: list[SpliceGraphNode],
-    verbose: bool = False,
-) -> None:
-    """Looks for evidence of simultaneous 3'/5' events (alt. both).  Assumes alt. 3' and
-    alt. 5' nodes have already been identified."""
-    # Using 5' events as a reference...
-    # For each 5' (donor site) event, we look at the nodes to see if any of them share
-    # the same child (acceptor site).
-    #
-    # Examples of alt. both event with 4 nodes:
-    #       ||||||||||----------------------|||||||||||||
-    #       ||||||||----------------------|||||||||||||
-    # Example with 6 nodes:
-    #       ||||||||||--------------|||||||||||||
-    #       ||||||------------|||||||||||||
-    #       |||||||||||||--------------|||||||||||||
-    # An alt. both event, and an alt. 5' event:
-    #       ||||||||||----------------------|||||||||||||  alt.5' only
-    #       ||||||||------------------------|||||||||||
-    #       ||||||||||||||----------------------|||||||||||||  alt. both
-    #
-    # Note that the first two donors have edges to the same acceptor site
-    # while the third donor has its own unique acceptor site.  Thus the rule to
-    # apply is: any node within an alt 5' group that connects to a unique
-    # acceptor that is not shared with any other member of that group becomes
-    # an alt. both event.
-    #
-    # An alt. both event, and an alt. 3' event:
-    #       ||||||||||----------------------|||||||||||||  alt.3' only
-    #       ||||||||||-------------------|||||||||||
-    #       ||||||||||||----------------------|||||||||||||  alt. both
-    #
-    # Note that the first two acceptors have edges to the same donor site
-    # while the third donor has its own unique acceptor site.  Thus the rule to
-    # apply is: any node within an alt 3' group that connects to a unique
-    # donor that is not shared with any other member of that group becomes
-    # an alt. both event.
-    alt5Events = altSiteEventList(nodes, AlternativeSplicingEvent.ALT5, verbose=verbose)
-    for event in alt5Events:
-        for n in event:
-            nodeAcceptors = {c.acceptorEnd() for c in n.children}
-            otherAcceptors = {c.acceptorEnd() for m in event for c in m.children if m != n}
-            shared = nodeAcceptors & otherAcceptors
-            if not shared:
-                n.removeAltForm(AlternativeSplicingEvent.ALT5)
-                n.addAltForm(AlternativeSplicingEvent.ALTB5)
-
-    alt3Events = altSiteEventList(nodes, AlternativeSplicingEvent.ALT3)
-    for event in alt3Events:
-        for n in event:
-            nodeDonors = {c.donorEnd() for c in n.parents}
-            otherDonors = {c.donorEnd() for m in event for c in m.parents if m != n}
-            shared = nodeDonors & otherDonors
-            if not shared:
-                n.removeAltForm(AlternativeSplicingEvent.ALT3)
-                n.addAltForm(AlternativeSplicingEvent.ALTB3)
-
-
-def detectAltDonor(
-    n: SpliceGraphNode,
-    nodes: list[SpliceGraphNode],
-    edges: set[Edge],
-    verbose: bool = False,
-) -> None:
-    """Looks for evidence that identifies the given node as an alternate donor."""
-    # Inference rules:
-    #  - Establish set of all nodes that overlap the given one
-    #  - Get the set of nodes flanking edges that the node contains (retained introns)
-    #  - Get the set of all nodes that overlap all children of the given one
-    #    (other retained introns)
-    #  - Subtract those overlapping children from the first set
-    #  - For those that remain, if any have acceptor sites different from
-    #    this one, mark it as an alternate acceptor
-    if not n.children:
-        return
-    allOverlaps = {o for o in nodes if o.children and overlap(o, n)}
-    containedEdges = {e for e in edges if containsEdge(n, e)}
-    flankingNodes = {e.parent for e in containedEdges if overlapsAll(n, e.parent.children)}
-    childOverlaps = {o for o in nodes if overlapsAll(o, n.children)}
-    overlapSet = allOverlaps - childOverlaps - flankingNodes
-
-    for o in overlapSet:
-        if o.donorEnd() != n.donorEnd():
-            n.addAltForm(AlternativeSplicingEvent.ALT5)
-            return
-
-
-def detectRetainedIntron(n: SpliceGraphNode, edges: set[Edge]) -> None:
-    """Looks for evidence in the edge list that identifies the given node as a retained intron."""
-    for e in edges:
-        if containsEdge(n, e):
-            n.addAltForm(AlternativeSplicingEvent.IR)
-            return
-
-
-def detectSkippedExon(n: SpliceGraphNode, edges: set[Edge]) -> None:
-    """Looks for evidence in the edge list that identifies the given node as a skipped exon."""
-    annotation = AlternativeSplicingEvent.ES
-    if not n.parents:
-        annotation = AlternativeSplicingEvent.ALTI
-    if not n.children:
-        annotation = AlternativeSplicingEvent.ALTT
-    for e in edges:
-        if e.minpos < n.minpos and n.maxpos < e.maxpos:
-            n.addAltForm(annotation)
-            return
-
-
-# ------------------------------------------------------------------------
-# Graph manipulation functions:
-def commonAS(A: SpliceGraph, B: SpliceGraph) -> SpliceGraph:
-    """Returns a graph that contains just the nodes and AS
-    events found in both A and B.  Uses the fact that
-    A^B = AUB - A\\B - B\\A"""
-    combined = A.union(B)
-    [AminB, BminA] = diffAS(A, B)
-    subgraph = graphMinusAS(combined, AminB)
-    return graphMinusAS(subgraph, BminA)
-
-
-def diffAS(A: SpliceGraph, B: SpliceGraph) -> list[SpliceGraph]:
-    """Detects alternative splicing differences between two graphs.
-    Returns two graphs: one that contains the nodes in A with AS not
-    found in B and another that contains nodes in B without events in A."""
-    return [graphMinusAS(A, B), graphMinusAS(B, A)]
-
-
-def equivalentGraphs(A, B):
-    """Returns True if SpliceGraphs A and B are equivalent; False otherwise.
-    This is distinct from the SpliceGraph.__eq__ method as it ignores
-    attributes that may be changed in the prediction process."""
-    Anodes = A.nodeDict.values()
-    Bnodes = B.nodeDict.values()
-    if len(Anodes) != len(Bnodes):
-        return False
-    for n in Anodes:
-        Aedges = childEdges(n)
-        try:
-            idx = Bnodes.index(n)
-            o = Bnodes[idx]
-            Bedges = childEdges(o)
-            if Aedges != Bedges:
-                return False
-        except ValueError:
-            return False
-    return True
-
-
-def getFirstGraph(f: str | TextIO, *, annotate: bool = False, verbose: bool = False) -> SpliceGraph:
-    """Returns just the first splice graph found in a file."""
-    try:
-        result = next(SpliceGraphParser(f, verbose=verbose))
-        if annotate:
-            result.annotate()
-        return result
-    except StopIteration:
-        raise ValueError("No graph found in %s" % f)
-
-
-def graphMinusAS(A: SpliceGraph, B: SpliceGraph) -> SpliceGraph:
-    """Detects alternative splicing differences between two graphs.
-    Returns a graph that contains just the nodes in A that are
-    annotated with AS not found in B.  Note that if A is a subgraph
-    of B, this will return None."""
-    # Get all nodes with AS annotations.  Note that we do
-    # not report nodes missing from one graph or the other.
-    nodesA = [n for n in A.resolvedNodes() if n.hasAS()]
-    result = SpliceGraph(name=A.getName(), chromosome=A.chromosome, strand=A.strand)
-    for a in nodesA:
-        aAltSet = set(a.altFormSet)
-        if not aAltSet:
-            continue
-
-        b = B.getNode(a.start, a.end)
-        if b:
-            bAltSet = set(b.altFormSet)
-            aAltSet = aAltSet - bAltSet
-            if not aAltSet:
-                continue
-
-        node = result.addNode(a.id, a.minpos, a.maxpos)
-        for event in aAltSet:
-            node.addAltForm(event)
-    return result
-
-
-def graphSubtract(A: SpliceGraph, B: SpliceGraph, *, resolvedOnly: bool = True) -> SpliceGraph:
-    """Returns a graph that represents the nodes and edges in A minus those in B."""
-    name = "%s\\%s" % (A.getName(), B.getName())
-    result = SpliceGraph(name=name, chromosome=A.chromosome, strand=A.strand)
-    # Use full graph position range
-    result.minpos = A.minpos
-    result.maxpos = A.maxpos
-
-    nodesA = A.resolvedNodes() if resolvedOnly else A.nodeDict.values()
-    nodesB = B.resolvedNodes() if resolvedOnly else B.nodeDict.values()
-    subsetA = []
-    for a in nodesA:
-        if a not in nodesB:
-            newNode = result.addNode(a.id, a.minpos, a.maxpos)
-            newNode.attrs = a.attrs
-            subsetA.append(a)
-
-    for a in subsetA:
-        for c in a.children:
-            if c in subsetA:
-                result.addEdge(a.id, c.id)
-
-    return result
-
-
-def consistencyCoefficients(A, B):
-    """Deprecated.  Use recall(A,B) instead."""
-    return recall(A, B)
-
-
-def jaccardCoefficients(A, B):
-    """Returns the Jaccard coefficients for the similarity between the
-    two graphs' vertex and edge sets, respectively.  (Recall that the
-    Jaccard coefficient for a set is |A^B|/|AUB|.)  Note that if both
-    A and B are the empty set, the Jaccard coefficient is 1."""
-    setA = set(A.resolvedNodes())
-    setB = set(B.resolvedNodes())
-    AandB = setA.intersection(setB)
-    AorB = setA.union(setB)
-    nodeCoefficient = float(len(AandB)) / len(AorB) if AorB else 1.0
-
-    edgesA = edgeSet(A)
-    edgesB = edgeSet(B)
-    AandB = edgesA.intersection(edgesB)
-    AorB = edgesA.union(edgesB)
-    edgeCoefficient = float(len(AandB)) / len(AorB) if AorB else 1.0
-
-    return nodeCoefficient, edgeCoefficient
-
-
-def nodeString(nodeList):
-    """Returns a string representation of all node ids in a list."""
-    return ",".join([n.id for n in nodeList])
-
-
-def recall(A, B):
-    """Returns recall values for the similarity between graphs
-    A and B for node and edge sets, respectively.  The recall
-    for set A relative to B is |A^B|/|B|.  Note that if A and B
-    are both empty, the recall value is 1."""
-    nodesB = set(B.resolvedNodes())
-    AandB = set(A.resolvedNodes()) & nodesB
-    nodeCoefficient = float(len(AandB)) / len(nodesB) if nodesB else 1.0
-
-    edgesB = edgeSet(B)
-    AandB = edgeSet(A) & edgesB
-    edgeCoefficient = float(len(AandB)) / len(edgesB) if edgesB else 1.0
-
-    return nodeCoefficient, edgeCoefficient
-
-
-def splitFiles(parser, directory=None):
-    """Given a parser on a file that contains multiple models, writes each
-    model into its own file prefixed with its graph name.  First removes
-    special characters from the name.  For example:
-        'AT1G01448|alt 3/5' --> 'AT1G01448_alt_3_5_graph.gff'"""
-    import os
-
-    def fixName(s):
-        result = s.replace(" ", "_")
-        result = result.replace("|", "_")
-        result = result.replace("/", "_")
-        result = result.replace("\\", "_")
-        return result.replace("*", "")
-
-    for g in parser.__iter__():
-        outName = "%s_graph.gff" % fixName(g.getName())
-        outFile = os.path.join(directory, outName) if directory else outName
-        g.writeGFF(outFile)
-
-
-def updateLeaf(A: SpliceGraph, B: SpliceGraph, *, uniqueLeaf: bool = False) -> None:
-    """Method that updates leaf nodes in graph A with nodes from graph B prior to
-    merging the two graphs.  We look for longer nodes with the same acceptor site."""
-    mergeDict = {}
-    for leaf in A.getLeaves():
-        longer = [
-            n
-            for n in B.nodeDict.values()
-            if n.acceptorEnd() == leaf.acceptorEnd() and len(n) > len(leaf)
-        ]
-        if not longer:
-            continue
-        if uniqueLeaf and len(longer) > 1:
-            continue
-        maxLen = max([len(n) for n in longer])
-        longest = [n for n in longer if len(n) == maxLen][0]
-
-        # If the new length matches any other nodes,
-        # merge them after the loop has finished
-        other = A.getNode(longest.minpos, longest.maxpos)
-        if other:
-            mergeDict[leaf] = other
-        else:
-            leaf.update(longest.minpos, longest.maxpos)
-
-    # Merge and remove nodes that would have been duplicates
-    for node in mergeDict:
-        other = mergeDict[node]
-        for p in node.parents:
-            A.addEdge(p.id, other.id)
-            p.removeChild(node)
-        del A.nodeDict[node.id]
-
-
-def updateRoot(A: SpliceGraph, B: SpliceGraph, *, uniqueRoot: bool = False) -> None:
-    """Method that updates root nodes in graph A using nodes from graph B prior to
-    merging the two graphs.  We look for longer nodes that have the same donor site."""
-    mergeDict = {}
-    for root in A.getRoots():
-        longer = [
-            n for n in B.nodeDict.values() if n.donorEnd() == root.donorEnd() and len(n) > len(root)
-        ]
-        if not longer:
-            continue
-        if uniqueRoot and len(longer) > 1:
-            continue
-        maxLen = max([len(n) for n in longer])
-        longest = [n for n in longer if len(n) == maxLen][0]
-
-        # If the new length matches any other nodes,
-        # merge them after the loop has finished
-        other = A.getNode(longest.minpos, longest.maxpos)
-        if other:
-            mergeDict[root] = other
-        else:
-            root.update(longest.minpos, longest.maxpos)
-
-    # Merge and remove nodes that would have been duplicates
-    for node in mergeDict:
-        other = mergeDict[node]
-        for c in node.children:
-            A.addEdge(other.id, c.id)
-            c.removeParent(node)
-        del A.nodeDict[node.id]
-
-
-# ========================================================================
-# Class definitions
-class Edge:
-    """Encapsulates an edge in the graph.  These are not stored with a splice
-    graph, but used for splice graph creation and annotation."""
-
-    def __init__(self, parent: SpliceGraphNode, child: SpliceGraphNode) -> None:
-        self.parent = parent
-        self.child = child
-        self.pos = sorted([parent.minpos, parent.maxpos, child.minpos, child.maxpos])
-        # minpos/maxpos are related to the edge itself, not the outer positions
-        self.minpos = self.pos[1]
-        self.maxpos = self.pos[2]
-
-    def __eq__(self, o: object) -> bool:
-        # Using minpos/maxpos allows an edge to be compared with an exon.
-        if not isinstance(o, Edge):
-            return NotImplemented
-        return (
-            self.minpos == o.minpos
-            and self.maxpos == o.maxpos
-            and self.pos[0] == o.pos[0]
-            and self.pos[3] == o.pos[3]
-        )
-
-    def __lt__(self, o: Edge) -> bool:
-        return tuple(self.pos) < tuple(o.pos)
-
-    def __getitem__(self, i: int) -> int:
-        return self.pos[i]
-
-    def __hash__(self) -> int:
-        return hash(str(self))
-
-    def __len__(self) -> int:
-        return self.maxpos - self.minpos
-
-    def overlaps(self, o: Edge) -> bool:
-        """Returns true if the edge portions overlap; false otherwise."""
-        return self.maxpos > o.minpos and self.minpos < o.maxpos
-
-    def sameEdge(self, o: Edge) -> bool:
-        """Returns true if the edge portions are the same; false otherwise."""
-        return self.minpos == o.minpos and self.maxpos == o.maxpos
-
-    def __repr__(self) -> str:
-        return f"{self.pos[0]},{self.pos[1]},{self.pos[2]},{self.pos[3]}"
-
-    def __str__(self) -> str:
-        return f"{self.pos[1]},{self.pos[2]}"
-
-
+@dataclass(slots=True)
 class NullNode:
-    """Null node object encapsulates the most basic information about a node."""
+    """Coordinate-only node used for equality lookups by interval."""
 
-    def __init__(self, start: int, end: int) -> None:
-        self.start = start
-        self.end = end
-        self.minpos = min(start, end)
-        self.maxpos = max(start, end)
+    start: int
+    end: int
+    minpos: int = field(init=False)
+    maxpos: int = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.minpos = min(self.start, self.end)
+        self.maxpos = max(self.start, self.end)
 
 
+@dataclass(slots=True, init=False, eq=False)
 class SpliceGraphNode:
-    """This is the node class to use for constructing splice graphs for GFF input/output."""
+    """Pure data container for genomic coordinates and node attributes."""
+
+    id: str
+    chromosome: str
+    strand: str
+    minpos: int
+    maxpos: int
+    start: int
+    end: int
+    attrs: dict[str, NodeAttributeValue]
+    altFormSet: set[AlternativeSplicingEvent]
+    isoformSet: set[str]
+    origStart: int
+    origEnd: int
 
     def __init__(
         self,
@@ -786,1046 +113,395 @@ class SpliceGraphNode:
         end: int,
         strand: str | Strand,
         chrom: str,
-        parents: list[SpliceGraphNode] | None = None,
-        children: list[SpliceGraphNode] | None = None,
     ) -> None:
         self.id = id
-        self.strand = coerce_enum(strand, Strand, field="strand").value
         self.chromosome = chrom
+        self.strand = coerce_enum(strand, Strand, field="strand").value
         self.minpos = min(start, end)
         self.maxpos = max(start, end)
-        (self.start, self.end) = (
-            (self.minpos, self.maxpos) if strand == "+" else (self.maxpos, self.minpos)
-        )
-        self.parents: list[SpliceGraphNode] = list(parents) if parents is not None else []
-        self.children: list[SpliceGraphNode] = list(children) if children is not None else []
-        self.attrs: dict[str, str | set[int]] = {}
-        self.altFormSet: set[AlternativeSplicingEvent] = set()
-        self.isoformSet: set[str] = set()
-        # Added for adjustable ranges
+        if self.strand == Strand.MINUS.value:
+            self.start = self.maxpos
+            self.end = self.minpos
+        else:
+            self.start = self.minpos
+            self.end = self.maxpos
+        self.attrs = {}
+        self.altFormSet = set()
+        self.isoformSet = set()
         self.origStart = self.start
         self.origEnd = self.end
 
-    def acceptorEnd(self):
-        """Returns the position of the exon's 5' (upstream) end."""
+    def acceptorEnd(self) -> int:
         return self.start
 
+    def donorEnd(self) -> int:
+        return self.end
+
     def _sync_alt_form_attr(self) -> None:
-        self.attrs[AS_KEY] = ",".join(form.value for form in self.altFormSet)
+        self.attrs[AS_KEY] = ",".join(sorted(form.value for form in self.altFormSet))
 
     def addAltForm(
         self,
         form: str | AlternativeSplicingEvent | AlternativeSplicingEventName,
     ) -> None:
-        """Adds an AS form to the node's list of forms."""
         if isinstance(form, str) and not form.strip():
             return
         event = _coerce_alt_splicing_event(form)
         self.altFormSet.add(event)
-        for x in self.altFormSet:
-            assert len(x.value) > 0
         self._sync_alt_form_attr()
-
-    def addAttribute(self, key, value):
-        """Adds the given key-value pair to a node's attribute list.  If the
-        key is already in the attribute dictionary, the new value overwrites the old."""
-        self.attrs[key] = value
-
-    def addChild(self, c):
-        """Adds a child node (edge) to a node.  If the child is already known the child
-        list is unchanged."""
-        if c not in self.children:
-            self.children.append(c)
-            c.addParent(self)
-
-    def addCodon(self, codon, codonType):
-        """If the codon falls within the node, its start position is added to the set;
-        otherwise the list is unchanged."""
-
-        if (not isinstance(codon, tuple)) or (len(codon) != 2):
-            raise ValueError(
-                "Codons must be provided as a duple of (start,end) positions: received %s"
-                % str(codon)
-            )
-
-        pos = min(codon) if self.strand == "+" else max(codon)
-        if self.contains(pos):
-            assert isinstance(pos, int)
-            self.attrs.setdefault(codonType, set())
-            self.attrs[codonType].add(pos)
-
-    def addEndCodon(self, codon):
-        """Adds an end codon to the node."""
-        self.addCodon(codon, END_CODON_KEY)
-
-    def addFormsFromString(self, s):
-        """Adds AS forms to node list from a string representation."""
-        for form in s.split(","):
-            self.addAltForm(form.strip())
-
-    def addIsoformString(self, isoformString):
-        """Adds a set of isoform names to the node's set of isoforms."""
-        for iso in isoformString.split(","):
-            self.addIsoform(iso)
-
-    def addIsoform(self, isoform):
-        """Adds an isoform name to the node's set of isoforms."""
-        if isoform is None:
-            raise ValueError("Received illegal isoform for %s" % self.id)
-        self.isoformSet.add(isoform)
-        self.attrs[ISO_KEY] = ",".join(self.isoformSet)
-
-    def addParent(self, p):
-        """Adds a parent node (edge) to a node.  If the parent is already known the parent
-        list is unchanged."""
-        if p not in self.parents:
-            self.parents.append(p)
-
-    def addStartCodon(self, codon):
-        """If the codon position falls within the node it is added to the set;
-        otherwise the list is unchanged."""
-        self.addCodon(codon, START_CODON_KEY)
-
-    def altForms(self):
-        """Returns a list of AS forms associated with the node."""
-        for x in self.altFormSet:
-            assert len(x.value) > 0
-        return [form.value for form in self.altFormSet]
-
-    def altFormString(self):
-        """Returns a string of AS forms associated with the node."""
-        try:
-            return self.attrs[AS_KEY]
-        except KeyError:
-            return ""
-
-    def attributeString(self):
-        """Returns a string of all attributes associated with this node, suitable for a
-        GFF attributes field.  For example:
-                  ID=ei_27;Parent=ei_26;AltForm=Alt. 3',Retained Intron"""
-        result = ""
-        for k in self.attrs.keys():
-            if k == AS_KEY and not self.altFormSet:
-                continue
-            if k == ISO_KEY and not self.isoformSet:
-                continue
-
-            if result:
-                result += ";"
-            if k in [START_CODON_KEY, END_CODON_KEY]:
-                result += "%s=%s" % (k, self.codonString(k))
-            else:
-                result += "%s=%s" % (k, self.attrs[k])
-        return result
-
-    def branchingFactor(self):
-        return max(len(self.parents), len(self.children))
-
-    def __lt__(self, other: SpliceGraphNode) -> bool:
-        """Permits sorting based on minimum node position; ties use max position."""
-        if self.minpos == other.minpos:
-            return self.maxpos < other.maxpos
-        return self.minpos < other.minpos
-
-    def codons(self, codonType):
-        """Returns a list of codon positions within the node, or
-        an empty list if there are no codons of the given type."""
-        try:
-            return sorted(self.attrs[codonType])
-        except KeyError:
-            return []
-
-    def codonString(self, codonType):
-        """Returns a list of codon positions within the node as a string,
-        or None if there are no codons of the given type."""
-        try:
-            codons = sorted(self.attrs[codonType])
-            return ",".join(["%d" % x for x in codons])
-        except KeyError:
-            pass
-
-    def contains(self, pos):
-        """Returns true if the given position falls within the node; false otherwise."""
-        return self.minpos <= pos <= self.maxpos
-
-    def donorEnd(self):
-        """Returns the position of the exon's 3' (downstream) end."""
-        return self.end
-
-    def downstreamOf(self, pos):
-        """Returns true if the node is downstream of the position; false otherwise."""
-        return (self.minpos > pos) if self.strand == "+" else (self.maxpos < pos)
-
-    def __eq__(self, other: object) -> bool:
-        """Node equality is based solely on its start/end positions."""
-        if not isinstance(other, (SpliceGraphNode, NullNode)):
-            return NotImplemented
-        return self.minpos == other.minpos and self.maxpos == other.maxpos
-
-    def endCodons(self):
-        """Returns a list of end codon start positions within the node."""
-        return self.codons(END_CODON_KEY)
-
-    def endCodonString(self):
-        """Returns a list of end codon start positions within the node as a string."""
-        return self.codonString(END_CODON_KEY)
-
-    def gffString(self):
-        """Returns a GFF-formatted string representing the given graph feature."""
-        if self.parents:
-            # Example: chr1	SpliceGraph	child	37373	37398	.	-	.	ID=gm_20;Parent=gm_19
-            result = "%s\t%s\t%s\t%d\t%d\t.\t%s\t.\tID=%s;Parent=%s" % (
-                self.chromosome,
-                SOURCE_NAME,
-                CHILD_REC,
-                self.minpos,
-                self.maxpos,
-                self.strand,
-                self.id,
-                nodeString(self.parents),
-            )
-        else:
-            # Example: chr1	SpliceGraph	parent	37569	37757	.	-	.	ID=gm_19
-            result = "%s\t%s\t%s\t%d\t%d\t.\t%s\t.\tID=%s" % (
-                self.chromosome,
-                SOURCE_NAME,
-                PARENT_REC,
-                self.minpos,
-                self.maxpos,
-                self.strand,
-                self.id,
-            )
-        if self.attrs:
-            result += ";%s" % self.attributeString()
-        return result
-
-    def hasAS(self):
-        """Returns true if the node has evidence of AS; false otherwise."""
-        for x in self.altFormSet:
-            assert len(x.value) > 0
-        return bool(self.altFormSet)
-
-    def hasDisposition(self, disposition):
-        """Returns true if the node has the given disposition; false otherwise."""
-        try:
-            return self.attrs[DISPOSITION_KEY] == disposition
-        except KeyError:
-            return False
-
-    def __hash__(self):
-        hashString = "%d,%d" % (self.minpos, self.maxpos)
-        return hashString.__hash__()
-
-    def isAltAcceptor(self):
-        """Returns true if the node represents a retained intron; false otherwise."""
-        for x in self.altFormSet:
-            assert len(x.value) > 0
-        return AlternativeSplicingEvent.ALT3 in self.altFormSet
-
-    def isAltDonor(self):
-        """Returns true if the node represents a retained intron; false otherwise."""
-        for x in self.altFormSet:
-            assert len(x.value) > 0
-        return AlternativeSplicingEvent.ALT5 in self.altFormSet
-
-    def isKnown(self):
-        """Returns true if the node is known from the gene model; false otherwise."""
-        return self.hasDisposition(KNOWN_NODE)
-
-    def isLeaf(self):
-        """Returns true if the node is a leaf node; false otherwise."""
-        return len(self.children) == 0
-
-    def isPredicted(self):
-        """Returns true if the node is predicted; false otherwise."""
-        return self.hasDisposition(PREDICTED_NODE)
-
-    def isRetainedIntron(self):
-        """Returns true if the node represents a retained intron; false otherwise."""
-        for x in self.altFormSet:
-            assert len(x.value) > 0
-        return AlternativeSplicingEvent.IR in self.altFormSet
-
-    def isRoot(self):
-        """Returns true if the node is a root node; false otherwise."""
-        return len(self.parents) == 0
-
-    def isSkippedExon(self):
-        """Returns true if the node represents a retained intron; false otherwise."""
-        for x in self.altFormSet:
-            assert len(x.value) > 0
-        return AlternativeSplicingEvent.ES in self.altFormSet
-
-    def isUnresolved(self):
-        """Returns true if the node is unresolved; false otherwise."""
-        return self.hasDisposition(UNRESOLVED_NODE)
-
-    def isoformList(self):
-        """Returns a list of isoforms associated with the node."""
-        return list(self.isoformSet)
-
-    def isoformString(self):
-        """Returns a string representation of isoforms associated with the node."""
-        try:
-            return self.attrs[ISO_KEY]
-        except KeyError:
-            return None
-
-    def __len__(self):
-        """Returns the length of the genomic region represented by the node."""
-        return self.maxpos - self.minpos + 1
-
-    def putativeChildren(self):
-        """Returns a set of putative children for an unresolved node,
-        or an empty set if there are none or the node is not unresolved."""
-        try:
-            return self.attrs[PUTATIVE_CHILDREN].split(",")
-        except KeyError:
-            return set()
-
-    def putativeParents(self):
-        """Returns a set of putative parents for an unresolved node,
-        or None if there are none or the node is not unresolved."""
-        try:
-            return self.attrs[PUTATIVE_PARENTS].split(",")
-        except KeyError:
-            return set()
 
     def removeAltForm(
         self,
         form: str | AlternativeSplicingEvent | AlternativeSplicingEventName,
     ) -> None:
-        """Adds an AS form to the node's list of forms."""
         if isinstance(form, str) and not form.strip():
             return
         event = _coerce_alt_splicing_event(form)
         self.altFormSet.discard(event)
-        for x in self.altFormSet:
-            assert len(x.value) > 0
         self._sync_alt_form_attr()
 
-    def removeChild(self, child):
-        """Removes the child from this node's list."""
-        self.children.remove(child)
+    def addAttribute(self, key: str, value: NodeAttributeValue) -> None:
+        self.attrs[key] = value
 
-    def removeParent(self, parent):
-        """Removes the parent from this node's list."""
-        self.parents.remove(parent)
+    def addCodon(self, codon: tuple[int, int], codon_type: str) -> None:
+        if len(codon) != 2:
+            raise ValueError(f"Codons must be 2-tuples; received {codon!r}")
+        pos = min(codon) if self.strand == Strand.PLUS.value else max(codon)
+        if self.contains(pos):
+            existing = self.attrs.setdefault(codon_type, set())
+            if not isinstance(existing, set):
+                raise TypeError(f"Codon attribute {codon_type} is not a set")
+            existing.add(pos)
 
-    def __repr__(self):
-        if self.parents:
-            return "%s %d-%d children=%s parents=%s" % (
-                self.id,
-                self.start,
-                self.end,
-                nodeString(self.children),
-                nodeString(self.parents),
-            )
-        else:
-            return "Root %s %d-%d children=%s" % (
-                self.id,
-                self.start,
-                self.end,
-                nodeString(self.children),
-            )
+    def addStartCodon(self, codon: tuple[int, int]) -> None:
+        self.addCodon(codon, START_CODON_KEY)
 
-    def setUnresolved(
-        self,
-        preserve: list[str] | None = None,
-        acceptors: list[int] | None = None,
-        donors: list[int] | None = None,
-    ) -> None:
-        """
-        Makes a node unresolved by setting its disposition attribute and
-        by removing edges between the node and parents and children in the graph.
-        Caller may preserve some display edges by listing nodes in a preserve list.
-        """
-        preserve_nodes = preserve or []
-        acceptor_sites = acceptors or []
-        donor_sites = donors or []
+    def addEndCodon(self, codon: tuple[int, int]) -> None:
+        self.addCodon(codon, END_CODON_KEY)
 
-        self.addAttribute(DISPOSITION_KEY, UNRESOLVED_NODE)
-        if acceptor_sites:
-            self.addAttribute(ACCEPTORS_KEY, list_string(acceptor_sites))
-        if donor_sites:
-            self.addAttribute(DONORS_KEY, list_string(donor_sites))
+    def addFormsFromString(self, forms: str) -> None:
+        for form in forms.split(","):
+            self.addAltForm(form.strip())
 
-        for c in list(self.children):
-            if c.id in preserve_nodes:
+    def addIsoform(self, isoform: str) -> None:
+        if isoform is None:
+            raise ValueError(f"Received illegal isoform for {self.id}")
+        self.isoformSet.add(isoform)
+        self.attrs[ISO_KEY] = ",".join(sorted(self.isoformSet))
+
+    def addIsoformString(self, isoform_string: str) -> None:
+        for isoform in isoform_string.split(","):
+            cleaned = isoform.strip()
+            if cleaned:
+                self.addIsoform(cleaned)
+
+    def altForms(self) -> list[str]:
+        return [form.value for form in sorted(self.altFormSet, key=lambda form: form.value)]
+
+    def altFormString(self) -> str:
+        value = self.attrs.get(AS_KEY)
+        return value if isinstance(value, str) else ""
+
+    def attributeString(self) -> str:
+        attr_parts: list[str] = []
+        for key in sorted(self.attrs):
+            if key == AS_KEY and not self.altFormSet:
                 continue
-            c.removeParent(self)
-            self.children.remove(c)
-
-        for p in list(self.parents):
-            if p.id in preserve_nodes:
+            if key == ISO_KEY and not self.isoformSet:
                 continue
-            p.removeChild(self)
-            self.parents.remove(p)
+            value = self.attrs[key]
+            if isinstance(value, set):
+                rendered = ",".join(str(item) for item in sorted(value))
+            else:
+                rendered = value
+            attr_parts.append(f"{key}={rendered}")
+        return ";".join(attr_parts)
 
-    def startCodons(self):
-        """Returns a list of start codon start positions within the node."""
+    def codons(self, codon_type: str) -> list[int]:
+        value = self.attrs.get(codon_type)
+        if isinstance(value, set):
+            return sorted(value)
+        return []
+
+    def codonString(self, codon_type: str) -> str | None:
+        codons = self.codons(codon_type)
+        if not codons:
+            return None
+        return ",".join(str(value) for value in codons)
+
+    def contains(self, pos: int) -> bool:
+        return self.minpos <= pos <= self.maxpos
+
+    def downstreamOf(self, pos: int) -> bool:
+        return self.minpos > pos if self.strand == Strand.PLUS.value else self.maxpos < pos
+
+    def endCodons(self) -> list[int]:
+        return self.codons(END_CODON_KEY)
+
+    def endCodonString(self) -> str | None:
+        return self.codonString(END_CODON_KEY)
+
+    def hasAS(self) -> bool:
+        return bool(self.altFormSet)
+
+    def hasDisposition(self, disposition: str) -> bool:
+        value = self.attrs.get(DISPOSITION_KEY)
+        return value == disposition
+
+    def isAltAcceptor(self) -> bool:
+        return AlternativeSplicingEvent.ALT3 in self.altFormSet
+
+    def isAltDonor(self) -> bool:
+        return AlternativeSplicingEvent.ALT5 in self.altFormSet
+
+    def isKnown(self) -> bool:
+        return self.hasDisposition(KNOWN_NODE)
+
+    def isPredicted(self) -> bool:
+        return self.hasDisposition(PREDICTED_NODE)
+
+    def isRetainedIntron(self) -> bool:
+        return AlternativeSplicingEvent.IR in self.altFormSet
+
+    def isSkippedExon(self) -> bool:
+        return AlternativeSplicingEvent.ES in self.altFormSet
+
+    def isUnresolved(self) -> bool:
+        return self.hasDisposition(UNRESOLVED_NODE)
+
+    def isoformList(self) -> list[str]:
+        return sorted(self.isoformSet)
+
+    def isoformString(self) -> str | None:
+        value = self.attrs.get(ISO_KEY)
+        return value if isinstance(value, str) else None
+
+    def putativeChildren(self) -> set[str]:
+        value = self.attrs.get(PUTATIVE_CHILDREN)
+        if isinstance(value, str) and value:
+            return set(value.split(","))
+        return set()
+
+    def putativeParents(self) -> set[str]:
+        value = self.attrs.get(PUTATIVE_PARENTS)
+        if isinstance(value, str) and value:
+            return set(value.split(","))
+        return set()
+
+    def startCodons(self) -> list[int]:
         return self.codons(START_CODON_KEY)
 
-    def startCodonString(self):
-        """Returns a list of start codon start positions within the node as a string."""
+    def startCodonString(self) -> str | None:
         return self.codonString(START_CODON_KEY)
 
-    def __str__(self):
-        if self.parents:
-            return "%s %d-%d (parents:%d/children:%d)" % (
-                self.id,
-                self.start,
-                self.end,
-                len(self.parents),
-                len(self.children),
-            )
-        else:
-            return "Root %s %d-%d (children:%d)" % (
-                self.id,
-                self.start,
-                self.end,
-                len(self.children),
-            )
-
-    def update(self, minpos, maxpos):
-        """Mutates the node based on the revised min/max positions."""
-        assert minpos <= maxpos
+    def update(self, minpos: int, maxpos: int) -> None:
         self.minpos = minpos
         self.maxpos = maxpos
-        self.start = minpos if self.strand == "+" else maxpos
-        self.end = maxpos if self.strand == "+" else minpos
+        if self.strand == Strand.MINUS.value:
+            self.start = maxpos
+            self.end = minpos
+        else:
+            self.start = minpos
+            self.end = maxpos
 
-    def upstreamOf(self, pos):
-        """Returns true if the node is upstream of the position; false otherwise."""
-        return (self.maxpos < pos) if self.strand == "+" else (self.minpos > pos)
+    def upstreamOf(self, pos: int) -> bool:
+        return self.maxpos < pos if self.strand == Strand.PLUS.value else self.minpos > pos
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, (NullNode, SpliceGraphNode)):
+            return NotImplemented
+        return self.minpos == other.minpos and self.maxpos == other.maxpos
+
+    def __lt__(self, other: SpliceGraphNode) -> bool:
+        return (self.minpos, self.maxpos, self.id) < (other.minpos, other.maxpos, other.id)
+
+    def __hash__(self) -> int:
+        return hash((self.minpos, self.maxpos))
+
+    def __len__(self) -> int:
+        return self.maxpos - self.minpos + 1
+
+    def __repr__(self) -> str:
+        return f"{self.id} {self.start}-{self.end}"
+
+    def __str__(self) -> str:
+        return f"{self.id} {self.start}-{self.end}"
 
 
 class SpliceGraph:
-    """Main class for storing splice graph data."""
+    """NetworkX-backed manager for splice graph topology."""
 
-    def __init__(self, name, chromosome, strand):
-        """
-        Instantiate a splice graph.
-
-        :Parameters:
-           'name'       - gene name to associate with the graph
-           'chromosome' - chromosome/scaffold name to associate with the
-                          graph (GFF format requirement)
-           'strand'     - strand associated with the graph
-        """
+    def __init__(self, name: str, chromosome: str, strand: str | Strand) -> None:
         self.chromosome = chromosome
         self.strand = coerce_enum(strand, Strand, field="strand").value
-        self.nodeDict = {}
-        self.attrs = {}
+        self.attrs: dict[str, str] = {}
         self.minpos = sys.maxsize
         self.maxpos = 0
-        # NB: guarantees attributes exist for the graph
+        self._nx_graph: nx.DiGraph = nx.DiGraph()
         self.setName(name)
 
-    def addNode(self, newId, start, end):
-        """Add a node to the splice graph if it doesn't already exist."""
-        try:
-            # Look for another node with the same start/end positions
-            tmpNode = NullNode(start, end)
-            allNodes = list(self.nodeDict.values())
-            idx = allNodes.index(tmpNode)
-            node = allNodes[idx]
-        except ValueError:
-            self.nodeDict[newId] = SpliceGraphNode(newId, start, end, self.strand, self.chromosome)
-            node = self.nodeDict[newId]
-            self.minpos = min(self.minpos, node.minpos)
-            self.maxpos = max(self.maxpos, node.maxpos)
-
-        return node
-
-    def addCodons(self, codonList, codonType):
-        """Adds codons to every node in the graph."""
-        for codon in codonList:
-            for node in self.nodeDict.values():
-                node.addCodon(codon, codonType)
-
-    def addEdge(self, pid, cid):
-        """Add an edge to the splice graph if it doesn't already exist."""
-        try:
-            parent = self.nodeDict[pid]
-        except KeyError:
-            raise Exception("Error adding edge from node %s: node not found in graph" % pid)
-
-        try:
-            child = self.nodeDict[cid]
-        except KeyError:
-            raise Exception("Error adding edge to node %s: node not found in graph" % cid)
-
-        parent.addChild(child)
-
-    def addEndCodons(self, codonList):
-        """Adds end codons to all nodes in the graph."""
-        self.addCodons(codonList, END_CODON_KEY)
-
-    def addStartCodons(self, codonList):
-        """Adds start codons to all nodes in the graph."""
-        self.addCodons(codonList, START_CODON_KEY)
-
-    def adjust(self, adjustment):
-        """
-        Shifts the positions of all nodes in the graph by the given amount.
-        This is useful for example for converting a graph based on positions
-        [0,n-1] for an environment that uses positions [1,n].
-        """
-        for n in self.nodeDict.values():
-            n.start += adjustment
-            n.end += adjustment
-            n.minpos += adjustment
-            n.maxpos += adjustment
-
-        self.minpos += adjustment
-        self.maxpos += adjustment
-
-    def altForms(self):
-        """Returns a set of all AS forms found in the graph."""
-        result: set[str] = set()
-        for n in self.nodeDict.values():
-            result.update(n.altForms())
-        for x in result:
-            assert len(x) > 0
-        return result
-
-    def annotate(self, verbose=False):
-        """Updates all AS annotations for the graph."""
-        edges = edgeSet(self)
-        nodes = self.resolvedNodes()
-        for n in nodes:
-            # First reset the node AS annotations
-            n.altFormSet = set()
-            n.attrs[AS_KEY] = ""
-            for x in n.altFormSet:
-                assert len(x.value) > 0
-
-            # Assign annotations to the node
-            detectSkippedExon(n, edges)
-            detectRetainedIntron(n, edges)
-            if n.children:
-                detectAltDonor(n, nodes, edges, verbose=verbose)
-            if n.parents:
-                detectAltAcceptor(n, nodes, edges)
-
-        # Removed (11/21/2011) after conversation with Asa:
-        ## detectAltBoth(nodes)
-
-    def attributeString(self):
-        """Returns a string of all graph attributes, for GFF attributes fields."""
-        return ";".join(["%s=%s" % (k, self.attrs[k]) for k in sorted(self.attrs.keys())])
-
-    def branchingStats(self):
-        """Returns the min, max and average branching factor for the nodes in the graph."""
-        branches = [n.branchingFactor() for n in self.resolvedNodes()]
-        # NB: len(branches) has to be at least 1 since there must be at least 1 node to have a graph
-        try:
-            avg = float(sum(branches)) / len(branches)
-        except ZeroDivisionError:
-            raise ValueError("Attempted to compute branching factor on an empty graph")
-
-        return min(branches), max(branches), avg
-
-    def __lt__(self, other: SpliceGraph) -> bool:
-        """Permits sorting graphs based on minimum position; ties use max position."""
-        if self.minpos == other.minpos:
-            return self.maxpos < other.maxpos
-        return self.minpos < other.minpos
-
-    def deleteNode(self, n):
-        """Removes a node from a graph, along with all edges attached to it.
-        Returns the node that was deleted."""
-        # Caller must catch KeyError if this fails
-        node = self.nodeDict[n.id]
-        for p in node.parents:
-            p.removeChild(node)
-        for c in node.children:
-            c.removeParent(node)
-        del self.nodeDict[n.id]
-        return node
-
-    def distinctAltEvents(self):
-        """Returns a list of distinct AS events found in the graph.
-        Each event is reported as a tuple: (node-start,node-end,event-type,count).
-        Alt. 5'/Alt. 3' events are the only ones with a count greater than 1 and
-        are reported using the shortest node involved."""
-        result = []
-        alt5Nodes = [
-            n for n in self.resolvedNodes() if AlternativeSplicingEvent.ALT5 in n.altFormSet
-        ]
-        while alt5Nodes:
-            n = alt5Nodes.pop()
-            others = [o for o in alt5Nodes if o.acceptorEnd() == n.acceptorEnd()]
-            for o in others:
-                if len(o) < len(n):
-                    n = o
-                alt5Nodes.remove(o)
-            result.append(
-                (
-                    n.start,
-                    n.end,
-                    AlternativeSplicingEvent.ALT5.value,
-                    len(others) + 1,
-                )
-            )
-
-        alt3Nodes = [
-            n for n in self.resolvedNodes() if AlternativeSplicingEvent.ALT3 in n.altFormSet
-        ]
-        while alt3Nodes:
-            n = alt3Nodes.pop()
-            others = [o for o in alt3Nodes if o.donorEnd() == n.donorEnd()]
-            for o in others:
-                if len(o) < len(n):
-                    n = o
-                alt3Nodes.remove(o)
-            result.append(
-                (
-                    n.start,
-                    n.end,
-                    AlternativeSplicingEvent.ALT3.value,
-                    len(others) + 1,
-                )
-            )
-
-        for n in self.resolvedNodes():
-            for as_event in NON_35_EVENTS:
-                if as_event in n.altFormSet:
-                    result.append((n.start, n.end, as_event.value, 1))
-
-        return result
-
-    def downstreamOf(self, a, b):
-        """Returns true if a is downstream of b; false otherwise."""
-        return (a > b) if self.strand == "+" else (b > a)
-
-    def duplicate(self):
-        """Returns a duplicate of the current graph.  This performs
-        the same function as copy.deepcopy(), but without the risk
-        of stack overflow for large graphs."""
-        result = SpliceGraph(self.getName(), self.chromosome, self.strand)
-        result.minpos = self.minpos
-        result.maxpos = self.maxpos
-        result.attrs.update(self.attrs)
-
-        # First pass: create nodes in graph
-        for n in self.nodeDict.values():
-            newNode = result.addNode(n.id, n.start, n.end)
-            newNode.attrs.update(n.attrs)
-            newNode.isoformSet = set(n.isoformSet)
-            newNode.attrs[ISO_KEY] = ",".join(newNode.isoformSet)
-
-        # Second pass: create edges in graph
-        for n in self.nodeDict.values():
-            for c in n.children:
-                result.addEdge(n.id, c.id)
-
-        return result
-
-    def __eq__(self, other):
-        """Returns true if two splice graphs are identical; false otherwise."""
-        nodes = self.nodeDict.values()
-        otherNodes = other.nodeDict.values()
-        if len(nodes) != len(otherNodes):
-            return False
-        for n in nodes:
-            edges = childEdges(n)
-            try:
-                idx = otherNodes.index(n)
-                o = otherNodes[idx]
-                otherEdges = childEdges(o)
-                if edges != otherEdges:
-                    return False
-                if n.attrs != o.attrs:
-                    return False
-            except ValueError:
-                return False
-        return True
-
-    def expandedModel(self, name, oldRange, newRange):
-        """Marks a graph when it expands a gene model beyond its original bounds.
-        oldRange and newRange must be (minpos,maxpos) pairs."""
-        if len(oldRange) != 2 or not all(isinstance(v, int) for v in oldRange):
-            raise ValueError("old range must be 2 int values")
-
-        if len(newRange) != 2 or not all(isinstance(v, int) for v in newRange):
-            raise ValueError("new range must be 2 int values")
-
-        self.attrs[ALT_MODEL_KEY] = "%s from (%d,%d) to (%d,%d)" % (
-            name,
-            oldRange[0],
-            oldRange[1],
-            newRange[0],
-            newRange[1],
-        )
-
-    def getAcceptors(self):
-        """Returns a list of distinct acceptor sites in the graph."""
-        result = {acceptor(n) for n in self.nodeDict.values() if not n.isRoot()}
-        return list(result)
-
-    def getDonors(self):
-        """Returns a list of distinct donor sites in the graph."""
-        result = {donor(n) for n in self.nodeDict.values() if not n.isLeaf()}
-        return list(result)
-
-    def getNode(self, start, end):
-        """Returns the node represented by the given positions, if it exists."""
-        # NB: May want to add option to locate only resolved nodes
-        try:
-            # Look for a node with the same start/end positions
-            tmpNode = NullNode(start, end)
-            allNodes = list(self.nodeDict.values())
-            idx = allNodes.index(tmpNode)
-            return allNodes[idx]
-        except ValueError:
-            return None
-
-    def getLeaves(self):
-        """Returns a list of nodes that have no children."""
-        return [n for n in self.nodeDict.values() if not n.children]
-
-    def getName(self):
-        """Central method for retrieving the name.  This is a temporary
-        hack until a better method is implemented."""
-        return self.attrs[ID_ATTR]
-
-    def getRoots(self):
-        """Returns a list of nodes that have no parents."""
-        return [n for n in self.nodeDict.values() if not n.parents]
-
-    def gffString(self, node=None):
-        """Returns a GFF-formatted string representing the given graph feature."""
-        result = "%s\t%s\t%s\t%d\t%d\t.\t%s\t.\t%s" % (
-            self.chromosome,
-            SOURCE_NAME,
-            GENE_REC,
-            self.minpos,
-            self.maxpos,
-            self.strand,
-            self.attributeString(),
-        )
-        return result
-
-    def hasAS(self):
-        """Returns true if the graph has evidence of AS; false otherwise."""
-        for n in self.resolvedNodes():
-            if n.hasAS():
-                return True
-        return False
-
-    def isEmpty(self):
-        """Returns true if the graph is empty (has no nodes or edges); false otherwise."""
-        return len(self.nodeDict) == 0
-
-    def isoformDict(self):
-        """Returns a dictionary where each isoform name is
-        keyed to a sorted list of nodes in the isoform."""
-        result = {}
-        nodes = self.resolvedNodes()
-        nodes.sort(
-            key=lambda node: (node.minpos, node.maxpos, node.id),
-            reverse=(self.strand == "-"),
-        )
-        for n in nodes:
-            for iso in n.isoformSet:
-                result.setdefault(iso, [])
-                result[iso].append(n)
-        return result
-
-    def isoformGraph(self, isoNames, *, fuzzyMatch: bool = False):
-        """Returns a splice graph that represents just the given isoforms.
-        Isoforms may be given as a comma-separated string, a list or a set.
-        Setting 'fuzzyMatch' to True allows you to specify part of an isoform
-        name in the list; it will match all isoforms that contain that part."""
-        isoNames = as_list(isoNames)
-        result = None
-        for name in isoNames:
-            if fuzzyMatch:
-                nodes = []
-                query = name.upper()
-                for n in self.resolvedNodes():
-                    for x in n.isoformSet:
-                        if x.upper().find(query) >= 0:
-                            nodes.append(n)
-            else:
-                nodes = [n for n in self.resolvedNodes() if name in n.isoformSet]
-
-            if not nodes:
-                raise ValueError(
-                    "%s not found in graph %s (isoforms %s)\n"
-                    % (name, self.getName(), ",".join(self.isoforms()))
-                )
-
-            graph = SpliceGraph(name, self.chromosome, self.strand)
-            prev = None
-            for n in nodes:
-                curr = graph.addNode(n.id, n.minpos, n.maxpos)
-                curr.attrs = dict(n.attrs)
-                curr.isoformSet = {name}
-                curr.attrs[ISO_KEY] = ",".join(curr.isoformSet)
-                if prev:
-                    graph.addEdge(prev.id, curr.id)
-                prev = curr
-            result = graph if result is None else result.union(graph)
-        if result:
-            result.setName("|".join(isoNames))
-        return result
-
-    def isoforms(self):
-        """Returns a list of all isoform strings associated with nodes in the graph."""
-        isoSet = set()
-        for n in self.resolvedNodes():
-            isoSet = isoSet | n.isoformSet
-        return sorted(list(isoSet))
-
-    def __len__(self):
-        return self.maxpos - self.minpos + 1 if self.maxpos > self.minpos else 0
-
-    def mergeNodes(self, a, b):
-        """Merges two nodes by using the lowest min position and the highest
-        max position of the two nodes.  The new node will have the same identifier
-        as the first original node.  All parents and all children are combined and the
-        original nodes will be deleted from the graph.  Returns the original nodes."""
-        node1 = self.nodeDict[a]
-        node2 = self.nodeDict[b]
-        minpos = min(node1.minpos, node2.minpos)
-        maxpos = max(node1.maxpos, node2.maxpos)
-
-        # Caller must catch KeyError if this fails
-        self.deleteNode(node1)
-        self.deleteNode(node2)
-
-        # Either create a new node or grab an existing one
-        newNode = self.addNode(node1.id, minpos, maxpos)
-
-        # Only add parents/children that are still in the graph
-        for c in node1.children + node2.children:
-            if c.id in self.nodeDict:
-                newNode.addChild(c)
-        for p in node1.parents + node2.parents:
-            if p.id in self.nodeDict:
-                p.addChild(newNode)
-
-        self.nodeDict[newNode.id] = newNode
-        return (node1, node2)
-
-    def nameString(self):
-        """Returns the graph name.  Graphs that have been merged will have more than
-        one name given as a hyphenated list."""
-        names = set(self.getName().split(","))
-        if len(names) > 1:
-            return "Merged " + "+".join(names)
-        else:
-            return self.getName()
-
-    def __ne__(self, other):
-        """Returns true if two splice graphs are different; false otherwise."""
-        return not self.__eq__(other)
-
-    def __str__(self):
-        return "%s (%s) %d-%d (%d nodes)" % (
-            self.getName(),
-            self.strand,
-            self.minpos,
-            self.maxpos,
-            len(self.nodeDict),
-        )
-
-    def resolvedNodes(self):
-        """Returns a list of all resolved nodes: those actually used in the graph."""
-        return [x for x in self.nodeDict.values() if not x.isUnresolved()]
-
-    def setName(self, name):
-        """Provides a central method for storing the name in both places.
-        This is a temporary hack until a better method is implemented."""
-        self.name = name
-        self.attrs[ID_ATTR] = name
-
-    def union(
-        self,
-        other: SpliceGraph,
-        *,
-        keepName: bool = False,
-        mergeEnds: bool = False,
-        idGenerator: Iterator[str] | None = None,
-    ) -> SpliceGraph:
-        """Merges two graphs into one.  Adds nodes that are distinct and merges nodes
-        that have the same start/end positions.  Merged nodes will share AS
-        information.  New attributes may be added, but conflicts will be resolved
-        in favor of the existing graph."""
-        idgen = idGenerator if idGenerator is not None else idFactory("%s_U" % self.getName())
-
-        # establish correct strand
-        self_strand = coerce_enum(self.strand, Strand, field="strand")
-        other_strand = coerce_enum(other.strand, Strand, field="strand")
-        strand = self_strand
-        if self_strand.value in VALID_STRANDS:
-            if other_strand.value in VALID_STRANDS and self_strand != other_strand:
-                raise ValueError("Cannot merge graphs with conflicting strands.")
-        elif other_strand.value in VALID_STRANDS:
-            strand = other_strand
-
-        # update graph name
-        if keepName:
-            newName = self.getName()
-        else:
-            names = set(self.getName().split(","))
-            names.add(other.getName())
-            newName = ",".join(names)
-
-        if mergeEnds:
-            updateRoot(other, self)
-            updateLeaf(other, self)
-
-        result = SpliceGraph(newName, self.chromosome, strand.value)
-        allNodes = self.resolvedNodes() + other.resolvedNodes()
-        for node in allNodes:
-            newNode = result.addNode(next(idgen), node.minpos, node.maxpos)
-            for c in node.children:
-                cNode = result.addNode(next(idgen), c.minpos, c.maxpos)
-                newNode.addChild(cNode)
-            for p in node.parents:
-                pNode = result.addNode(next(idgen), p.minpos, p.maxpos)
-                pNode.addChild(newNode)
-            for iso in node.isoformSet:
-                newNode.addIsoform(iso)
-            for k in node.attrs:
-                if k == AS_KEY:
-                    for f in node.altForms():
-                        newNode.addAltForm(f)
-                elif k != ISO_KEY:
-                    newNode.attrs[k] = node.attrs[k]
-        return result
-
-    def unresolvedNodes(self):
-        """Returns a list of all unresolved nodes in the graph."""
-        return [x for x in self.nodeDict.values() if x.isUnresolved()]
-
-    def upstreamOf(self, a, b):
-        """Returns true if a is upstream of b; false otherwise."""
-        return (a < b) if self.strand == "+" else (b < a)
-
-    def validate(self, halt: bool = False) -> str | None:
-        """Returns None if the splicegraph is valid; otherwise returns a reason it is invalid."""
-        reason: str | None = None
-        all_nodes = list(self.nodeDict.values())
-        ## allNodes   = self.resolvedNodes()
-        node_set = set(all_nodes)
-        node_list = list(node_set)
-        all_node_ids = [node.id for node in all_nodes]
-        unique_ids = [node.id for node in node_set]
-        roots = self.getRoots()
-        leaves = self.getLeaves()
-        if len(roots) == 0 or len(leaves) == 0:
-            reason = f"Graph is missing roots or leaves ({len(roots)} roots, {len(leaves)} leaves)"
-
-        for n in all_nodes:
-            if reason:
-                break
-            # Detect duplicate nodes: only one will appear in set
-            if n.id not in unique_ids:
-                other = node_list[node_list.index(n)]
-                reason = (
-                    f"Duplicate node {n.id} ({n.minpos}-{n.maxpos}) matches "
-                    f"{other.id} ({other.minpos}-{other.maxpos})"
-                )
-
-            # Detect invalid child/parent ids
-            for o in n.children:
-                if o.id not in all_node_ids:
-                    reason = f"Node {n.id}: child {o.id} not in graph"
-                elif o.id not in unique_ids:
-                    twin = node_list[node_list.index(o)]
-                    reason = (
-                        f"Node {n.id}: child {o.id} ({o.minpos}-{o.maxpos}) "
-                        f"is not unique ({twin.id} {twin.minpos}-{twin.maxpos})"
-                    )
-
-            for o in n.parents:
-                if o.id not in all_node_ids:
-                    reason = f"Node {n.id} parent {o.id} not in graph"
-                elif o.id not in unique_ids:
-                    twin = node_list[node_list.index(o)]
-                    reason = (
-                        f"Node {n.id} parent {o.id} ({o.minpos}-{o.maxpos}) "
-                        f"is not unique ({twin.id} {twin.minpos}-{twin.maxpos})"
-                    )
-
-        if reason and halt:
-            LOGGER.error(
-                "illegal_graph_validation_failed",
-                nodes=[str(node) for node in all_nodes],
-                reason=reason,
-            )
-            raise ValueError(f"Illegal graph:\n{reason}")
-        elif reason:
-            return reason
+    @property
+    def nodeDict(self) -> dict[str, SpliceGraphNode]:
+        return {
+            node_id: node_data["data"] for node_id, node_data in self._nx_graph.nodes(data=True)
+        }
+
+    def _sorted_nodes(self, node_ids: Iterable[str]) -> list[SpliceGraphNode]:
+        nodes = [self._nx_graph.nodes[node_id]["data"] for node_id in node_ids]
+        return sorted(nodes, key=lambda node: (node.minpos, node.maxpos, node.id))
+
+    def _find_existing_node(self, start: int, end: int) -> SpliceGraphNode | None:
+        probe = NullNode(start, end)
+        for node in self.nodeDict.values():
+            if node == probe:
+                return node
         return None
 
-    def writeGFF(self, fileRef: str | TextIO, haltOnError: bool = False) -> bool:
-        """Writes a splice graph to a file in GFF format.  The file may be given
-        either as an output stream or as a file path.
-        """
-        reason = self.validate()
-        if reason:
-            if haltOnError:
-                raise ValueError(
-                    f'Cannot write invalid splice graph {self.getName()} to file:\n"{reason}"\n'
-                )
-            else:
-                LOGGER.warning(
-                    "writing_invalid_splice_graph",
-                    graph_name=self.getName(),
-                    reason=reason,
-                )
+    def _recompute_bounds(self) -> None:
+        nodes = list(self.nodeDict.values())
+        if not nodes:
+            self.minpos = sys.maxsize
+            self.maxpos = 0
+            return
+        self.minpos = min(node.minpos for node in nodes)
+        self.maxpos = max(node.maxpos for node in nodes)
 
-        roots = set(self.getRoots())
-        other = set(self.nodeDict.values()) - roots
+    def _node(self, node_or_id: str | SpliceGraphNode) -> SpliceGraphNode:
+        if isinstance(node_or_id, SpliceGraphNode):
+            return node_or_id
+        return self._nx_graph.nodes[node_or_id]["data"]
 
-        def _write_graph(out_stream: TextIO) -> None:
-            out_stream.write(f"{self.gffString()}\n")
-            for p in roots:
-                out_stream.write(f"{p.gffString()}\n")
-            for o in other:
-                out_stream.write(f"{o.gffString()}\n")
+    def addNode(self, newId: str, start: int, end: int) -> SpliceGraphNode:
+        existing = self._find_existing_node(start, end)
+        if existing is not None:
+            return existing
+        node = SpliceGraphNode(newId, start, end, self.strand, self.chromosome)
+        self._nx_graph.add_node(node.id, data=node)
+        self.minpos = min(self.minpos, node.minpos)
+        self.maxpos = max(self.maxpos, node.maxpos)
+        return node
 
-        if isinstance(fileRef, str):
-            with open(fileRef, "w") as out_stream:
-                _write_graph(out_stream)
+    def addCodons(self, codon_list: Iterable[tuple[int, int]], codon_type: str) -> None:
+        for codon in codon_list:
+            for node in self.nodeDict.values():
+                node.addCodon(codon, codon_type)
+
+    def addEdge(self, pid: str, cid: str) -> None:
+        if pid not in self._nx_graph:
+            raise ValueError(f"Error adding edge: parent node {pid} not found in graph")
+        if cid not in self._nx_graph:
+            raise ValueError(f"Error adding edge: child node {cid} not found in graph")
+        self._nx_graph.add_edge(pid, cid)
+
+    def addEndCodons(self, codon_list: Iterable[tuple[int, int]]) -> None:
+        self.addCodons(codon_list, END_CODON_KEY)
+
+    def addStartCodons(self, codon_list: Iterable[tuple[int, int]]) -> None:
+        self.addCodons(codon_list, START_CODON_KEY)
+
+    def adjust(self, adjustment: int) -> None:
+        for node in self.nodeDict.values():
+            node.update(node.minpos + adjustment, node.maxpos + adjustment)
+        if self.nodeDict:
+            self.minpos += adjustment
+            self.maxpos += adjustment
+
+    def attributeString(self) -> str:
+        return ";".join(f"{key}={self.attrs[key]}" for key in sorted(self.attrs))
+
+    def deleteNode(self, node_id: str | SpliceGraphNode) -> SpliceGraphNode:
+        node = self._node(node_id)
+        self._nx_graph.remove_node(node.id)
+        self._recompute_bounds()
+        return node
+
+    def getLeaves(self) -> list[SpliceGraphNode]:
+        return self._sorted_nodes(
+            node_id for node_id, degree in self._nx_graph.out_degree() if degree == 0
+        )
+
+    def getName(self) -> str:
+        return self.attrs[ID_ATTR]
+
+    def getNode(self, start: int, end: int) -> SpliceGraphNode | None:
+        return self._find_existing_node(start, end)
+
+    def getRoots(self) -> list[SpliceGraphNode]:
+        return self._sorted_nodes(
+            node_id for node_id, degree in self._nx_graph.in_degree() if degree == 0
+        )
+
+    def isEmpty(self) -> bool:
+        return self._nx_graph.number_of_nodes() == 0
+
+    def predecessors(self, node_or_id: str | SpliceGraphNode) -> list[SpliceGraphNode]:
+        node = self._node(node_or_id)
+        return self._sorted_nodes(self._nx_graph.predecessors(node.id))
+
+    def predecessor_ids(self, node_id: str) -> list[str]:
+        return sorted(self._nx_graph.predecessors(node_id))
+
+    def resolvedNodes(self) -> list[SpliceGraphNode]:
+        return [node for node in self.nodeDict.values() if not node.isUnresolved()]
+
+    def setName(self, name: str) -> None:
+        self.attrs[ID_ATTR] = name
+
+    def successors(self, node_or_id: str | SpliceGraphNode) -> list[SpliceGraphNode]:
+        node = self._node(node_or_id)
+        return self._sorted_nodes(self._nx_graph.successors(node.id))
+
+    def successor_ids(self, node_id: str) -> list[str]:
+        return sorted(self._nx_graph.successors(node_id))
+
+    def unresolvedNodes(self) -> list[SpliceGraphNode]:
+        return [node for node in self.nodeDict.values() if node.isUnresolved()]
+
+    def validate(self, halt: bool = False) -> str | None:
+        reason: str | None = None
+        if self._nx_graph.number_of_nodes() == 0:
+            reason = "Graph is empty."
         else:
-            _write_graph(fileRef)
-        return True
+            roots = self.getRoots()
+            leaves = self.getLeaves()
+            if not roots or not leaves:
+                reason = (
+                    f"Graph is missing roots or leaves ({len(roots)} roots, {len(leaves)} leaves)"
+                )
+            elif not nx.is_directed_acyclic_graph(self._nx_graph):
+                reason = "Graph contains cycles (not a valid DAG)."
+
+        if reason and halt:
+            LOGGER.error("illegal_graph_validation_failed", reason=reason)
+            raise ValueError(f"Illegal graph:\n{reason}")
+        return reason
+
+    def __len__(self) -> int:
+        return self.maxpos - self.minpos + 1 if self.maxpos >= self.minpos else 0
+
+    def __str__(self) -> str:
+        return (
+            f"{self.getName()} ({self.strand}) {self.minpos}-{self.maxpos} "
+            f"({self._nx_graph.number_of_nodes()} nodes)"
+        )
 
 
 class SpliceGraphParser:
-    """Class that parses a GFF file filled with splice graphs and provides an
-    iterator over each graph in the file."""
+    """Parse splice graph GFF files into networkx-backed ``SpliceGraph`` objects."""
 
     def __init__(self, fileRef: str | TextIO, *, verbose: bool = False) -> None:
-        """Parses a GFF file filled with splice graphs and returns each graph in an iterator.
-        The file may be given either as an input stream or as a file path."""
         self.verbose = verbose
-
-        if isinstance(fileRef, str):
-            self.instream = ez_open(fileRef)
-        else:
-            self.instream = fileRef
-
+        self.instream = ez_open(fileRef) if isinstance(fileRef, str) else fileRef
         if self.instream is None:
             raise ValueError("No input file stream given.")
-
         self.graphDict: dict[str, SpliceGraph] = {}
         self._graph_keys: list[str] = []
         self.loadFromFile()
 
     def __iter__(self) -> SpliceGraphParser:
-        """Iterator implementation."""
         return self
 
     def __next__(self) -> SpliceGraph:
-        """Iterator implementation."""
         if self.graphId >= len(self._graph_keys):
             raise StopIteration
         key = self._graph_keys[self.graphId]
@@ -1833,87 +509,76 @@ class SpliceGraphParser:
         return self.graphDict[key]
 
     def __len__(self) -> int:
-        """Returns the number of nodes in the graph."""
         return len(self.graphDict)
 
     def loadFromFile(self) -> None:
-        """Loads all graphs stored in a GFF file."""
-        lineNo = 0
+        line_no = 0
         graph: SpliceGraph | None = None
-        # aliases keep track of nodes with different ids but identical start/end positions
         alias: dict[str, str] = {}
         edges: set[tuple[str, str]] = set()
         indicator = ProgressIndicator(100000, verbose=self.verbose)
         try:
             for line in self.instream:
                 indicator.update()
-                lineNo += 1
+                line_no += 1
                 if line.startswith("#"):
                     continue
-                s = line.strip()
-                parts = s.split("\t")
-
+                record = line.strip()
+                parts = record.split("\t")
                 try:
-                    recType = coerce_enum(parts[2].lower(), RecordType, field="record_type").value
+                    rec_type = coerce_enum(parts[2].lower(), RecordType, field="record_type").value
                     start = int(parts[3])
                     end = int(parts[4])
-                except IndexError:
+                except (IndexError, ValueError) as exc:
                     raise ValueError(
-                        "Illegal record in splice graph file at line %d:\n\t%s" % (lineNo, s)
-                    )
-                except ValueError:
-                    raise ValueError(
-                        "Illegal record type in splice graph file at line %d:\n\t%s" % (lineNo, s)
-                    )
+                        f"Illegal record in splice graph file at line {line_no}:\n\t{record}"
+                    ) from exc
 
-                if recType not in VALID_RECTYPES:
+                if rec_type not in VALID_RECTYPES:
                     raise ValueError(
-                        "Illegal record type in splice graph file at line %d:\n\t%s" % (lineNo, s)
+                        f"Illegal record type in splice graph file at line {line_no}:\n\t{record}"
                     )
 
-                attrs = self._parse_attributes(parts[-1], lineNo)
-
-                try:
-                    node_id = attrs[ID_ATTR]
-                except KeyError:
+                attrs = self._parse_attributes(parts[-1], line_no)
+                node_id = attrs.get(ID_ATTR)
+                if node_id is None:
                     raise ValueError(
-                        "GFF attribute field '%s' has no ID at line %d" % (parts[-1], lineNo)
+                        f"GFF attribute field '{parts[-1]}' has no ID at line {line_no}"
                     )
 
-                if recType in VALID_GENES:
-                    # Add edges to previous graph
+                if rec_type in VALID_GENES:
                     if graph is not None:
                         for parent_id, child_id in edges:
                             graph.addEdge(alias[parent_id], alias[child_id])
-                    # Start new graph
                     graph = SpliceGraph(name=node_id, chromosome=parts[0], strand=parts[6])
                     graph.minpos = min(start, end)
                     graph.maxpos = max(start, end)
-                    for k in attrs:
-                        if k not in KNOWN_ATTRS:
-                            graph.attrs[k] = attrs[k]
+                    for key, value in attrs.items():
+                        if key not in KNOWN_ATTRS:
+                            graph.attrs[key] = value
                     self.graphDict[node_id] = graph
-                    edges = set()
                     alias = {}
-                elif graph is None:
-                    raise ValueError("Graph feature found before graph header at line %d" % lineNo)
-                else:
-                    node = graph.addNode(node_id, start, end)
-                    alias[node_id] = node.id
-                    for k in attrs:
-                        if k == AS_KEY:
-                            node.addFormsFromString(attrs[k])
-                        elif k == ISO_KEY and attrs[k]:
-                            node.addIsoformString(attrs[k])
-                        elif k in [START_CODON_KEY, END_CODON_KEY] and attrs[k]:
-                            node.attrs[k] = {int(x) for x in attrs[k].split(",")}
-                        elif k not in KNOWN_ATTRS:
-                            node.addAttribute(k, attrs[k])
+                    edges = set()
+                    continue
 
-                    if PARENT_ATTR in attrs:
-                        parents = attrs[PARENT_ATTR].split(",")
-                        for parent in parents:
-                            edges.add((parent, node_id))
+                if graph is None:
+                    raise ValueError(f"Graph feature found before graph header at line {line_no}")
+
+                node = graph.addNode(node_id, start, end)
+                alias[node_id] = node.id
+                for key, value in attrs.items():
+                    if key == AS_KEY:
+                        node.addFormsFromString(value)
+                    elif key == ISO_KEY and value:
+                        node.addIsoformString(value)
+                    elif key in {START_CODON_KEY, END_CODON_KEY} and value:
+                        node.attrs[key] = {int(item) for item in value.split(",")}
+                    elif key not in KNOWN_ATTRS:
+                        node.addAttribute(key, value)
+
+                if PARENT_ATTR in attrs:
+                    for parent in attrs[PARENT_ATTR].split(","):
+                        edges.add((parent, node_id))
 
             if graph is not None:
                 for parent_id, child_id in edges:
@@ -1921,13 +586,11 @@ class SpliceGraphParser:
         finally:
             indicator.finish()
 
-        # Initialize iterator counter
         self.graphId = 0
         self._graph_keys = list(self.graphDict.keys())
 
     @staticmethod
     def _parse_attributes(field: str, line_no: int) -> dict[str, str]:
-        """Convert `a=b;c=d` into key/value pairs while preserving '=' in values."""
         attrs: dict[str, str] = {}
         for pair in field.split(";"):
             if not pair:
@@ -1935,7 +598,22 @@ class SpliceGraphParser:
             key, sep, value = pair.partition("=")
             if not sep or not key:
                 raise ValueError(
-                    "Illegal attribute field '%s' at line %d in GFF file." % (field, line_no)
+                    f"Illegal attribute field '{field}' at line {line_no} in GFF file."
                 )
             attrs[key] = value
         return attrs
+
+
+__all__ = [
+    "AS_KEY",
+    "CHILD_REC",
+    "GENE_REC",
+    "ID_ATTR",
+    "KNOWN_ATTRS",
+    "PARENT_ATTR",
+    "PARENT_REC",
+    "SOURCE_NAME",
+    "SpliceGraph",
+    "SpliceGraphNode",
+    "SpliceGraphParser",
+]

--- a/SpliceGrapher/core/graph_math.py
+++ b/SpliceGrapher/core/graph_math.py
@@ -1,0 +1,55 @@
+"""Pure functions for comparing and subtracting splice graphs."""
+
+from __future__ import annotations
+
+from typing import cast
+
+from SpliceGrapher.SpliceGraph import SpliceGraph, SpliceGraphNode
+
+EdgeCoords = tuple[int, int, int, int]
+
+
+def _get_edge_coords(graph: SpliceGraph) -> set[EdgeCoords]:
+    """Extract canonical edge coordinates for cross-graph comparisons."""
+    coords: set[EdgeCoords] = set()
+    for parent_id, child_id in graph._nx_graph.edges:
+        parent = cast(SpliceGraphNode, graph._nx_graph.nodes[parent_id]["data"])
+        child = cast(SpliceGraphNode, graph._nx_graph.nodes[child_id]["data"])
+        coords.add((parent.minpos, parent.maxpos, child.minpos, child.maxpos))
+    return coords
+
+
+def jaccard_coefficients(graph_a: SpliceGraph, graph_b: SpliceGraph) -> tuple[float, float]:
+    """Return Jaccard coefficients for resolved nodes and coordinate-based edges."""
+    nodes_a = set(graph_a.resolvedNodes())
+    nodes_b = set(graph_b.resolvedNodes())
+    node_union = nodes_a | nodes_b
+    node_coeff = (len(nodes_a & nodes_b) / len(node_union)) if node_union else 1.0
+
+    edges_a = _get_edge_coords(graph_a)
+    edges_b = _get_edge_coords(graph_b)
+    edge_union = edges_a | edges_b
+    edge_coeff = (len(edges_a & edges_b) / len(edge_union)) if edge_union else 1.0
+    return float(node_coeff), float(edge_coeff)
+
+
+def recall(graph_a: SpliceGraph, graph_b: SpliceGraph) -> tuple[float, float]:
+    """Return recall values using ``graph_b`` as the denominator set."""
+    nodes_b = set(graph_b.resolvedNodes())
+    node_coeff = (len(set(graph_a.resolvedNodes()) & nodes_b) / len(nodes_b)) if nodes_b else 1.0
+
+    edges_b = _get_edge_coords(graph_b)
+    edge_coeff = (len(_get_edge_coords(graph_a) & edges_b) / len(edges_b)) if edges_b else 1.0
+    return float(node_coeff), float(edge_coeff)
+
+
+def equivalent_graphs(graph_a: SpliceGraph, graph_b: SpliceGraph) -> bool:
+    """Return ``True`` when two graphs have identical node/edge coordinate sets."""
+    if len(graph_a.nodeDict) != len(graph_b.nodeDict):
+        return False
+    return set(graph_a.nodeDict.values()) == set(graph_b.nodeDict.values()) and _get_edge_coords(
+        graph_a
+    ) == _get_edge_coords(graph_b)
+
+
+__all__ = ["equivalent_graphs", "jaccard_coefficients", "recall"]

--- a/SpliceGrapher/core/splicing_events.py
+++ b/SpliceGrapher/core/splicing_events.py
@@ -1,0 +1,195 @@
+"""Pure functions for annotating alternative splicing events on splice graphs."""
+
+from __future__ import annotations
+
+from typing import cast
+
+from SpliceGrapher.core.enums import AlternativeSplicingEvent
+from SpliceGrapher.core.interval_helpers import (
+    InMemoryIntervalIndex,
+    interval_contains,
+    intervals_overlap,
+)
+from SpliceGrapher.SpliceGraph import AS_KEY, SpliceGraph, SpliceGraphNode
+
+EdgeBounds = tuple[int, int]
+
+
+def _inner_edge_bounds(parent: SpliceGraphNode, child: SpliceGraphNode) -> EdgeBounds:
+    positions = sorted([parent.minpos, parent.maxpos, child.minpos, child.maxpos])
+    return positions[1], positions[2]
+
+
+def _get_edge_bounds(graph: SpliceGraph) -> list[EdgeBounds]:
+    """Return legacy inner edge bounds for all edges in the graph."""
+    bounds: list[EdgeBounds] = []
+    for parent_id, child_id in graph._nx_graph.edges:
+        parent = cast(SpliceGraphNode, graph._nx_graph.nodes[parent_id]["data"])
+        child = cast(SpliceGraphNode, graph._nx_graph.nodes[child_id]["data"])
+        bounds.append(_inner_edge_bounds(parent, child))
+    return bounds
+
+
+def _annotate_alt3_events(nodes: list[SpliceGraphNode], graph: SpliceGraph) -> None:
+    nodes_with_parents = [node for node in nodes if graph.predecessor_ids(node.id)]
+    if not nodes_with_parents:
+        return
+
+    overlap_index = InMemoryIntervalIndex(nodes_with_parents)
+    for node in nodes_with_parents:
+        for other in overlap_index.overlaps(node, inclusive=False):
+            if other == node or not intervals_overlap(node, other, inclusive=False):
+                continue
+            if node.acceptorEnd() == other.acceptorEnd():
+                continue
+            node.addAltForm(AlternativeSplicingEvent.ALT3)
+            other.addAltForm(AlternativeSplicingEvent.ALT3)
+
+
+def _annotate_alt5_events(nodes: list[SpliceGraphNode], graph: SpliceGraph) -> None:
+    nodes_with_children = [node for node in nodes if graph.successor_ids(node.id)]
+    if not nodes_with_children:
+        return
+
+    overlap_index = InMemoryIntervalIndex(nodes_with_children)
+    for node in nodes_with_children:
+        for other in overlap_index.overlaps(node, inclusive=False):
+            if other == node or not intervals_overlap(node, other, inclusive=False):
+                continue
+            if node.donorEnd() == other.donorEnd():
+                continue
+            node.addAltForm(AlternativeSplicingEvent.ALT5)
+            other.addAltForm(AlternativeSplicingEvent.ALT5)
+
+
+def _annotate_branching_events(graph: SpliceGraph, nodes: list[SpliceGraphNode]) -> None:
+    """Detect base ALT3/ALT5 motifs using graph-owned overlap queries."""
+    _annotate_alt3_events(nodes, graph)
+    _annotate_alt5_events(nodes, graph)
+
+
+def _get_alt_site_event_groups(
+    graph: SpliceGraph,
+    nodes: list[SpliceGraphNode],
+    event_type: AlternativeSplicingEvent,
+) -> list[set[SpliceGraphNode]]:
+    """Group overlapping ALT3 or ALT5 nodes using legacy containment exclusions."""
+    event_nodes = sorted(
+        [node for node in nodes if event_type in node.altFormSet],
+        key=lambda node: (node.minpos, node.maxpos, node.id),
+    )
+    if not event_nodes:
+        return []
+
+    def get_neighbors(node: SpliceGraphNode) -> set[SpliceGraphNode]:
+        if event_type == AlternativeSplicingEvent.ALT3:
+            return set(graph.predecessors(node))
+        return set(graph.successors(node))
+
+    overlap_index = InMemoryIntervalIndex(event_nodes)
+    event_list: list[set[SpliceGraphNode]] = []
+    stored: set[SpliceGraphNode] = set()
+
+    for node in event_nodes:
+        current_set = {node}
+        neighbors = get_neighbors(node)
+
+        for other in overlap_index.overlaps(node, inclusive=False):
+            if other == node or not intervals_overlap(other, node, inclusive=False):
+                continue
+
+            other_neighbors = get_neighbors(other)
+            node_contains_other_neighbors = (
+                all(interval_contains(node, neighbor, strict=True) for neighbor in other_neighbors)
+                if other_neighbors
+                else False
+            )
+            other_contains_node_neighbors = (
+                all(interval_contains(other, neighbor, strict=True) for neighbor in neighbors)
+                if neighbors
+                else False
+            )
+
+            if not (node_contains_other_neighbors or other_contains_node_neighbors):
+                current_set.add(other)
+
+        merged = False
+        for existing_set in event_list:
+            if existing_set & current_set:
+                existing_set.update(current_set)
+                stored.update(current_set)
+                merged = True
+                break
+
+        if not merged and node not in stored:
+            event_list.append(current_set)
+            stored.update(current_set)
+
+    return event_list
+
+
+def _upgrade_to_alt_both(graph: SpliceGraph, nodes: list[SpliceGraphNode]) -> None:
+    """Upgrade base ALT3/ALT5 events to ALTB3/ALTB5 when paths are unique."""
+    alt5_groups = _get_alt_site_event_groups(graph, nodes, AlternativeSplicingEvent.ALT5)
+    for group in alt5_groups:
+        for node in group:
+            node_acceptors = {child.acceptorEnd() for child in graph.successors(node)}
+            other_acceptors = {
+                child.acceptorEnd()
+                for other in group
+                if other != node
+                for child in graph.successors(other)
+            }
+            if node_acceptors and not (node_acceptors & other_acceptors):
+                node.removeAltForm(AlternativeSplicingEvent.ALT5)
+                node.addAltForm(AlternativeSplicingEvent.ALTB5)
+
+    alt3_groups = _get_alt_site_event_groups(graph, nodes, AlternativeSplicingEvent.ALT3)
+    for group in alt3_groups:
+        for node in group:
+            node_donors = {parent.donorEnd() for parent in graph.predecessors(node)}
+            other_donors = {
+                parent.donorEnd()
+                for other in group
+                if other != node
+                for parent in graph.predecessors(other)
+            }
+            if node_donors and not (node_donors & other_donors):
+                node.removeAltForm(AlternativeSplicingEvent.ALT3)
+                node.addAltForm(AlternativeSplicingEvent.ALTB3)
+
+
+def annotate_graph_events(graph: SpliceGraph) -> None:
+    """Annotate motif-level ES/IR/ALT3/ALT5 events on a networkx-backed graph."""
+    nodes = graph.resolvedNodes()
+    edge_bounds = _get_edge_bounds(graph)
+
+    for node in nodes:
+        node.altFormSet.clear()
+        node.attrs.pop(AS_KEY, None)
+
+    for node in nodes:
+        is_skipped = False
+        is_retained = False
+        for edge_min, edge_max in edge_bounds:
+            if edge_min < node.minpos and node.maxpos < edge_max:
+                is_skipped = True
+            if node.minpos <= edge_min and edge_max <= node.maxpos:
+                is_retained = True
+
+        if is_skipped:
+            if not graph.predecessor_ids(node.id):
+                node.addAltForm(AlternativeSplicingEvent.ALTI)
+            elif not graph.successor_ids(node.id):
+                node.addAltForm(AlternativeSplicingEvent.ALTT)
+            else:
+                node.addAltForm(AlternativeSplicingEvent.ES)
+
+        if is_retained:
+            node.addAltForm(AlternativeSplicingEvent.IR)
+
+    _annotate_branching_events(graph, nodes)
+    _upgrade_to_alt_both(graph, nodes)
+
+
+__all__ = ["annotate_graph_events"]

--- a/SpliceGrapher/formats/writers/gene_model.py
+++ b/SpliceGrapher/formats/writers/gene_model.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Collection, Iterator
-from contextlib import contextmanager
+from collections.abc import Callable, Collection
 from typing import TYPE_CHECKING, TextIO
 
 from SpliceGrapher.formats.serializers import (
@@ -11,6 +10,7 @@ from SpliceGrapher.formats.serializers import (
     gff_text_for_gene,
     gtf_text_for_gene,
 )
+from SpliceGrapher.shared.file_utils import open_output
 from SpliceGrapher.shared.progress import ProgressIndicator
 
 if TYPE_CHECKING:
@@ -27,15 +27,6 @@ def _gene_sort_key(gene: Gene) -> tuple[int, int, str]:
     return (gene.minpos, gene.maxpos, gene.id)
 
 
-@contextmanager
-def _open_output(path: str | TextIO) -> Iterator[TextIO]:
-    if isinstance(path, str):
-        with open(path, "w") as stream:
-            yield stream
-        return
-    yield path
-
-
 def write_gff(
     model: GeneModel,
     gff_path: str | TextIO,
@@ -45,7 +36,7 @@ def write_gff(
     verbose: bool = False,
 ) -> None:
     """Write full gene model to GFF output."""
-    with _open_output(gff_path) as out_stream:
+    with open_output(gff_path) as out_stream:
         chrom_list = sorted(model.all_chr)
         indicator = ProgressIndicator(10000, verbose=verbose)
         for chrom_name in chrom_list:
@@ -73,7 +64,7 @@ def write_gtf(
     verbose: bool = False,
 ) -> None:
     """Write full gene model to GTF output."""
-    with _open_output(gtf_path) as out_stream:
+    with open_output(gtf_path) as out_stream:
         chrom_list = sorted(model.all_chr)
         indicator = ProgressIndicator(10000, verbose=verbose)
         for chrom_name in chrom_list:

--- a/SpliceGrapher/formats/writers/splice_graph.py
+++ b/SpliceGrapher/formats/writers/splice_graph.py
@@ -1,0 +1,82 @@
+"""Writer boundary for ``SpliceGraph`` serialization."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, TextIO
+
+import structlog
+
+from SpliceGrapher.shared.file_utils import open_output
+from SpliceGrapher.SpliceGraph import CHILD_REC, GENE_REC, PARENT_REC, SOURCE_NAME
+
+if TYPE_CHECKING:
+    from SpliceGrapher.SpliceGraph import SpliceGraph, SpliceGraphNode
+
+LOGGER = structlog.get_logger(__name__)
+
+
+def _gff_line_for_graph(graph: SpliceGraph) -> str:
+    attrs_str = ";".join(f"{key}={value}" for key, value in sorted(graph.attrs.items()))
+    return (
+        f"{graph.chromosome}\t{SOURCE_NAME}\t{GENE_REC}\t"
+        f"{graph.minpos}\t{graph.maxpos}\t.\t{graph.strand}\t.\t{attrs_str}"
+    )
+
+
+def _gff_line_for_node(
+    node: SpliceGraphNode,
+    parent_ids: Iterable[str] | None = None,
+) -> str:
+    parents = list(parent_ids) if parent_ids is not None else []
+    record_type = CHILD_REC if parents else PARENT_REC
+    attr_parts = [f"ID={node.id}"]
+    if parents:
+        attr_parts.append(f"Parent={','.join(parents)}")
+    node_attrs = node.attributeString()
+    if node_attrs:
+        attr_parts.append(node_attrs)
+    attrs_str = ";".join(attr_parts)
+    return (
+        f"{node.chromosome}\t{SOURCE_NAME}\t{record_type}\t"
+        f"{node.minpos}\t{node.maxpos}\t.\t{node.strand}\t.\t{attrs_str}"
+    )
+
+
+def write_splice_graph_gff(
+    graph: SpliceGraph,
+    out_path: str | TextIO,
+    *,
+    halt_on_error: bool = False,
+) -> bool:
+    reason = graph.validate()
+    if reason:
+        if halt_on_error:
+            raise ValueError(
+                f'Cannot write invalid splice graph {graph.getName()} to file:\n"{reason}"\n'
+            )
+        LOGGER.warning(
+            "writing_invalid_splice_graph",
+            graph_name=graph.getName(),
+            reason=reason,
+        )
+
+    root_ids = {node_id for node_id, degree in graph._nx_graph.in_degree() if degree == 0}
+    other_ids = set(graph._nx_graph.nodes) - root_ids
+
+    def _node_sort_key(node_id: str) -> tuple[int, int, str]:
+        node = graph._nx_graph.nodes[node_id]["data"]
+        return (node.minpos, node.maxpos, node.id)
+
+    with open_output(out_path) as out_stream:
+        out_stream.write(f"{_gff_line_for_graph(graph)}\n")
+        for node_id in sorted(root_ids, key=_node_sort_key):
+            node = graph._nx_graph.nodes[node_id]["data"]
+            out_stream.write(f"{_gff_line_for_node(node)}\n")
+        for node_id in sorted(other_ids, key=_node_sort_key):
+            node = graph._nx_graph.nodes[node_id]["data"]
+            out_stream.write(f"{_gff_line_for_node(node, graph.predecessor_ids(node_id))}\n")
+    return True
+
+
+__all__ = ["write_splice_graph_gff"]

--- a/SpliceGrapher/shared/file_utils.py
+++ b/SpliceGrapher/shared/file_utils.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import gzip
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import TextIO
 
@@ -31,6 +33,16 @@ def ez_open(file_name: str | Path) -> TextIO:
         return gzip.open(path, mode="rt")
 
     return path.open("r")
+
+
+@contextmanager
+def open_output(path: str | Path | TextIO) -> Iterator[TextIO]:
+    """Yield a writable text stream for a path or existing stream."""
+    if isinstance(path, (str, Path)):
+        with _as_path(path).open("w") as stream:
+            yield stream
+        return
+    yield path
 
 
 def file_len(path: str | Path) -> int:
@@ -103,6 +115,7 @@ __all__ = [
     "file_prefix",
     "find_file",
     "make_graph_list_file",
+    "open_output",
     "validate_dir",
     "validate_file",
 ]

--- a/docs/adr/2026-03-06-splicegraph-networkx-boundary.md
+++ b/docs/adr/2026-03-06-splicegraph-networkx-boundary.md
@@ -1,0 +1,65 @@
+# ADR: SpliceGraph Topology Backend and Boundary
+
+- Date: 2026-03-06
+- Status: Accepted
+- Issue: `#168`
+
+## Context
+
+`SpliceGrapher/SpliceGraph.py` currently mixes four concerns in one mutable object graph:
+
+1. genomic node data,
+2. graph topology storage,
+3. traversal/mutation APIs, and
+4. GFF serialization.
+
+That design is encoded through `SpliceGraph.nodeDict`, node-local `parents` and `children` lists, and `SpliceGraph.writeGFF()`. The result is high coupling, duplicated traversal logic, a broad mutation surface, and no clean serialization boundary.
+
+A staged compatibility mirror was explicitly rejected for this rewrite. Maintaining a `networkx` graph alongside node-local `parents` / `children` state would create a split-brain architecture with multiple sources of truth.
+
+## Decision
+
+For issue `#168`, `SpliceGraph` topology is owned by `networkx.DiGraph`.
+
+The architecture boundary is:
+
+- `SpliceGraph` is the sole owner of graph topology.
+- `SpliceGraphNode` is a pure data container for genomic coordinates, identifiers, strand/chromosome metadata, and node attributes.
+- Nodes do not own or mutate parent/child relationships.
+- All topology mutations must route through `SpliceGraph` APIs.
+- All topology traversals must route through `SpliceGraph` APIs.
+- Serialization is not a `SpliceGraph` responsibility; GFF writing moves to `SpliceGrapher/formats/writers/splice_graph.py`.
+
+Concretely, the rewrite should:
+
+- replace topology storage with a `networkx.DiGraph`,
+- remove `nodeDict` as the canonical graph store,
+- delete node-local `parents` and `children` state,
+- delete node-level edge mutation helpers such as `addChild`, `addParent`, `removeChild`, and `removeParent`,
+- expose graph-owned APIs for operations such as adding/removing edges, removing nodes, enumerating roots/leaves, and predecessor/successor traversal,
+- delete `SpliceGraph.writeGFF()` from the data model, and
+- provide a writer boundary in `SpliceGrapher/formats/writers/splice_graph.py` that reuses a shared output helper instead of duplicating writer-local `_open_output` logic.
+
+## Consequences
+
+### Positive
+
+- one source of truth for topology,
+- less duplicated traversal code,
+- clearer mutation boundaries,
+- easier graph algorithms through `networkx`,
+- simpler node model semantics, and
+- a clean serialization boundary aligned with the existing `formats/writers/` direction.
+
+### Negative
+
+- this is a deliberate breaking change for downstream callers that directly mutate `node.parents` / `node.children`,
+- SGN, iDiffIR, and TAPIS call sites will need follow-on migration work,
+- `graph.writeGFF(...)` callers will need migration to the new writer API, and
+- legacy convenience patterns on nodes will be removed rather than preserved.
+
+## Non-Goals
+
+This ADR does not require parser extraction or a compatibility shim layer.
+
+The rewrite should not preserve node-level topology mutation APIs behind proxies or mirrors. Downstream code should be updated to use graph-owned APIs instead.

--- a/tests/test_graph_math.py
+++ b/tests/test_graph_math.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from SpliceGrapher.core.graph_math import (
+    equivalent_graphs,
+    jaccard_coefficients,
+    recall,
+)
+from SpliceGrapher.SpliceGraph import SpliceGraph
+
+
+def _build_linear_graph(
+    name: str,
+    left_id: str,
+    right_id: str,
+    *,
+    with_tail: bool = False,
+) -> SpliceGraph:
+    graph = SpliceGraph(name, "chr1", "+")
+    graph.addNode(left_id, 10, 20)
+    graph.addNode(right_id, 30, 40)
+    graph.addEdge(left_id, right_id)
+    if with_tail:
+        graph.addNode(f"{name}_tail", 50, 60)
+        graph.addEdge(right_id, f"{name}_tail")
+    return graph
+
+
+def test_equivalent_graphs_ignore_node_ids_and_graph_names() -> None:
+    left = _build_linear_graph("left", "left_a", "left_b")
+    right = _build_linear_graph("right", "right_x", "right_y")
+
+    assert equivalent_graphs(left, right) is True
+
+
+def test_jaccard_coefficients_compare_edges_by_coordinates() -> None:
+    left = _build_linear_graph("left", "left_a", "left_b")
+    right = _build_linear_graph("right", "right_x", "right_y", with_tail=True)
+
+    node_coeff, edge_coeff = jaccard_coefficients(left, right)
+
+    assert node_coeff == 2.0 / 3.0
+    assert edge_coeff == 1.0 / 2.0
+
+
+def test_recall_uses_graph_b_as_denominator_for_nodes_and_edges() -> None:
+    left = _build_linear_graph("left", "left_a", "left_b")
+    right = _build_linear_graph("right", "right_x", "right_y", with_tail=True)
+
+    node_coeff, edge_coeff = recall(left, right)
+
+    assert node_coeff == 2.0 / 3.0
+    assert edge_coeff == 1.0 / 2.0

--- a/tests/test_integration_simple.py
+++ b/tests/test_integration_simple.py
@@ -1,15 +1,16 @@
 from pathlib import Path
 
 from SpliceGrapher.formats.annotation_io import load_gene_models
+from SpliceGrapher.formats.writers.splice_graph import write_splice_graph_gff
 from SpliceGrapher.SpliceGraph import SpliceGraph, SpliceGraphParser
 from tests.helpers.idiffir_fixture_builder import build_fixture
 
 
 def _build_graph(name: str, start: int) -> SpliceGraph:
     graph = SpliceGraph(name, "chr1", "+")
-    left = graph.addNode(f"{name}_left", start, start + 20)
-    right = graph.addNode(f"{name}_right", start + 40, start + 60)
-    left.addChild(right)
+    graph.addNode(f"{name}_left", start, start + 20)
+    graph.addNode(f"{name}_right", start + 40, start + 60)
+    graph.addEdge(f"{name}_left", f"{name}_right")
     return graph
 
 
@@ -19,10 +20,9 @@ def _load_single_graph(path: Path) -> SpliceGraph:
     return next(iter(parser.graphDict.values()))
 
 
-def test_happy_path_load_union_write_cycle(tmp_path: Path) -> None:
+def test_happy_path_load_and_write_cycle(tmp_path: Path) -> None:
     fixture = build_fixture(tmp_path)
 
-    # Annotation path: load normalized gene model and ensure write roundtrip works.
     model = load_gene_models(str(fixture.gff3))
     model_out = tmp_path / "annotation.roundtrip.gff3"
     model.write_gff(str(model_out))
@@ -30,19 +30,12 @@ def test_happy_path_load_union_write_cycle(tmp_path: Path) -> None:
     assert "\tgene\t" in model_text
     assert "\texon\t" in model_text
 
-    # Graph path: load two serialized graphs, union them, then write merged output.
-    left_path = tmp_path / "left.graph.gff3"
-    right_path = tmp_path / "right.graph.gff3"
-    _build_graph("left", 10).writeGFF(str(left_path))
-    _build_graph("right", 15).writeGFF(str(right_path))
+    graph_path = tmp_path / "graph.gff3"
+    graph = _build_graph("left", 10)
+    assert write_splice_graph_gff(graph, str(graph_path)) is True
 
-    left_graph = _load_single_graph(left_path)
-    right_graph = _load_single_graph(right_path)
-
-    merged = left_graph.union(right_graph)
-    merged_out = tmp_path / "merged.graph.gff3"
-    assert merged.writeGFF(str(merged_out))
-
-    merged_loaded = _load_single_graph(merged_out)
-    assert merged_loaded.getName()
-    assert len(merged_loaded.nodeDict) >= 2
+    loaded = _load_single_graph(graph_path)
+    assert loaded.getName() == "left"
+    assert set(loaded.nodeDict) == {"left_left", "left_right"}
+    assert [node.id for node in loaded.getRoots()] == ["left_left"]
+    assert [node.id for node in loaded.getLeaves()] == ["left_right"]

--- a/tests/test_splice_graph.py
+++ b/tests/test_splice_graph.py
@@ -2,90 +2,16 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import networkx as nx
 import pytest
 
-import SpliceGrapher.SpliceGraph as splice_graph_module
 from SpliceGrapher.core.enums import (
     AlternativeSplicingEvent,
     AlternativeSplicingEventName,
+    Strand,
 )
-from SpliceGrapher.SpliceGraph import (
-    ALT3_ABBREV,
-    ALT5_ABBREV,
-    AS_KEY,
-    GENE_REC,
-    SpliceGraph,
-    SpliceGraphNode,
-    SpliceGraphParser,
-    altSiteEventList,
-    commonAS,
-    diffAS,
-    getFirstGraph,
-    graphMinusAS,
-    overlap,
-)
-
-
-def test_union_uses_resolved_strand_when_merging_unknown_strand_graph() -> None:
-    left = SpliceGraph("left", "chr1", ".")
-    left.addNode("L1", 10, 20)
-
-    right = SpliceGraph("right", "chr1", "+")
-    right.addNode("R1", 30, 40)
-
-    merged = left.union(right)
-
-    assert merged.strand == "+"
-
-
-def test_union_rejects_invalid_runtime_strand_value() -> None:
-    left = SpliceGraph("left", "chr1", "+")
-    left.addNode("L1", 10, 20)
-
-    right = SpliceGraph("right", "chr1", "+")
-    right.addNode("R1", 30, 40)
-    right.strand = "?"
-
-    with pytest.raises(ValueError):
-        left.union(right)
-
-
-def test_union_rejects_conflicting_known_strands_with_value_error() -> None:
-    left = SpliceGraph("left", "chr1", "+")
-    left.addNode("L1", 10, 20)
-
-    right = SpliceGraph("right", "chr1", "-")
-    right.addNode("R1", 30, 40)
-
-    with pytest.raises(ValueError, match="conflicting strands"):
-        left.union(right)
-
-
-def test_union_requires_explicit_known_kwargs() -> None:
-    left = SpliceGraph("left", "chr1", "+")
-    left.addNode("L1", 10, 20)
-
-    right = SpliceGraph("right", "chr1", "+")
-    right.addNode("R1", 30, 40)
-
-    merged = left.union(right, keepName=True)
-    assert merged.getName() == "left"
-
-    with pytest.raises(TypeError):
-        left.union(right, keep_name=True)  # type: ignore[call-arg]
-
-
-def test_splice_graph_node_defaults_do_not_share_parent_or_child_lists() -> None:
-    left = SpliceGraphNode("L", 10, 20, "+", "chr1")
-    right = SpliceGraphNode("R", 30, 40, "+", "chr1")
-    parent = SpliceGraphNode("P", 1, 5, "+", "chr1")
-    child = SpliceGraphNode("C", 50, 60, "+", "chr1")
-
-    left.parents.append(parent)
-    left.children.append(child)
-
-    assert right.parents == []
-    assert right.children == []
+from SpliceGrapher.formats.writers.splice_graph import write_splice_graph_gff
+from SpliceGrapher.SpliceGraph import GENE_REC, SpliceGraph, SpliceGraphNode, SpliceGraphParser
 
 
 def _write_graph_header(path: Path, attrs: str) -> None:
@@ -93,6 +19,72 @@ def _write_graph_header(path: Path, attrs: str) -> None:
         f"chr1\tSpliceGrapher\t{GENE_REC}\t1\t20\t.\t+\t.\t{attrs}\n",
         encoding="utf-8",
     )
+
+
+def _load_single_graph(path: Path) -> SpliceGraph:
+    parser = SpliceGraphParser(str(path))
+    assert len(parser.graphDict) == 1
+    return next(iter(parser.graphDict.values()))
+
+
+def test_splice_graph_node_is_pure_data() -> None:
+    node = SpliceGraphNode(
+        id="exon_1",
+        start=100,
+        end=200,
+        strand=Strand.PLUS,
+        chrom="chr1",
+    )
+
+    assert node.id == "exon_1"
+    assert node.minpos == 100
+    assert node.maxpos == 200
+
+    with pytest.raises(AttributeError):
+        _ = node.parents  # type: ignore[attr-defined]
+
+    with pytest.raises(AttributeError):
+        _ = node.children  # type: ignore[attr-defined]
+
+    with pytest.raises(AttributeError):
+        _ = node.addChild  # type: ignore[attr-defined]
+
+    with pytest.raises(AttributeError):
+        _ = node.removeParent  # type: ignore[attr-defined]
+
+
+def test_splice_graph_manages_topology() -> None:
+    graph = SpliceGraph(name="test_gene", chromosome="chr1", strand=Strand.PLUS)
+
+    node_a = graph.addNode(newId="exon_1", start=100, end=200)
+    node_b = graph.addNode(newId="exon_2", start=300, end=400)
+
+    assert isinstance(graph._nx_graph, nx.DiGraph)
+    assert "exon_1" in graph._nx_graph.nodes
+    assert graph._nx_graph.nodes["exon_1"]["data"] == node_a
+    assert graph.nodeDict["exon_2"] == node_b
+
+    graph.addEdge("exon_1", "exon_2")
+
+    assert graph._nx_graph.has_edge("exon_1", "exon_2")
+    assert [node.id for node in graph.getRoots()] == ["exon_1"]
+    assert [node.id for node in graph.getLeaves()] == ["exon_2"]
+
+
+def test_splice_graph_missing_edge_handling() -> None:
+    graph = SpliceGraph(name="test_gene", chromosome="chr1", strand=Strand.PLUS)
+    graph.addNode(newId="exon_1", start=100, end=200)
+
+    with pytest.raises(ValueError, match="not found in graph"):
+        graph.addEdge("exon_1", "phantom_exon")
+
+
+def test_alt_form_set_normalizes_event_name_to_event_code() -> None:
+    node = SpliceGraphNode("n1", 10, 20, "+", "chr1")
+
+    node.addAltForm(AlternativeSplicingEventName.ALT3.value)
+
+    assert set(node.altForms()) == {AlternativeSplicingEvent.ALT3.value}
 
 
 def test_parser_preserves_equals_in_attribute_values(tmp_path: Path) -> None:
@@ -105,204 +97,20 @@ def test_parser_preserves_equals_in_attribute_values(tmp_path: Path) -> None:
     assert graph.attrs["Note"] == "alpha=beta"
 
 
-def test_get_first_graph_uses_explicit_options(tmp_path: Path) -> None:
-    graph_path = tmp_path / "graph.gff3"
-    _write_graph_header(graph_path, "ID=G1")
+def test_write_splice_graph_gff_roundtrip(tmp_path: Path) -> None:
+    graph = SpliceGraph("graph_1", "chr1", Strand.PLUS)
+    graph.addNode("exon_1", 100, 200)
+    graph.addNode("exon_2", 300, 400)
+    graph.addEdge("exon_1", "exon_2")
 
-    graph = getFirstGraph(str(graph_path), annotate=False, verbose=False)
-    assert graph.getName() == "G1"
+    with pytest.raises(AttributeError):
+        _ = graph.writeGFF  # type: ignore[attr-defined]
 
-    with pytest.raises(TypeError):
-        getFirstGraph(str(graph_path), bad_option=True)  # type: ignore[call-arg]
+    out_path = tmp_path / "graph.gff3"
+    assert write_splice_graph_gff(graph, str(out_path)) is True
 
+    loaded = _load_single_graph(out_path)
 
-def test_parser_progress_indicator_finishes_on_parse_error(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    graph_path = tmp_path / "invalid.gff3"
-    _write_graph_header(graph_path, "ID")
-
-    class DummyIndicator:
-        finished = False
-
-        def __init__(self, *_args, **_kwargs) -> None:
-            pass
-
-        def update(self) -> None:
-            pass
-
-        def finish(self) -> None:
-            type(self).finished = True
-
-    monkeypatch.setattr(splice_graph_module, "ProgressIndicator", DummyIndicator)
-
-    with pytest.raises(ValueError, match="Illegal attribute field"):
-        SpliceGraphParser(str(graph_path))
-
-    assert DummyIndicator.finished is True
-
-
-def test_parser_next_does_not_mask_internal_type_errors(tmp_path: Path) -> None:
-    graph_path = tmp_path / "graph.gff3"
-    _write_graph_header(graph_path, "ID=G1")
-
-    parser = SpliceGraphParser(str(graph_path))
-    parser.graphId = "broken"  # type: ignore[assignment]
-
-    with pytest.raises(TypeError):
-        next(parser)
-
-
-def test_parser_requires_explicit_constructor_kwargs(tmp_path: Path) -> None:
-    graph_path = tmp_path / "graph.gff3"
-    _write_graph_header(graph_path, "ID=G1")
-
-    with pytest.raises(TypeError):
-        SpliceGraphParser(str(graph_path), bad_option=True)  # type: ignore[call-arg]
-
-
-def test_overlap_helper_preserves_strict_boundary_behavior() -> None:
-    graph = SpliceGraph("g", "chr1", "+")
-    left = graph.addNode("L", 10, 20)
-    touching = graph.addNode("T", 20, 30)
-    crossing = graph.addNode("C", 19, 25)
-
-    assert not overlap(left, touching)
-    assert overlap(left, crossing)
-
-
-def _graph_alt_nodes(
-    *,
-    name: str,
-    records: list[tuple[str, int, int, list[str]]],
-) -> SpliceGraph:
-    graph = SpliceGraph(name, "chr1", "+")
-    for node_id, start, end, forms in records:
-        node = graph.addNode(node_id, start, end)
-        for form in forms:
-            node.addAltForm(form)
-    return graph
-
-
-def _alt_signature(graph: SpliceGraph) -> set[tuple[int, int, str]]:
-    return {
-        (node.minpos, node.maxpos, form)
-        for node in graph.resolvedNodes()
-        for form in node.altForms()
-    }
-
-
-def test_graph_minus_as_reports_only_a_specific_events() -> None:
-    graph_a = _graph_alt_nodes(
-        name="A",
-        records=[
-            ("a1", 10, 20, [ALT3_ABBREV]),
-            ("a2", 40, 50, [ALT5_ABBREV]),
-        ],
-    )
-    graph_b = _graph_alt_nodes(
-        name="B",
-        records=[
-            ("b1", 10, 20, [ALT5_ABBREV]),
-            ("b2", 40, 50, [ALT5_ABBREV]),
-        ],
-    )
-
-    minus = graphMinusAS(graph_a, graph_b)
-
-    assert _alt_signature(minus) == {(10, 20, ALT3_ABBREV)}
-
-
-def test_diff_as_is_directional_for_shared_nodes_with_different_as() -> None:
-    graph_a = _graph_alt_nodes(
-        name="A",
-        records=[("a1", 10, 20, [ALT3_ABBREV]), ("a2", 40, 50, [ALT5_ABBREV])],
-    )
-    graph_b = _graph_alt_nodes(
-        name="B",
-        records=[("b1", 10, 20, [ALT5_ABBREV]), ("b2", 40, 50, [ALT5_ABBREV])],
-    )
-
-    a_minus_b, b_minus_a = diffAS(graph_a, graph_b)
-
-    assert _alt_signature(a_minus_b) == {(10, 20, ALT3_ABBREV)}
-    assert _alt_signature(b_minus_a) == {(10, 20, ALT5_ABBREV)}
-
-
-def test_common_as_excludes_partial_coordinate_overlaps() -> None:
-    graph_a = _graph_alt_nodes(name="A", records=[("a1", 10, 20, [ALT3_ABBREV])])
-    graph_b = _graph_alt_nodes(name="B", records=[("b1", 12, 22, [ALT3_ABBREV])])
-
-    common = commonAS(graph_a, graph_b)
-
-    assert common.resolvedNodes() == []
-
-
-def test_alt_site_event_list_uses_overlap_candidates_not_full_scan(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    graph = SpliceGraph("g", "chr1", "+")
-    event_nodes = []
-    for i in range(120):
-        start = 10 + (i * 20)
-        node = graph.addNode(f"n{i}", start, start + 5)
-        node.addAltForm(ALT5_ABBREV)
-        child = graph.addNode(f"c{i}", 5000 + (i * 20), 5005 + (i * 20))
-        node.addChild(child)
-        event_nodes.append(node)
-
-    overlap_calls = 0
-    original_overlap = splice_graph_module.overlap
-
-    def counting_overlap(left: SpliceGraphNode, right: SpliceGraphNode) -> bool:
-        nonlocal overlap_calls
-        overlap_calls += 1
-        return original_overlap(left, right)
-
-    monkeypatch.setattr(splice_graph_module, "overlap", counting_overlap)
-
-    events = altSiteEventList(graph.resolvedNodes(), ALT5_ABBREV)
-
-    assert len(events) == len(event_nodes)
-    assert overlap_calls < 1000
-
-
-def test_alt_form_set_normalizes_event_name_to_event_code() -> None:
-    node = SpliceGraphNode("n1", 10, 20, "+", "chr1")
-
-    node.addAltForm(AlternativeSplicingEventName.ALT3.value)
-
-    assert set(node.altForms()) == {AlternativeSplicingEvent.ALT3.value}
-    assert node.attrs[AS_KEY] == AlternativeSplicingEvent.ALT3.value
-    assert node.hasAS() is True
-
-
-def test_alt_form_set_accepts_enum_members_and_preserves_public_strings() -> None:
-    node = SpliceGraphNode("n1", 10, 20, "+", "chr1")
-
-    node.addAltForm(AlternativeSplicingEvent.ALT5)
-    node.addAltForm(AlternativeSplicingEvent.ALT3)
-
-    assert set(node.altForms()) == {
-        AlternativeSplicingEvent.ALT5.value,
-        AlternativeSplicingEvent.ALT3.value,
-    }
-    assert node.isAltDonor() is True
-    assert node.isAltAcceptor() is True
-
-
-def test_as_domain_constants_are_derived_from_core_event_enums() -> None:
-    expected_codes = [event.value for event in AlternativeSplicingEvent]
-    expected_names = [event_name.value for event_name in AlternativeSplicingEventName]
-
-    assert splice_graph_module.AS_ABBREVS == expected_codes
-    assert splice_graph_module.AS_NAMES == expected_names
-    assert (
-        splice_graph_module.EVENT_NAME[AlternativeSplicingEvent.ALT3.value]
-        == AlternativeSplicingEventName.ALT3.value
-    )
-    assert (
-        splice_graph_module.EVENT_ABBREV[AlternativeSplicingEventName.ALT3.value]
-        == AlternativeSplicingEvent.ALT3.value
-    )
+    assert set(loaded.nodeDict) == {"exon_1", "exon_2"}
+    assert [node.id for node in loaded.getRoots()] == ["exon_1"]
+    assert [node.id for node in loaded.getLeaves()] == ["exon_2"]

--- a/tests/test_splicing_events.py
+++ b/tests/test_splicing_events.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from SpliceGrapher.core.enums import AlternativeSplicingEvent
+from SpliceGrapher.core.splicing_events import annotate_graph_events
+from SpliceGrapher.SpliceGraph import SpliceGraph
+
+
+def test_annotate_graph_events_marks_skipped_exon_for_bypass_motif() -> None:
+    graph = SpliceGraph("skip", "chr1", "+")
+    graph.addNode("a", 10, 20)
+    graph.addNode("b", 30, 40)
+    graph.addNode("c", 50, 60)
+    graph.addEdge("a", "b")
+    graph.addEdge("b", "c")
+    graph.addEdge("a", "c")
+
+    annotate_graph_events(graph)
+
+    assert AlternativeSplicingEvent.ES in graph.nodeDict["b"].altFormSet
+
+
+def test_annotate_graph_events_marks_retained_intron_for_containing_node() -> None:
+    graph = SpliceGraph("retain", "chr1", "+")
+    graph.addNode("a", 10, 20)
+    graph.addNode("container", 15, 35)
+    graph.addNode("c", 30, 40)
+    graph.addEdge("a", "c")
+
+    annotate_graph_events(graph)
+
+    assert AlternativeSplicingEvent.IR in graph.nodeDict["container"].altFormSet
+
+
+def test_annotate_graph_events_marks_alt3_for_shared_parent_children() -> None:
+    graph = SpliceGraph("alt3", "chr1", "+")
+    graph.addNode("a", 10, 20)
+    graph.addNode("b", 30, 40)
+    graph.addNode("c", 35, 45)
+    graph.addEdge("a", "b")
+    graph.addEdge("a", "c")
+
+    annotate_graph_events(graph)
+
+    assert AlternativeSplicingEvent.ALT3 in graph.nodeDict["b"].altFormSet
+    assert AlternativeSplicingEvent.ALT3 in graph.nodeDict["c"].altFormSet
+
+
+def test_annotate_graph_events_marks_alt5_for_shared_child_parents() -> None:
+    graph = SpliceGraph("alt5", "chr1", "+")
+    graph.addNode("b", 30, 40)
+    graph.addNode("c", 35, 45)
+    graph.addNode("d", 60, 70)
+    graph.addEdge("b", "d")
+    graph.addEdge("c", "d")
+
+    annotate_graph_events(graph)
+
+    assert AlternativeSplicingEvent.ALT5 in graph.nodeDict["b"].altFormSet
+    assert AlternativeSplicingEvent.ALT5 in graph.nodeDict["c"].altFormSet
+
+
+def test_annotate_graph_events_upgrades_alt5_to_altb5_for_unique_acceptors() -> None:
+    graph = SpliceGraph("altb5", "chr1", "+")
+    graph.addNode("root", 1, 5)
+    graph.addNode("alt_a", 10, 25)
+    graph.addNode("alt_b", 15, 30)
+    graph.addNode("acceptor_x", 40, 50)
+    graph.addNode("acceptor_y", 60, 70)
+    graph.addEdge("root", "alt_a")
+    graph.addEdge("root", "alt_b")
+    graph.addEdge("alt_a", "acceptor_x")
+    graph.addEdge("alt_b", "acceptor_y")
+
+    annotate_graph_events(graph)
+
+    assert AlternativeSplicingEvent.ALTB5 in graph.nodeDict["alt_a"].altFormSet
+    assert AlternativeSplicingEvent.ALTB5 in graph.nodeDict["alt_b"].altFormSet
+    assert AlternativeSplicingEvent.ALT5 not in graph.nodeDict["alt_a"].altFormSet
+    assert AlternativeSplicingEvent.ALT5 not in graph.nodeDict["alt_b"].altFormSet
+
+
+def test_annotate_graph_events_upgrades_alt3_to_altb3_for_unique_donors() -> None:
+    graph = SpliceGraph("altb3", "chr1", "+")
+    graph.addNode("donor_a", 1, 5)
+    graph.addNode("donor_b", 2, 8)
+    graph.addNode("alt_a", 10, 25)
+    graph.addNode("alt_b", 15, 30)
+    graph.addEdge("donor_a", "alt_a")
+    graph.addEdge("donor_b", "alt_b")
+
+    annotate_graph_events(graph)
+
+    assert AlternativeSplicingEvent.ALTB3 in graph.nodeDict["alt_a"].altFormSet
+    assert AlternativeSplicingEvent.ALTB3 in graph.nodeDict["alt_b"].altFormSet
+    assert AlternativeSplicingEvent.ALT3 not in graph.nodeDict["alt_a"].altFormSet
+    assert AlternativeSplicingEvent.ALT3 not in graph.nodeDict["alt_b"].altFormSet


### PR DESCRIPTION
## Summary
- replace the legacy SpliceGraph mutable topology model with a networkx-backed graph core and pure data nodes
- move splice-graph GFF serialization into `SpliceGrapher/formats/writers/splice_graph.py` and share `open_output()` across writers
- recover graph math and splicing-event logic with focused tests for graph equivalence, ES/IR/ALT3/ALT5, and ALTB3/ALTB5

Closes #168

## Test Plan
- [x] `uv run ruff check SpliceGrapher/SpliceGraph.py SpliceGrapher/core/graph_math.py SpliceGrapher/core/splicing_events.py SpliceGrapher/shared/file_utils.py SpliceGrapher/formats/writers/gene_model.py SpliceGrapher/formats/writers/splice_graph.py tests/test_splice_graph.py tests/test_integration_simple.py tests/test_graph_math.py tests/test_splicing_events.py`
- [x] `uv run ruff format --check SpliceGrapher/SpliceGraph.py SpliceGrapher/core/graph_math.py SpliceGrapher/core/splicing_events.py SpliceGrapher/shared/file_utils.py SpliceGrapher/formats/writers/gene_model.py SpliceGrapher/formats/writers/splice_graph.py tests/test_splice_graph.py tests/test_integration_simple.py tests/test_graph_math.py tests/test_splicing_events.py`
- [x] `uv run mypy SpliceGrapher/SpliceGraph.py SpliceGrapher/core/graph_math.py SpliceGrapher/core/splicing_events.py SpliceGrapher/shared/file_utils.py SpliceGrapher/formats/writers/gene_model.py SpliceGrapher/formats/writers/splice_graph.py tests/test_splice_graph.py tests/test_integration_simple.py tests/test_graph_math.py tests/test_splicing_events.py`
- [x] `PYTHONDONTWRITEBYTECODE=1 uv run pytest -q -p no:cacheprovider tests/test_splice_graph.py tests/test_integration_simple.py tests/test_graph_math.py tests/test_splicing_events.py`
- [x] `PYTHONDONTWRITEBYTECODE=1 uv run pytest -q -p no:cacheprovider`