### PR TITLE
refactor: hard-clean gene_model_gff record handlers

### DIFF
--- a/SpliceGrapher/formats/parsers/gene_model_gff_record_handlers.py
+++ b/SpliceGrapher/formats/parsers/gene_model_gff_record_handlers.py
@@ -32,6 +32,63 @@ from SpliceGrapher.formats.parsers.gene_model_gff_resolution import (
 RecordHandler: TypeAlias = Callable[[ParseContext, ParsedRecord], None]
 
 
+def _parent_gene_for_transcript(
+    ctx: ParseContext,
+    *,
+    chrom: str,
+    transcript: model_domain.Transcript,
+    fail_message: str,
+) -> model_domain.Gene | None:
+    parent_gene = ctx.model.get_mrna_parent(chrom, transcript.id)
+    if parent_gene is None:
+        ctx.fail(fail_message)
+        return None
+    return parent_gene
+
+
+def _register_transcript_links(
+    ctx: ParseContext,
+    *,
+    transcript: model_domain.Transcript,
+    parent_gene: model_domain.Gene,
+    chrom: str,
+) -> None:
+    ctx.model.mrna_forms.setdefault(chrom, {})[transcript.id] = transcript
+    ctx.model.mrna_gene.setdefault(chrom, {})[transcript.id] = parent_gene
+    drain_pending_children(
+        ctx,
+        transcript=transcript,
+        parent_gene=parent_gene,
+        chrom=chrom,
+    )
+
+
+def _resolve_region_target(
+    ctx: ParseContext,
+    record: ParsedRecord,
+    parent_id: str,
+) -> tuple[model_domain.Transcript, model_domain.Gene] | None:
+    mrna_record = resolve_parent(ctx, parent_id, record.chrom, search_genes=False)
+    if mrna_record is None:
+        ctx.write_verbose(f"line {record.line_no}: no Mrna {parent_id} found for {record.rec_type}")
+        queue_pending_child(ctx.pending_regions, record, parent_id)
+        return None
+    if not isinstance(mrna_record, model_domain.Transcript):
+        ctx.fail(f"line {record.line_no}: parent {parent_id} is not an Mrna record")
+        return None
+    parent_gene = _parent_gene_for_transcript(
+        ctx,
+        chrom=record.chrom,
+        transcript=mrna_record,
+        fail_message=(
+            f"line {record.line_no}: Mrna {mrna_record.id} is missing a parent gene for CDS record"
+        ),
+    )
+    if parent_gene is None:
+        return None
+    return mrna_record, parent_gene
+
+
 def handle_gene_record(ctx: ParseContext, record: ParsedRecord) -> None:
     gid = annotation_value(record.annots, model_domain.ID_FIELD)
     if gid is None:
@@ -101,11 +158,15 @@ def handle_exon_record(ctx: ParseContext, record: ParsedRecord) -> None:
         return
     existing_transcript = resolve_parent(ctx, parent_id, record.chrom, search_genes=False)
     if isinstance(existing_transcript, model_domain.Transcript):
-        parent_gene = ctx.model.get_mrna_parent(record.chrom, existing_transcript.id)
-        if parent_gene is None:
-            ctx.fail(
+        parent_gene = _parent_gene_for_transcript(
+            ctx,
+            chrom=record.chrom,
+            transcript=existing_transcript,
+            fail_message=(
                 f"line {record.line_no}: transcript {existing_transcript.id} is missing parent gene"
-            )
+            ),
+        )
+        if parent_gene is None:
             return
         strand = resolve_strand(
             ctx,
@@ -158,13 +219,11 @@ def handle_exon_record(ctx: ParseContext, record: ParsedRecord) -> None:
         ctx.stats.iso_count += 1
     transcript = gene_obj.transcripts.get(isoform.id)
     if isinstance(transcript, model_domain.Transcript):
-        ctx.model.mrna_forms.setdefault(record.chrom, {})[transcript.id] = transcript
-        ctx.model.mrna_gene.setdefault(record.chrom, {})[transcript.id] = gene_obj
-        drain_pending_children(
+        _register_transcript_links(
             ctx,
             transcript=transcript,
-            parent_gene=gene_obj,
             chrom=record.chrom,
+            parent_gene=gene_obj,
         )
 
 
@@ -231,9 +290,7 @@ def handle_mrna_record(ctx: ParseContext, record: ParsedRecord) -> None:
         attr=mrna_attr,
     )
     mrna_gene.add_transcript(mrna)
-    ctx.model.mrna_forms.setdefault(record.chrom, {})[transcript_id] = mrna
-    ctx.model.mrna_gene.setdefault(record.chrom, {})[transcript_id] = mrna_gene
-    drain_pending_children(
+    _register_transcript_links(
         ctx,
         transcript=mrna,
         parent_gene=mrna_gene,
@@ -257,20 +314,10 @@ def handle_transcript_region_record(ctx: ParseContext, record: ParsedRecord) -> 
     parent_id = parent_annotation(record)
     if parent_id is None:
         return
-    mrna_record = resolve_parent(ctx, parent_id, record.chrom, search_genes=False)
-    if mrna_record is None:
-        ctx.write_verbose(f"line {record.line_no}: no Mrna {parent_id} found for {record.rec_type}")
-        queue_pending_child(ctx.pending_regions, record, parent_id)
+    target = _resolve_region_target(ctx, record, parent_id)
+    if target is None:
         return
-    if not isinstance(mrna_record, model_domain.Transcript):
-        ctx.fail(f"line {record.line_no}: parent {parent_id} is not an Mrna record")
-        return
-    parent_gene = ctx.model.get_mrna_parent(record.chrom, mrna_record.id)
-    if parent_gene is None:
-        ctx.fail(
-            f"line {record.line_no}: Mrna {mrna_record.id} is missing a parent gene for CDS record"
-        )
-        return
+    mrna_record, parent_gene = target
 
     strand = resolve_strand(
         ctx,

--- a/docs/plans/2026-03-24-gene-model-record-handlers-hard-clean-design.md
+++ b/docs/plans/2026-03-24-gene-model-record-handlers-hard-clean-design.md
@@ -1,0 +1,40 @@
+# Gene Model Record Handlers Hard Clean Design
+
+## Goal
+
+Reduce branch density and duplicated dispatch logic in
+`SpliceGrapher/formats/parsers/gene_model_gff_record_handlers.py` while
+preserving parser behavior and public API boundaries.
+
+## Existing Smells
+
+- Repeated transcript-parent-gene lookup logic across exon/CDS-region handlers.
+- Repeated model-link registration (`mrna_forms`/`mrna_gene`) plus pending-drain flow.
+- Mixed dispatch and bookkeeping concerns inside large handler functions.
+
+## Proposed Shape
+
+Introduce internal helper seams inside the handlers module:
+
+1. `_parent_gene_for_transcript(...)`
+- Centralize transcript -> parent gene lookup with fail-fast error handling.
+
+2. `_register_transcript_links(...)`
+- Centralize transcript registration to model maps and pending child draining.
+
+3. `_resolve_region_target(...)`
+- Centralize CDS/UTR parent transcript resolution including pending queue behavior.
+
+Handlers retain current signatures and routing through `RECORD_HANDLERS`.
+
+## Behavioral Constraints
+
+- No changes to public parser entrypoints (`load_gene_model_records`).
+- No new compatibility wrappers or alias APIs.
+- Preserve existing fail/queue semantics and verbose messaging intent.
+
+## Verification Strategy
+
+- New boundary tests for helper seams and queue behavior.
+- Existing parser and gene model tests as regression net.
+- Full repo gates before PR.

--- a/docs/plans/2026-03-24-gene-model-record-handlers-hard-clean-implementation-plan.md
+++ b/docs/plans/2026-03-24-gene-model-record-handlers-hard-clean-implementation-plan.md
@@ -1,0 +1,46 @@
+# Gene Model Record Handlers Hard Clean Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Hard-clean `gene_model_gff_record_handlers.py` by extracting internal dispatch helpers while preserving parser behavior.
+
+**Architecture:** Keep handler entrypoints and `RECORD_HANDLERS` unchanged, but move repeated transcript-parent resolution and transcript-link registration into private helper seams used by exon, mRNA, and transcript-region handlers.
+
+**Tech Stack:** Python 3.11+, pytest, ruff, mypy, uv.
+
+---
+
+### Task 1: Add red boundary tests for helper seams
+
+**Files:**
+- Create: `tests/test_gene_model_gff_record_handlers_boundary.py`
+
+1. Add tests requiring private helpers for transcript-link registration and region-target resolution.
+2. Run red test command:
+   - `PYTHONDONTWRITEBYTECODE=1 uv run pytest -q -p no:cacheprovider tests/test_gene_model_gff_record_handlers_boundary.py`
+3. Verify expected failure is missing helper attributes.
+
+### Task 2: Extract helper seams in handlers module
+
+**Files:**
+- Modify: `SpliceGrapher/formats/parsers/gene_model_gff_record_handlers.py`
+
+1. Add `_parent_gene_for_transcript(...)` for centralized transcript->gene lookup.
+2. Add `_register_transcript_links(...)` for model map registration and pending drain.
+3. Add `_resolve_region_target(...)` for CDS/UTR parent resolution with pending queue behavior.
+4. Rewire `handle_exon_record`, `handle_mrna_record`, and `handle_transcript_region_record` to use helpers.
+
+### Task 3: Verify parity and run full gates
+
+**Files:**
+- Verify: parser and gene-model tests
+
+1. Run focused parser/gene-model suite:
+   - `PYTHONDONTWRITEBYTECODE=1 uv run pytest -q -p no:cacheprovider tests/test_gene_model_gff_record_handlers_boundary.py tests/test_gene_model_gff_parser.py tests/test_gene_model_gff_module_layout.py tests/test_gene_model.py`
+2. Run full gate chain:
+   - `uv run ruff check . --fix`
+   - `uv run ruff format .`
+   - `uv run mypy .`
+   - `PYTHONDONTWRITEBYTECODE=1 uv run pytest -q -p no:cacheprovider`
+   - `uv build`
+3. Commit only tracked code/test/docs changes and open PR linked to `#210`.

--- a/tests/test_gene_model_gff_record_handlers_boundary.py
+++ b/tests/test_gene_model_gff_record_handlers_boundary.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import importlib
+
+from SpliceGrapher.core.enums import RecordType
+from SpliceGrapher.formats import gene_model as gm
+from SpliceGrapher.formats.parsers.gene_model_gff_context import ParseContext
+from SpliceGrapher.formats.parsers.gene_model_gff_records import ParsedRecord
+
+parser_record_handlers = importlib.import_module(
+    "SpliceGrapher.formats.parsers.gene_model_gff_record_handlers"
+)
+
+
+def _build_context() -> tuple[ParseContext, gm.Gene]:
+    model = gm.GeneModel()
+    model.add_chromosome(1, 500, "chr1")
+    gene = gm.Gene("GENE1", None, 10, 200, "chr1", "+")
+    model.add_gene(gene)
+    ctx = ParseContext(
+        model=model,
+        require_notes=False,
+        verbose=False,
+        ignore_errors=False,
+    )
+    return ctx, gene
+
+
+def _build_record(*, parent_id: str) -> ParsedRecord:
+    return ParsedRecord(
+        line_no=1,
+        raw_line=f"chr1\tsrc\tcds\t10\t20\t.\t+\t.\tParent={parent_id}",
+        annots={str(gm.PARENT_FIELD): parent_id},
+        chrom="chr1",
+        rec_type=RecordType.CDS,
+        start_pos=10,
+        end_pos=20,
+        strand="+",
+    )
+
+
+def _build_transcript(transcript_id: str, parent_gene_id: str) -> gm.Transcript:
+    return gm.Transcript(
+        transcript_id,
+        10,
+        200,
+        "chr1",
+        "+",
+        attr={
+            str(gm.PARENT_FIELD): parent_gene_id,
+            str(gm.ID_FIELD): transcript_id,
+            str(gm.NAME_FIELD): transcript_id,
+        },
+    )
+
+
+def test_register_transcript_links_tracks_mrna_maps() -> None:
+    ctx, gene = _build_context()
+    transcript = _build_transcript("TX1", gene.id)
+
+    parser_record_handlers._register_transcript_links(
+        ctx,
+        transcript=transcript,
+        parent_gene=gene,
+        chrom="chr1",
+    )
+
+    assert ctx.model.mrna_forms["chr1"]["TX1"] is transcript
+    assert ctx.model.mrna_gene["chr1"]["TX1"] is gene
+
+
+def test_resolve_region_target_returns_transcript_and_parent_gene_when_present() -> None:
+    ctx, gene = _build_context()
+    transcript = _build_transcript("TX1", gene.id)
+    gene.add_transcript(transcript)
+    ctx.model.mrna_forms.setdefault("chr1", {})["TX1"] = transcript
+    ctx.model.mrna_gene.setdefault("chr1", {})["TX1"] = gene
+    record = _build_record(parent_id="TX1")
+
+    result = parser_record_handlers._resolve_region_target(ctx, record, "TX1")
+
+    assert result is not None
+    resolved_transcript, parent_gene = result
+    assert resolved_transcript is transcript
+    assert parent_gene is gene
+
+
+def test_resolve_region_target_queues_pending_region_when_parent_missing() -> None:
+    ctx, _ = _build_context()
+    record = _build_record(parent_id="MISSING_TX")
+
+    result = parser_record_handlers._resolve_region_target(ctx, record, "MISSING_TX")
+
+    assert result is None
+    assert ("chr1", "MISSING_TX") in ctx.pending_regions


### PR DESCRIPTION
## Summary
- hard-cleaned `gene_model_gff_record_handlers` dispatch internals by extracting focused helper seams
- added `_parent_gene_for_transcript`, `_register_transcript_links`, and `_resolve_region_target` to remove duplicated branch logic
- rewired exon, mRNA, and transcript-region handlers to use helper seams while preserving parser behavior
- added boundary tests for helper seams and region pending-queue behavior
- added design and implementation plan docs for the #210 cleanup slice

## Verification
- `PYTHONDONTWRITEBYTECODE=1 uv run pytest -q -p no:cacheprovider tests/test_gene_model_gff_record_handlers_boundary.py`
- `PYTHONDONTWRITEBYTECODE=1 uv run pytest -q -p no:cacheprovider tests/test_gene_model_gff_record_handlers_boundary.py tests/test_gene_model_gff_parser.py tests/test_gene_model_gff_module_layout.py tests/test_gene_model.py`
- `uv run ruff check . --fix`
- `uv run ruff format .`
- `uv run mypy .`
- `PYTHONDONTWRITEBYTECODE=1 uv run pytest -q -p no:cacheprovider`
- `uv build`

Closes #210