### PR TITLE
refactor: hard-clean alignment_io collect boundary

### DIFF
--- a/SpliceGrapher/formats/alignment_io/api.py
+++ b/SpliceGrapher/formats/alignment_io/api.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+import os
 import sys
+from collections.abc import Mapping
+from os import PathLike
 from typing import Literal, cast, overload
 
-from SpliceGrapher.formats.depth_io import DepthSource
+import numpy
+
+from SpliceGrapher.formats.depth_io import DepthSource, is_depths_file, read_depths
+from SpliceGrapher.formats.junction import parse_junction_record
 
 from . import collect as collect_ops
 from .depths import calculate_gene_depths
@@ -21,6 +27,93 @@ from .types import (
     ReadDataSource,
     ReferencePath,
 )
+
+
+def _depth_map_to_arrays(depths: Mapping[str, list[int] | numpy.ndarray]) -> DepthMap:
+    """Normalize depth maps to int32 NumPy arrays."""
+    return {
+        chrom: numpy.asarray(chrom_depths, dtype=numpy.int32)
+        for chrom, chrom_depths in depths.items()
+    }
+
+
+def _is_depths_source(source: ReadDataSource) -> bool:
+    """Return ``True`` when ``source`` should be handled as a depths file."""
+    if not isinstance(source, (str, PathLike)):
+        return False
+
+    source_path = os.fspath(source)
+    lower = source_path.lower()
+    if lower.endswith((".sam", ".bam", ".cram")):
+        return False
+
+    if os.path.isfile(source_path):
+        try:
+            with open(source_path, "rb") as stream:
+                magic = stream.read(4)
+        except OSError:
+            magic = b""
+        if magic in {b"BAM\x01", b"CRAM"}:
+            return False
+
+    return is_depths_file(source_path)
+
+
+@overload
+def _collect_depths_source_data(
+    source: DepthSource,
+    *,
+    alignments: Literal[True],
+    include_depths: bool = True,
+    junctions: bool,
+    maxpos: int,
+    minanchor: int,
+    minjct: int,
+    verbose: bool,
+) -> CollectResultWithAlignments: ...
+
+
+@overload
+def _collect_depths_source_data(
+    source: DepthSource,
+    *,
+    alignments: Literal[False] = False,
+    include_depths: bool = True,
+    junctions: bool,
+    maxpos: int,
+    minanchor: int,
+    minjct: int,
+    verbose: bool,
+) -> CollectResult: ...
+
+
+def _collect_depths_source_data(
+    source: DepthSource,
+    *,
+    alignments: bool = False,
+    include_depths: bool = True,
+    junctions: bool,
+    maxpos: int,
+    minanchor: int,
+    minjct: int,
+    verbose: bool,
+) -> CollectResult | CollectResultWithAlignments:
+    """Bridge depths-file inputs into the public alignment I/O contract."""
+    depth_map, jcts = read_depths(
+        source,
+        parse_junction=parse_junction_record,
+        maxpos=maxpos,
+        minanchor=minanchor,
+        minjct=minjct,
+        depths=include_depths,
+        junctions=junctions,
+        verbose=verbose,
+    )
+    normalized_depths = _depth_map_to_arrays(depth_map)
+    if alignments:
+        empty_alignments: AlignmentMap = {}
+        return normalized_depths, jcts, empty_alignments
+    return normalized_depths, jcts
 
 
 def read_alignment_spans(
@@ -51,8 +144,8 @@ def read_alignment_depths(
     reference_fasta: ReferencePath = None,
 ) -> DepthMap:
     """Return read depths indexed by chromosome for SAM/BAM/CRAM sources."""
-    if collect_ops._is_depths_source(source):
-        depths, _ = collect_ops._collect_depths_source_data(
+    if _is_depths_source(source):
+        depths, _ = _collect_depths_source_data(
             cast(DepthSource, source),
             alignments=False,
             include_depths=True,
@@ -117,8 +210,8 @@ def read_alignment_junctions(
     reference_fasta: ReferencePath = None,
 ) -> JunctionMap:
     """Return splice junctions indexed by chromosome."""
-    if collect_ops._is_depths_source(source):
-        _, jcts = collect_ops._collect_depths_source_data(
+    if _is_depths_source(source):
+        _, jcts = _collect_depths_source_data(
             cast(DepthSource, source),
             alignments=False,
             include_depths=False,
@@ -184,9 +277,9 @@ def collect_alignment_data(
     reference_fasta: ReferencePath = None,
 ) -> CollectResult | CollectResultWithAlignments:
     """Return depths and junctions (and optionally alignments) from alignment input."""
-    if collect_ops._is_depths_source(source):
+    if _is_depths_source(source):
         if include_alignments:
-            return collect_ops._collect_depths_source_data(
+            return _collect_depths_source_data(
                 cast(DepthSource, source),
                 alignments=True,
                 include_depths=True,
@@ -196,7 +289,7 @@ def collect_alignment_data(
                 junctions=junctions,
                 verbose=verbose,
             )
-        return collect_ops._collect_depths_source_data(
+        return _collect_depths_source_data(
             cast(DepthSource, source),
             alignments=False,
             include_depths=True,

--- a/SpliceGrapher/formats/alignment_io/collect.py
+++ b/SpliceGrapher/formats/alignment_io/collect.py
@@ -2,17 +2,13 @@
 
 from __future__ import annotations
 
-import os
 import sys
-from collections.abc import Mapping
-from os import PathLike
 from typing import Literal, overload
 
 import numpy
 import pysam
 
-from SpliceGrapher.formats.depth_io import DepthSource, is_depths_file, read_depths
-from SpliceGrapher.formats.junction import SpliceJunction, parse_junction_record
+from SpliceGrapher.formats.junction import SpliceJunction
 
 from .sources import AlignmentStreamer, _make_chromosome_set
 from .types import (
@@ -24,7 +20,6 @@ from .types import (
     DepthMap,
     JunctionKey,
     JunctionMap,
-    ReadDataSource,
     ReferencePath,
 )
 
@@ -123,93 +118,6 @@ def _ensure_depth_capacity(depth_array: numpy.ndarray, required_size: int) -> nu
     expanded = numpy.zeros(new_size, dtype=depth_array.dtype)
     expanded[: depth_array.size] = depth_array
     return expanded
-
-
-def _depth_map_to_arrays(depths: Mapping[str, list[int] | numpy.ndarray]) -> DepthMap:
-    """Normalize depth maps to int32 NumPy arrays."""
-    return {
-        chrom: numpy.asarray(chrom_depths, dtype=numpy.int32)
-        for chrom, chrom_depths in depths.items()
-    }
-
-
-def _is_depths_source(source: ReadDataSource) -> bool:
-    """Return ``True`` when ``source`` should be handled as a depths file."""
-    if not isinstance(source, (str, PathLike)):
-        return False
-
-    source_path = os.fspath(source)
-    lower = source_path.lower()
-    if lower.endswith((".sam", ".bam", ".cram")):
-        return False
-
-    if os.path.isfile(source_path):
-        try:
-            with open(source_path, "rb") as stream:
-                magic = stream.read(4)
-        except OSError:
-            magic = b""
-        if magic in {b"BAM\x01", b"CRAM"}:
-            return False
-
-    return is_depths_file(source_path)
-
-
-@overload
-def _collect_depths_source_data(
-    source: DepthSource,
-    *,
-    alignments: Literal[True],
-    include_depths: bool = True,
-    junctions: bool,
-    maxpos: int,
-    minanchor: int,
-    minjct: int,
-    verbose: bool,
-) -> CollectResultWithAlignments: ...
-
-
-@overload
-def _collect_depths_source_data(
-    source: DepthSource,
-    *,
-    alignments: Literal[False] = False,
-    include_depths: bool = True,
-    junctions: bool,
-    maxpos: int,
-    minanchor: int,
-    minjct: int,
-    verbose: bool,
-) -> CollectResult: ...
-
-
-def _collect_depths_source_data(
-    source: DepthSource,
-    *,
-    alignments: bool = False,
-    include_depths: bool = True,
-    junctions: bool,
-    maxpos: int,
-    minanchor: int,
-    minjct: int,
-    verbose: bool,
-) -> CollectResult | CollectResultWithAlignments:
-    """Bridge legacy depths-file inputs into the public alignment I/O contract."""
-    depth_map, jcts = read_depths(
-        source,
-        parse_junction=parse_junction_record,
-        maxpos=maxpos,
-        minanchor=minanchor,
-        minjct=minjct,
-        depths=include_depths,
-        junctions=junctions,
-        verbose=verbose,
-    )
-    normalized_depths = _depth_map_to_arrays(depth_map)
-    if alignments:
-        empty_alignments: AlignmentMap = {}
-        return normalized_depths, jcts, empty_alignments
-    return normalized_depths, jcts
 
 
 @overload
@@ -362,9 +270,6 @@ def _collect_pysam_data(
 
 
 __all__ = [
-    "_collect_depths_source_data",
     "_collect_pysam_data",
-    "_depth_map_to_arrays",
-    "_is_depths_source",
     "_record_strand",
 ]

--- a/docs/plans/2026-03-21-alignment-collect-hard-clean-design.md
+++ b/docs/plans/2026-03-21-alignment-collect-hard-clean-design.md
@@ -1,0 +1,83 @@
+# Alignment Collect Lean Cleanup Design
+
+## Goal
+
+Clean up `SpliceGrapher/formats/alignment_io/collect.py` without adding new internal files or changing the public `alignment_io` package API.
+
+## Problem
+
+`collect.py` currently mixes two different responsibilities:
+- the real pysam-backed collection engine (`_collect_pysam_data`, junction building, depth accumulation)
+- cross-boundary glue that does not belong in a pysam collector (`_is_depths_source`, `_collect_depths_source_data`)
+
+That makes the module impure and makes `api.py` depend on collection internals that are not actually about pysam collection.
+
+## Design
+
+Keep the existing `alignment_io` package shape and make the boundary cleaner:
+
+- `collect.py` becomes the pure pysam-backed collection engine
+- `api.py` owns source classification and the depth-file fallback bridge because that logic belongs to the public contract layer
+- no new files are introduced
+- no public API names change
+
+## Module Responsibilities After the Cut
+
+### `SpliceGrapher/formats/alignment_io/collect.py`
+Keep only pysam-driven collection logic:
+- `_collect_pysam_data`
+- `_build_splice_junctions`
+- `_next_match_anchor`
+- `_record_strand`
+- depth-array helpers tightly coupled to pysam collection
+
+Remove from this module:
+- `_is_depths_source`
+- `_collect_depths_source_data`
+- `depth_io` imports that exist only for fallback bridging
+
+### `SpliceGrapher/formats/alignment_io/api.py`
+Own the public contract decisions:
+- source-type branching
+- depths-file fallback collection
+- calls into `collect._collect_pysam_data(...)` only for actual alignment sources
+
+Add private helpers here if needed:
+- `_is_depths_source`
+- `_collect_depths_source_data`
+
+## Why This Shape
+
+This is the smallest cleanup that improves the package boundary without repeating the over-splitting mistake from the abandoned `#205` attempt.
+
+It removes the impurity from `collect.py` while avoiding another package explosion.
+
+## Non-Goals
+
+This slice does not:
+- change `collect_alignment_data(...)` semantics
+- change depth/junction calculations
+- split `collect.py` into more files
+- rename public alignment API functions
+
+## Testing Strategy
+
+Pin the lean boundary rather than internal bloat:
+- `collect.py` should no longer expose `_is_depths_source` or `_collect_depths_source_data`
+- `api.py` should own those helpers
+- focused fallback tests should patch the new seam in `api.py`
+- parity tests for BAM/SAM/CRAM behavior must stay green
+
+## Verification
+
+Required gates:
+- `uv run ruff check . --fix`
+- `uv run ruff format .`
+- `uv run mypy .`
+- `PYTHONDONTWRITEBYTECODE=1 uv run pytest -q -p no:cacheprovider`
+- `uv build`
+
+## Next Step After This Slice
+
+After this lands, the next cleanup candidate should remain:
+- `SpliceGrapher/formats/parsers/gene_model_gff_record_handlers.py`

--- a/docs/plans/2026-03-21-alignment-collect-hard-clean-implementation-plan.md
+++ b/docs/plans/2026-03-21-alignment-collect-hard-clean-implementation-plan.md
@@ -1,0 +1,130 @@
+# Alignment Collect Lean Cleanup Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** make `SpliceGrapher/formats/alignment_io/collect.py` a pure pysam-backed collection engine without changing the public `alignment_io` API.
+
+**Architecture:** keep the existing `alignment_io` package shape. Move source classification and depths-file fallback bridging into `api.py`, and leave `collect.py` with only pysam traversal, junction construction, and depth-array helpers. Do not add new internal files.
+
+**Tech Stack:** Python 3.13, `pysam`, `numpy`, `pytest`, `ruff`, `mypy`, `uv`
+
+---
+
+### Task 1: Pin the lean boundary in tests
+
+**Files:**
+- Modify: `tests/test_alignment_io_process_utils_boundary.py`
+- Modify: `tests/test_alignment_io_constants.py`
+- Test: `tests/test_alignment_io_process_utils_boundary.py`
+- Test: `tests/test_alignment_io_constants.py`
+
+**Step 1: Write the failing test**
+
+Update the boundary tests so they expect:
+- `alignment_collect` still exposes `_collect_pysam_data`
+- `alignment_collect` no longer exposes `_is_depths_source`
+- `alignment_collect` no longer exposes `_collect_depths_source_data`
+- `alignment_api` now owns `_is_depths_source`
+- focused fallback tests patch `alignment_api._is_depths_source` and `alignment_api._collect_depths_source_data`
+
+**Step 2: Run test to verify it fails**
+
+Run: `PYTHONDONTWRITEBYTECODE=1 uv run pytest -q -p no:cacheprovider tests/test_alignment_io_process_utils_boundary.py tests/test_alignment_io_constants.py`
+
+Expected: FAIL because the helpers still live in `collect.py`.
+
+**Step 3: Write minimal implementation**
+
+Only land the red expectations in the tests.
+
+**Step 4: Run test to verify it fails cleanly**
+
+Run the same command again.
+
+Expected: FAIL for missing or stale helper ownership.
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_alignment_io_process_utils_boundary.py tests/test_alignment_io_constants.py
+git commit -m "test: pin alignment collect lean boundary"
+```
+
+### Task 2: Move the non-pysam helpers into `api.py`
+
+**Files:**
+- Modify: `SpliceGrapher/formats/alignment_io/api.py`
+- Modify: `SpliceGrapher/formats/alignment_io/collect.py`
+- Test: `tests/test_alignment_io_process_utils_boundary.py`
+- Test: `tests/test_alignment_io_constants.py`
+
+**Step 1: Write the failing test**
+
+Use the red boundary tests from Task 1.
+
+**Step 2: Run test to verify it fails**
+
+Run: `PYTHONDONTWRITEBYTECODE=1 uv run pytest -q -p no:cacheprovider tests/test_alignment_io_process_utils_boundary.py tests/test_alignment_io_constants.py`
+
+Expected: FAIL because `api.py` does not yet own the fallback helpers.
+
+**Step 3: Write minimal implementation**
+
+In `api.py`:
+- add private `_is_depths_source(...)`
+- add private `_collect_depths_source_data(...)`
+- update `read_alignment_depths(...)`, `read_alignment_junctions(...)`, and `collect_alignment_data(...)` to call the new local helpers
+
+In `collect.py`:
+- remove `_is_depths_source(...)`
+- remove `_collect_depths_source_data(...)`
+- remove `depth_io` imports used only by those helpers
+- keep only pysam-backed collection and its tight internal helpers
+- shrink `__all__` accordingly
+
+**Step 4: Run test to verify it passes**
+
+Run the same command again.
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add SpliceGrapher/formats/alignment_io/api.py SpliceGrapher/formats/alignment_io/collect.py tests/test_alignment_io_process_utils_boundary.py tests/test_alignment_io_constants.py
+git commit -m "refactor(formats): hard-clean alignment collect boundary"
+```
+
+### Task 3: Prove parity and full repo stability
+
+**Files:**
+- Test: `tests/test_alignment_io_parity.py`
+- Test: `tests/test_shortread_compat.py`
+- Test: repo-wide verification commands
+
+**Step 1: Run focused alignment tests**
+
+Run:
+- `PYTHONDONTWRITEBYTECODE=1 uv run pytest -q -p no:cacheprovider tests/test_alignment_io_process_utils_boundary.py tests/test_alignment_io_constants.py tests/test_alignment_io_parity.py tests/test_shortread_compat.py`
+
+Expected: PASS.
+
+**Step 2: Run full verification**
+
+Run:
+- `uv run ruff check . --fix`
+- `uv run ruff format .`
+- `uv run mypy .`
+- `PYTHONDONTWRITEBYTECODE=1 uv run pytest -q -p no:cacheprovider`
+- `uv build`
+
+Expected: PASS.
+
+**Step 3: Commit any final cleanup**
+
+If verification required final import or formatting cleanup:
+
+```bash
+git add SpliceGrapher/formats/alignment_io/api.py SpliceGrapher/formats/alignment_io/collect.py tests/test_alignment_io_process_utils_boundary.py tests/test_alignment_io_constants.py
+git commit -m "refactor(formats): finalize alignment collect cleanup"
+```

--- a/tests/test_alignment_io_constants.py
+++ b/tests/test_alignment_io_constants.py
@@ -16,6 +16,10 @@ def test_alignment_io_package_reexports_public_api_and_internal_layout() -> None
     assert hasattr(alignment_collect, "_collect_pysam_data")
     assert hasattr(alignment_sources, "_open_alignment_file")
     assert hasattr(alignment_types, "AlignmentSource")
+    assert not hasattr(alignment_collect, "_is_depths_source")
+    assert not hasattr(alignment_collect, "_collect_depths_source_data")
+    assert hasattr(alignment_api, "_is_depths_source")
+    assert hasattr(alignment_api, "_collect_depths_source_data")
 
 
 def test_alignment_io_uses_direct_header_enums_without_proxy_exports() -> None:

--- a/tests/test_alignment_io_process_utils_boundary.py
+++ b/tests/test_alignment_io_process_utils_boundary.py
@@ -72,9 +72,9 @@ def test_get_sam_read_data_depths_fallback_preserves_three_tuple_when_alignments
     fake_depths = {"chr1": [0, 1, 2]}
     fake_junctions: dict[str, list[object]] = {"chr1": []}
 
-    monkeypatch.setattr(alignment_collect, "_is_depths_source", lambda source: True)
+    monkeypatch.setattr(alignment_api, "_is_depths_source", lambda source: True)
     monkeypatch.setattr(
-        alignment_collect,
+        alignment_api,
         "read_depths",
         lambda *args, **kwargs: (fake_depths, fake_junctions),
     )


### PR DESCRIPTION
## Summary\n- hard-cut depths-source detection and depths fallback collection out of alignment_io/collect.py\n- move _is_depths_source and _collect_depths_source_data into alignment_io/api.py\n- keep collect.py focused on pysam collection internals only\n- update boundary tests to enforce helper ownership and keep depths fallback 3-tuple behavior\n\n## Verification\n- PYTHONDONTWRITEBYTECODE=1 uv run pytest -q -p no:cacheprovider tests/test_alignment_io_constants.py tests/test_alignment_io_process_utils_boundary.py\n- uv run ruff check . --fix\n- uv run ruff format .\n- uv run mypy .\n- PYTHONDONTWRITEBYTECODE=1 uv run pytest -q -p no:cacheprovider\n- uv build\n\nCloses #208